### PR TITLE
User name validation, reset password error, i18n update.

### DIFF
--- a/course/auth.py
+++ b/course/auth.py
@@ -285,14 +285,12 @@ def sign_in_by_user_pw(request):
 class SignUpForm(StyledModelForm):
     username = forms.CharField(required=True, max_length=30,
             label=_("Username"),
-            help_text=_("Required. 30 characters or fewer. Letters, "
-                "digits and @/./+/-/_ only."),
             validators=[
                 validators.RegexValidator('^[\\w.@+-]+$',
                     string_concat(
                         _('Enter a valid username.'), (' '),
-                        _('Enter a valid username. This value may '
-                            'contain only letters, numbers and @/./')
+                        _('This value may contain only letters, '
+                          'numbers and @/./+/-/_ characters.')
                         ),
                     'invalid')
                 ])

--- a/course/auth.py
+++ b/course/auth.py
@@ -122,10 +122,10 @@ class ImpersonateForm(StyledForm):
         self.fields["user"] = forms.ChoiceField(
                 choices=[
                     (
-                    # Translators: information displayed when selecting user
-                    # for impersonating. Customize how the name is shown, but
-                    # leave email first to retain usability of form sorted by
-                    # last name.
+                    # Translators: information displayed when selecting 
+                    # userfor impersonating. Customize how the name is 
+                    # shown, but leave email first to retain usability 
+                    # of form sorted by last name.
                         u.id, _("%(user_email)s - %(user_lastname)s, "
                             "%(user_firstname)s")
                             % {
@@ -285,14 +285,14 @@ def sign_in_by_user_pw(request):
 class SignUpForm(StyledModelForm):
     username = forms.CharField(required=True, max_length=30,
             label=_("Username"),
+            help_text=_("Required. 30 characters or fewer. Letters, "
+                "digits and @/./+/-/_ only."),
             validators=[
-                validators.RegexValidator(r'^[a-zA-Z]+[a-zA-Z0-9_-]{0,}$',
+                validators.RegexValidator('^[\\w.@+-]+$',
                     string_concat(
-                        _('Enter a valid username.'), 
-                        _(
-                            "A valid name should start with letters. "
-                            "Alphanumeric with hyphens and underscores. "
-                            "Do not use spaces.")
+                        _('Enter a valid username.'), (' '),
+                        _('Enter a valid username. This value may '
+                            'contain only letters, numbers and @/./')
                         ),
                     'invalid')
                 ])
@@ -322,7 +322,7 @@ def sign_up(request):
             if User.objects.filter(
                     username=form.cleaned_data["username"]).count():
                 messages.add_message(request, messages.ERROR,
-                        _("That user name is already taken."))
+                        _("A user with that username already exists."))
 
             elif User.objects.filter(
                     email__iexact=form.cleaned_data["email"]).count():
@@ -411,40 +411,43 @@ def reset_password(request):
 
             if user is None:
                 messages.add_message(request, messages.ERROR,
-                        _("Email address is not known."))
+                        _("That email address doesn't have an "
+                          "associated user account. Are you "
+                          "sure you've registered?"))
+            else:
+                from course.models import get_user_status
+                ustatus = get_user_status(user)
+                ustatus.sign_in_key = make_sign_in_key(user)
+                ustatus.save()
 
-            from course.models import get_user_status
-            ustatus = get_user_status(user)
-            ustatus.sign_in_key = make_sign_in_key(user)
-            ustatus.save()
+                from django.template.loader import render_to_string
+                message = render_to_string("course/sign-in-email.txt", {
+                    "user": user,
+                    "sign_in_uri": request.build_absolute_uri(
+                        reverse(
+                            "relate-reset_password_stage2",
+                            args=(user.id, ustatus.sign_in_key,))),
+                    "home_uri": request.build_absolute_uri(reverse("relate-home"))
+                    })
+                from django.core.mail import send_mail
+                send_mail(
+                        string_concat("[", _("RELATE"), "] ",
+                                     _("Password reset")),
+                        message,
+                        settings.ROBOT_EMAIL_FROM,
+                        recipient_list=[email])
 
-            from django.template.loader import render_to_string
-            message = render_to_string("course/sign-in-email.txt", {
-                "user": user,
-                "sign_in_uri": request.build_absolute_uri(
-                    reverse(
-                        "relate-reset_password_stage2",
-                        args=(user.id, ustatus.sign_in_key,))),
-                "home_uri": request.build_absolute_uri(reverse("relate-home"))
-                })
-            from django.core.mail import send_mail
-            send_mail(
-                    string_concat("[", _("RELATE"), "] ",
-                                 _("Password reset")),
-                    message,
-                    settings.ROBOT_EMAIL_FROM,
-                    recipient_list=[email])
+                messages.add_message(request, messages.INFO,
+                        _("Email sent. Please check your email and click "
+                        "the link."))
 
-            messages.add_message(request, messages.INFO,
-                    _("Email sent. Please check your email and click "
-                    "the link."))
-
-            return redirect("relate-home")
+                return redirect("relate-home")
     else:
         form = ResetPasswordForm()
 
     return render(request, "generic-form.html", {
-        "form_description": _("Reset Password"),
+        "form_description": _("Password reset on %(site_name)s")
+                % {"site_name": _("RELATE")},
         "form": form
         })
 
@@ -453,7 +456,7 @@ class ResetPasswordStage2Form(StyledForm):
     password = forms.CharField(widget=forms.PasswordInput(),
                               label=_("Password"))
     password_repeat = forms.CharField(widget=forms.PasswordInput(),
-                              label=_("Password repeat"))
+                              label=_("Password confirmation"))
 
     def __init__(self, *args, **kwargs):
         super(ResetPasswordStage2Form, self).__init__(*args, **kwargs)
@@ -467,7 +470,8 @@ class ResetPasswordStage2Form(StyledForm):
         password = cleaned_data.get("password")
         password_repeat = cleaned_data.get("password_repeat")
         if password and password != password_repeat:
-            self.add_error("password_repeat", _("Passwords do not match"))
+            self.add_error("password_repeat", 
+                    _("The two password fields didn't match."))
 
 
 def reset_password_stage2(request, user_id, sign_in_key):
@@ -515,7 +519,8 @@ def reset_password_stage2(request, user_id, sign_in_key):
         form = ResetPasswordStage2Form()
 
     return render(request, "generic-form.html", {
-        "form_description": _("Reset Password"),
+        "form_description": _("Password reset on %(site_name)s")
+                % {"site_name": _("RELATE")},
         "form": form
         })
 

--- a/course/auth.py
+++ b/course/auth.py
@@ -40,6 +40,7 @@ from django.contrib.auth.forms import \
         AuthenticationForm as AuthenticationFormBase
 from django.contrib.auth.decorators import user_passes_test
 from django.core.urlresolvers import reverse
+from django.core import validators
 
 from course.models import (
         UserStatus, user_status,
@@ -283,7 +284,18 @@ def sign_in_by_user_pw(request):
 
 class SignUpForm(StyledModelForm):
     username = forms.CharField(required=True, max_length=30,
-                              label=_("Username"))
+            label=_("Username"),
+            validators=[
+                validators.RegexValidator(r'^[a-zA-Z]+[a-zA-Z0-9_-]{0,}$',
+                    string_concat(
+                        _('Enter a valid username.'), 
+                        _(
+                            "A valid name should start with letters. "
+                            "Alphanumeric with hyphens and underscores. "
+                            "Do not use spaces.")
+                        ),
+                    'invalid')
+                ])
 
     class Meta:
         model = User

--- a/course/page/inline.py
+++ b/course/page/inline.py
@@ -309,7 +309,10 @@ class ShortAnswer(AnswerBase):
         self.matchers = [
                 parse_matcher(
                     vctx,
-                    string_concat("%s, ", 
+                    string_concat("%s, ",
+                                  # Translators: refers to optional
+                                  # correct answer for checking
+                                  # correctness sumbitted by students.
                                   _("answer"),
                                   " %d") % (location, i+1),
                     answer)
@@ -616,9 +619,10 @@ class InlineMultiQuestion(TextQuestionBase, PageBaseWithValue):
             raise ValidationError(
                     string_concat(
                         "%s: ",
-                        _("invalid answers name %s. A valid answer "
-                         "should start with letters, and hyphen and "
-                          "numbers are allowed, without spaces."))
+                        _("invalid answers name %s. "),
+                        _("A valid name should start with letters. "
+                            "Alphanumeric with underscores. "
+                            "Do not use spaces."))
                     % (
                         location,
                         ", ".join([
@@ -633,9 +637,10 @@ class InlineMultiQuestion(TextQuestionBase, PageBaseWithValue):
             raise ValidationError(
                     string_concat(
                         "%s: ",
-                        _("invalid embeded question name %s. A valid name "
-                         "should start with letters, and hyphens and "
-                          "underscores are allowed, without spaces."))
+                        _("invalid embeded question name %s. "),
+                        _("A valid name should start with letters. "
+                            "Alphanumeric with underscores. "
+                            "Do not use spaces."))
                         % (
                             location,
                             ", ".join([

--- a/course/page/text.py
+++ b/course/page/text.py
@@ -430,8 +430,8 @@ class FloatMatcher(TextAnswerMatcher):
         except:
             raise ValidationError(
                     string_concat(
-                        "%s: ",
-                        _("'value' is not a valid float literal"))
+                        "%s: 'value' ",
+                        _("does not provide a valid float literal"))
                     % location)
 
         if hasattr(matcher_desc, "rtol"):
@@ -441,8 +441,8 @@ class FloatMatcher(TextAnswerMatcher):
             except:
                 raise ValidationError(
                         string_concat(
-                            "%s: ",
-                            _("'rtol' is not a valid float literal"))
+                            "%s: 'rtol' ",
+                            _("does not provide a valid float literal"))
                         % location)
         if hasattr(matcher_desc, "atol"):
             try:
@@ -451,8 +451,8 @@ class FloatMatcher(TextAnswerMatcher):
             except:
                 raise ValidationError(
                         string_concat(
-                            "%s: ",
-                            _("'atol' is not a valid float literal"))
+                            "%s: 'atol' ",
+                            _("does not provide a valid float literal"))
                         % location)
 
         if (

--- a/locale/de/LC_MESSAGES/django.po
+++ b/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-08-25 16:12+0800\n"
+"POT-Creation-Date: 2015-08-25 17:02+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -171,40 +171,35 @@ msgstr ""
 msgid "Username"
 msgstr ""
 
-#: .\course\auth.py:288
-msgid "Required. 30 characters or fewer. Letters, digits and @/./+/-/_ only."
-msgstr ""
-
-#: .\course\auth.py:293
+#: .\course\auth.py:291
 msgid "Enter a valid username."
 msgstr ""
 
-#: .\course\auth.py:294
-msgid ""
-"Enter a valid username. This value may contain only letters, numbers and @/./"
+#: .\course\auth.py:292
+msgid "This value may contain only letters, numbers and @/./+/-/_ characters."
 msgstr ""
 
-#: .\course\auth.py:308 .\course\auth.py:393
+#: .\course\auth.py:306 .\course\auth.py:391
 msgid "Send email"
 msgstr ""
 
-#: .\course\auth.py:315 .\course\auth.py:399
+#: .\course\auth.py:313 .\course\auth.py:397
 msgid "password-based sign-in is not being used"
 msgstr ""
 
-#: .\course\auth.py:325
+#: .\course\auth.py:323
 msgid "A user with that username already exists."
 msgstr ""
 
-#: .\course\auth.py:330
+#: .\course\auth.py:328
 #, python-format
 msgid ""
 "That email address is already in use. Would you like to <a href='%s'>reset "
 "your password</a> instead?"
 msgstr ""
 
-#: .\course\auth.py:365 .\course\auth.py:434 .\course\auth.py:450
-#: .\course\auth.py:523 .\course\auth.py:582
+#: .\course\auth.py:363 .\course\auth.py:432 .\course\auth.py:448
+#: .\course\auth.py:521 .\course\auth.py:580
 #: .\course\templates\course\analytics-flow.html:5
 #: .\course\templates\course\analytics-flows.html:5
 #: .\course\templates\course\analytics-page.html:5
@@ -233,91 +228,91 @@ msgstr ""
 msgid "RELATE"
 msgstr ""
 
-#: .\course\auth.py:366
+#: .\course\auth.py:364
 msgid "Verify your email"
 msgstr ""
 
-#: .\course\auth.py:372 .\course\auth.py:441 .\course\auth.py:588
+#: .\course\auth.py:370 .\course\auth.py:439 .\course\auth.py:586
 msgid "Email sent. Please check your email and click the link."
 msgstr ""
 
-#: .\course\auth.py:381
+#: .\course\auth.py:379
 msgid "Sign up"
 msgstr ""
 
-#: .\course\auth.py:387 .\course\auth.py:533 .\course\models.py:408
+#: .\course\auth.py:385 .\course\auth.py:531 .\course\models.py:408
 msgid "Email"
 msgstr ""
 
-#: .\course\auth.py:414
+#: .\course\auth.py:412
 msgid ""
 "That email address doesn't have an associated user account. Are you sure "
 "you've registered?"
 msgstr ""
 
-#: .\course\auth.py:435
+#: .\course\auth.py:433
 msgid "Password reset"
 msgstr ""
 
-#: .\course\auth.py:449 .\course\auth.py:522
+#: .\course\auth.py:447 .\course\auth.py:520
 #, python-format
 msgid "Password reset on %(site_name)s"
 msgstr ""
 
-#: .\course\auth.py:457
+#: .\course\auth.py:455
 msgid "Password"
 msgstr ""
 
-#: .\course\auth.py:459
+#: .\course\auth.py:457
 msgid "Password confirmation"
 msgstr ""
 
-#: .\course\auth.py:465 .\course\auth.py:646 .\course\auth.py:659
+#: .\course\auth.py:463 .\course\auth.py:644 .\course\auth.py:657
 #: .\course\templates\course\course-page.html:30
 #: .\course\templates\course\home.html:22 .\course\versioning.py:376
 msgid "Update"
 msgstr ""
 
-#: .\course\auth.py:474
+#: .\course\auth.py:472
 msgid "The two password fields didn't match."
 msgstr ""
 
-#: .\course\auth.py:479 .\course\auth.py:545 .\course\auth.py:602
+#: .\course\auth.py:477 .\course\auth.py:543 .\course\auth.py:600
 msgid "email-based sign-in is not being used"
 msgstr ""
 
-#: .\course\auth.py:483 .\course\auth.py:608
+#: .\course\auth.py:481 .\course\auth.py:606
 msgid "Invalid sign-in token. Perhaps you've used an old token email?"
 msgstr ""
 
-#: .\course\auth.py:485 .\course\auth.py:493 .\course\auth.py:498
-#: .\course\auth.py:610 .\course\auth.py:615
+#: .\course\auth.py:483 .\course\auth.py:491 .\course\auth.py:496
+#: .\course\auth.py:608 .\course\auth.py:613
 msgid "invalid sign-in token"
 msgstr ""
 
-#: .\course\auth.py:497 .\course\auth.py:614
+#: .\course\auth.py:495 .\course\auth.py:612
 msgid "Account disabled."
 msgstr ""
 
-#: .\course\auth.py:508 .\course\auth.py:621
+#: .\course\auth.py:506 .\course\auth.py:619
 msgid ""
 "Successfully signed in. Please complete your registration information below."
 msgstr ""
 
-#: .\course\auth.py:515 .\course\auth.py:628
+#: .\course\auth.py:513 .\course\auth.py:626
 msgid "Successfully signed in."
 msgstr ""
 
-#: .\course\auth.py:539
+#: .\course\auth.py:537
 msgid "Send sign-in email"
 msgstr ""
 
-#: .\course\auth.py:582
+#: .\course\auth.py:580
 #, python-format
 msgid "Your %(RELATE)s sign-in link"
 msgstr ""
 
-#: .\course\auth.py:680 .\course\auth.py:690
+#: .\course\auth.py:678 .\course\auth.py:688
 msgid "Profile data saved."
 msgstr ""
 

--- a/locale/de/LC_MESSAGES/django.po
+++ b/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-08-08 16:21+0800\n"
+"POT-Creation-Date: 2015-08-25 16:12+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,55 +18,56 @@ msgstr ""
 "Language: \n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: .\course\admin.py:104 .\course\admin.py:278
+#: .\course\admin.py:104 .\course\admin.py:280
 msgid "First name"
 msgstr ""
 
-#: .\course\admin.py:110 .\course\admin.py:284
+#: .\course\admin.py:110 .\course\admin.py:286
 msgid "Last name"
 msgstr ""
 
-#: .\course\admin.py:268
+#: .\course\admin.py:270
 msgid "Tags must belong to same course as participation."
 msgstr ""
 
-#: .\course\admin.py:387 .\course\admin.py:505 .\course\admin.py:589
-#: .\course\admin.py:702 .\course\admin.py:776
-#: .\course\templates\course\gradebook-single.html:17 .\course\views.py:464
+#: .\course\admin.py:389 .\course\admin.py:507 .\course\admin.py:591
+#: .\course\admin.py:704 .\course\admin.py:778
+#: .\course\templates\course\gradebook-single.html:17 .\course\views.py:514
 msgid "Participant"
 msgstr ""
 
-#: .\course\admin.py:482 .\course\admin.py:584 .\course\admin.py:692
-#: .\course\admin.py:771 .\course\models.py:259
+#: .\course\admin.py:484 .\course\admin.py:586 .\course\admin.py:694
+#: .\course\admin.py:773 .\course\models.py:269
 msgid "Course"
 msgstr ""
 
-#: .\course\admin.py:487 .\course\flow.py:1400 .\course\models.py:427
-#: .\course\models.py:454 .\course\models.py:814 .\course\models.py:880
-#: .\course\models.py:987 .\course\templates\course\gradebook-opp-list.html:26
-#: .\course\templates\course\gradebook-single.html:134 .\course\views.py:309
-#: .\course\views.py:392 .\course\views.py:468
+#: .\course\admin.py:489 .\course\flow.py:1439 .\course\models.py:439
+#: .\course\models.py:466 .\course\models.py:826 .\course\models.py:892
+#: .\course\models.py:1001
+#: .\course\templates\course\gradebook-opp-list.html:26
+#: .\course\templates\course\gradebook-single.html:134 .\course\views.py:359
+#: .\course\views.py:442 .\course\views.py:518
 msgid "Flow ID"
 msgstr ""
 
-#: .\course\admin.py:496 .\course\models.py:550
+#: .\course\admin.py:498 .\course\models.py:562
 #: .\course\templates\course\gradebook-single.html:216
 msgid "Page ID"
 msgstr ""
 
-#: .\course\admin.py:503
+#: .\course\admin.py:505
 msgid "anonymous"
 msgstr ""
 
-#: .\course\admin.py:510
+#: .\course\admin.py:512
 msgid "Has answer"
 msgstr ""
 
-#: .\course\admin.py:515
+#: .\course\admin.py:517
 msgid "Flow Session ID"
 msgstr ""
 
-#: .\course\admin.py:697
+#: .\course\admin.py:699
 msgid "Opportunity"
 msgstr ""
 
@@ -105,91 +106,105 @@ msgstr ""
 msgid "Course module"
 msgstr ""
 
-#: .\course\auth.py:112
+#: .\course\auth.py:113
 msgid "Error while impersonating."
 msgstr ""
 
-#. Translators: information displayed when selecting user
-#. for impersonating. Customize how the name is shown, but
-#. leave email first to retain usability of form sorted by
-#. last name.
-#: .\course\auth.py:128 .\course\views.py:442
+#. Translators: information displayed when selecting
+#. userfor impersonating. Customize how the name is
+#. shown, but leave email first to retain usability
+#. of form sorted by last name.
+#: .\course\auth.py:129 .\course\views.py:492
 #, python-format
 msgid "%(user_email)s - %(user_lastname)s, %(user_firstname)s"
 msgstr ""
 
-#: .\course\auth.py:139
+#: .\course\auth.py:140
 msgid "Select user to impersonate."
 msgstr ""
 
-#: .\course\auth.py:140 .\course\templates\course\grade-import-preview.html:18
+#: .\course\auth.py:141 .\course\templates\course\grade-import-preview.html:18
 msgid "User"
 msgstr ""
 
-#: .\course\auth.py:142
+#: .\course\auth.py:143
 msgid "Impersonate"
 msgstr ""
 
-#: .\course\auth.py:150
+#: .\course\auth.py:151
 msgid "Already impersonating someone."
 msgstr ""
 
-#: .\course\auth.py:159
+#: .\course\auth.py:160
 #, python-format
 msgid "Now impersonating '%s'."
 msgstr ""
 
-#: .\course\auth.py:168 .\relate\templates\base.html:78
+#: .\course\auth.py:169 .\relate\templates\base.html:78
 msgid "Impersonate user"
 msgstr ""
 
-#: .\course\auth.py:178 .\relate\templates\base.html:76
+#: .\course\auth.py:179 .\relate\templates\base.html:76
 msgid "Stop impersonating"
 msgstr ""
 
-#: .\course\auth.py:184
+#: .\course\auth.py:185
 msgid "Not currently impersonating anyone."
 msgstr ""
 
-#: .\course\auth.py:191
+#: .\course\auth.py:192
 msgid "No longer impersonating anyone."
 msgstr ""
 
-#: .\course\auth.py:200
+#: .\course\auth.py:201
 msgid "Stop impersonating user"
 msgstr ""
 
-#: .\course\auth.py:272 .\course\templates\course\course-page.html:38
+#: .\course\auth.py:273 .\course\templates\course\course-page.html:38
 #: .\course\templates\course\flow-start.html:186
 #: .\course\templates\course\login.html:7 .\relate\templates\403.html:14
 #: .\relate\templates\base.html:104
 msgid "Sign in"
 msgstr ""
 
-#: .\course\auth.py:286
+#: .\course\auth.py:287
 msgid "Username"
 msgstr ""
 
-#: .\course\auth.py:296 .\course\auth.py:381
+#: .\course\auth.py:288
+msgid "Required. 30 characters or fewer. Letters, digits and @/./+/-/_ only."
+msgstr ""
+
+#: .\course\auth.py:293
+msgid "Enter a valid username."
+msgstr ""
+
+#: .\course\auth.py:294
+msgid ""
+"Enter a valid username. This value may contain only letters, numbers and @/./"
+msgstr ""
+
+#: .\course\auth.py:308 .\course\auth.py:393
 msgid "Send email"
 msgstr ""
 
-#: .\course\auth.py:303 .\course\auth.py:387
+#: .\course\auth.py:315 .\course\auth.py:399
 msgid "password-based sign-in is not being used"
 msgstr ""
 
-#: .\course\auth.py:313
-msgid "That user name is already taken."
+#: .\course\auth.py:325
+msgid "A user with that username already exists."
 msgstr ""
 
-#: .\course\auth.py:318
+#: .\course\auth.py:330
 #, python-format
 msgid ""
 "That email address is already in use. Would you like to <a href='%s'>reset "
 "your password</a> instead?"
 msgstr ""
 
-#: .\course\auth.py:353 .\course\auth.py:420 .\course\auth.py:565
+#: .\course\auth.py:365 .\course\auth.py:434 .\course\auth.py:450
+#: .\course\auth.py:523 .\course\auth.py:582
 #: .\course\templates\course\analytics-flow.html:5
 #: .\course\templates\course\analytics-flows.html:5
 #: .\course\templates\course\analytics-page.html:5
@@ -218,93 +233,96 @@ msgstr ""
 msgid "RELATE"
 msgstr ""
 
-#: .\course\auth.py:354
+#: .\course\auth.py:366
 msgid "Verify your email"
 msgstr ""
 
-#: .\course\auth.py:360 .\course\auth.py:427 .\course\auth.py:571
+#: .\course\auth.py:372 .\course\auth.py:441 .\course\auth.py:588
 msgid "Email sent. Please check your email and click the link."
 msgstr ""
 
-#: .\course\auth.py:369
+#: .\course\auth.py:381
 msgid "Sign up"
 msgstr ""
 
-#: .\course\auth.py:375 .\course\auth.py:516 .\course\models.py:396
+#: .\course\auth.py:387 .\course\auth.py:533 .\course\models.py:408
 msgid "Email"
 msgstr ""
 
-#: .\course\auth.py:402
-msgid "Email address is not known."
+#: .\course\auth.py:414
+msgid ""
+"That email address doesn't have an associated user account. Are you sure "
+"you've registered?"
 msgstr ""
 
-#: .\course\auth.py:421
+#: .\course\auth.py:435
 msgid "Password reset"
 msgstr ""
 
-#: .\course\auth.py:435 .\course\auth.py:506
-msgid "Reset Password"
+#: .\course\auth.py:449 .\course\auth.py:522
+#, python-format
+msgid "Password reset on %(site_name)s"
 msgstr ""
 
-#: .\course\auth.py:442
+#: .\course\auth.py:457
 msgid "Password"
 msgstr ""
 
-#: .\course\auth.py:444
-msgid "Password repeat"
+#: .\course\auth.py:459
+msgid "Password confirmation"
 msgstr ""
 
-#: .\course\auth.py:450 .\course\auth.py:629 .\course\auth.py:642
+#: .\course\auth.py:465 .\course\auth.py:646 .\course\auth.py:659
 #: .\course\templates\course\course-page.html:30
-#: .\course\templates\course\home.html:22 .\course\versioning.py:370
+#: .\course\templates\course\home.html:22 .\course\versioning.py:376
 msgid "Update"
 msgstr ""
 
-#: .\course\auth.py:458
-msgid "Passwords do not match"
+#: .\course\auth.py:474
+msgid "The two password fields didn't match."
 msgstr ""
 
-#: .\course\auth.py:463 .\course\auth.py:528 .\course\auth.py:585
+#: .\course\auth.py:479 .\course\auth.py:545 .\course\auth.py:602
 msgid "email-based sign-in is not being used"
 msgstr ""
 
-#: .\course\auth.py:467 .\course\auth.py:591
+#: .\course\auth.py:483 .\course\auth.py:608
 msgid "Invalid sign-in token. Perhaps you've used an old token email?"
 msgstr ""
 
-#: .\course\auth.py:469 .\course\auth.py:477 .\course\auth.py:482
-#: .\course\auth.py:593 .\course\auth.py:598
+#: .\course\auth.py:485 .\course\auth.py:493 .\course\auth.py:498
+#: .\course\auth.py:610 .\course\auth.py:615
 msgid "invalid sign-in token"
 msgstr ""
 
-#: .\course\auth.py:481 .\course\auth.py:597
+#: .\course\auth.py:497 .\course\auth.py:614
 msgid "Account disabled."
 msgstr ""
 
-#: .\course\auth.py:492 .\course\auth.py:604
+#: .\course\auth.py:508 .\course\auth.py:621
 msgid ""
 "Successfully signed in. Please complete your registration information below."
 msgstr ""
 
-#: .\course\auth.py:499 .\course\auth.py:611
+#: .\course\auth.py:515 .\course\auth.py:628
 msgid "Successfully signed in."
 msgstr ""
 
-#: .\course\auth.py:522
+#: .\course\auth.py:539
 msgid "Send sign-in email"
 msgstr ""
 
-#: .\course\auth.py:565
+#: .\course\auth.py:582
 #, python-format
 msgid "Your %(RELATE)s sign-in link"
 msgstr ""
 
-#: .\course\auth.py:663 .\course\auth.py:673
+#: .\course\auth.py:680 .\course\auth.py:690
 msgid "Profile data saved."
 msgstr ""
 
 #. Translators: format of event kind in Event model
-#: .\course\calendar.py:48 .\course\calendar.py:190 .\course\models.py:282
+#: .\course\calendar.py:48 .\course\calendar.py:190 .\course\models.py:292
 msgid "Should be lower_case_with_underscores, no spaces allowed."
 msgstr ""
 
@@ -456,151 +474,151 @@ msgstr ""
 msgid "unknown expiration mode"
 msgstr ""
 
-#: .\course\constants.py:172
+#: .\course\constants.py:195
 msgctxt "Flow permission"
 msgid "View the flow"
 msgstr ""
 
-#: .\course\constants.py:174
+#: .\course\constants.py:197
 msgctxt "Flow permission"
 msgid "Submit answers"
 msgstr ""
 
-#: .\course\constants.py:176
+#: .\course\constants.py:199
 msgctxt "Flow permission"
 msgid "End session"
 msgstr ""
 
-#: .\course\constants.py:178
+#: .\course\constants.py:201
 msgctxt "Flow permission"
 msgid "Change already-graded answer"
 msgstr ""
 
-#: .\course\constants.py:181
+#: .\course\constants.py:204
 msgctxt "Flow permission"
 msgid "See whether an answer is correct"
 msgstr ""
 
-#: .\course\constants.py:184
+#: .\course\constants.py:207
 msgctxt "Flow permission"
 msgid "See the correct answer before answering"
 msgstr ""
 
-#: .\course\constants.py:187
+#: .\course\constants.py:210
 msgctxt "Flow permission"
 msgid "See the correct answer after answering"
 msgstr ""
 
-#: .\course\constants.py:190
+#: .\course\constants.py:213
 msgctxt "Flow permission"
 msgid "Set the session to 'roll over' expiration mode"
 msgstr ""
 
-#: .\course\constants.py:202
+#: .\course\constants.py:225
 msgctxt "Flow rule kind choices"
 msgid "Session Start"
 msgstr ""
 
-#: .\course\constants.py:204
+#: .\course\constants.py:227
 msgctxt "Flow rule kind choices"
 msgid "Session Access"
 msgstr ""
 
-#: .\course\constants.py:206
+#: .\course\constants.py:229
 msgctxt "Flow rule kind choices"
 msgid "Grading"
 msgstr ""
 
-#: .\course\constants.py:244
+#: .\course\constants.py:267
 msgctxt "Grade aggregation strategy"
 msgid "Use the max grade"
 msgstr ""
 
-#: .\course\constants.py:246
+#: .\course\constants.py:269
 msgctxt "Grade aggregation strategy"
 msgid "Use the avg grade"
 msgstr ""
 
-#: .\course\constants.py:248
+#: .\course\constants.py:271
 msgctxt "Grade aggregation strategy"
 msgid "Use the min grade"
 msgstr ""
 
-#: .\course\constants.py:250
+#: .\course\constants.py:273
 msgctxt "Grade aggregation strategy"
 msgid "Use the earliest grade"
 msgstr ""
 
-#: .\course\constants.py:252
+#: .\course\constants.py:275
 msgctxt "Grade aggregation strategy"
 msgid "Use the latest grade"
 msgstr ""
 
-#: .\course\constants.py:269
+#: .\course\constants.py:292
 msgctxt "Grade state change"
 msgid "Grading started"
 msgstr ""
 
-#: .\course\constants.py:271
+#: .\course\constants.py:294
 msgctxt "Grade state change"
 msgid "Graded"
 msgstr ""
 
-#: .\course\constants.py:273
+#: .\course\constants.py:296
 msgctxt "Grade state change"
 msgid "Retrieved"
 msgstr ""
 
-#: .\course\constants.py:275
+#: .\course\constants.py:298
 msgctxt "Grade state change"
 msgid "Unavailable"
 msgstr ""
 
-#: .\course\constants.py:277
+#: .\course\constants.py:300
 msgctxt "Grade state change"
 msgid "Extension"
 msgstr ""
 
-#: .\course\constants.py:279
+#: .\course\constants.py:302
 msgctxt "Grade state change"
 msgid "Report sent"
 msgstr ""
 
-#: .\course\constants.py:281
+#: .\course\constants.py:304
 msgctxt "Grade state change"
 msgid "Do-over"
 msgstr ""
 
-#: .\course\constants.py:283
+#: .\course\constants.py:306
 msgctxt "Grade state change"
 msgid "Exempt"
 msgstr ""
 
-#: .\course\content.py:75
+#: .\course\content.py:104
 #, python-format
 msgid "resource '%s' not found"
 msgstr ""
 
-#: .\course\content.py:251
+#: .\course\content.py:280
 msgid "I have no idea what a processing instruction is."
 msgstr ""
 
-#: .\course\content.py:526
+#: .\course\content.py:571
 #, python-format
 msgid "invalid period: %s"
 msgstr ""
 
-#: .\course\content.py:613 .\course\content.py:638
+#: .\course\content.py:658 .\course\content.py:683
 #, python-format
 msgid "unrecognized date/time specification: '%s' (interpreted as 'now')"
 msgstr ""
 
-#: .\course\content.py:728
+#: .\course\content.py:773
 #, python-format
 msgid "page '%(group_id)s/%(page_id)s' in flow '%(flow_id)s'"
 msgstr ""
 
-#: .\course\content.py:781
+#: .\course\content.py:826
 #, python-format
 msgid "repo page class must conist of two dotted components (invalid: '%s')"
 msgstr ""
@@ -660,7 +678,7 @@ msgstr ""
 msgid "Deny enrollment"
 msgstr ""
 
-#: .\course\enrollment.py:220 .\course\models.py:401
+#: .\course\enrollment.py:220 .\course\models.py:413
 #: .\course\templates\course\gradebook-participant-list.html:27
 msgid "Role"
 msgstr ""
@@ -694,7 +712,7 @@ msgstr ""
 msgid "cannot grade ungraded answer"
 msgstr ""
 
-#: .\course\flow.py:463 .\course\flow.py:1331
+#: .\course\flow.py:463 .\course\flow.py:1370
 msgid "Can't end a session that's already ended"
 msgstr ""
 
@@ -758,123 +776,127 @@ msgstr ""
 msgid "may not view other people's sessions"
 msgstr ""
 
-#: .\course\flow.py:895
+#: .\course\flow.py:932
 msgid "Save answer"
 msgstr ""
 
-#: .\course\flow.py:902
+#: .\course\flow.py:939
 msgid "Submit answer for grading"
 msgstr ""
 
-#: .\course\flow.py:906
+#: .\course\flow.py:943
 msgid "Submit final answer"
 msgstr ""
 
-#: .\course\flow.py:915
+#: .\course\flow.py:952
 msgid "Save answer and move on"
 msgstr ""
 
-#: .\course\flow.py:923
+#: .\course\flow.py:960
 msgid "Save answer and finish"
 msgstr ""
 
-#: .\course\flow.py:936
+#: .\course\flow.py:973
 msgid "could not find which button was pressed"
 msgstr ""
 
-#: .\course\flow.py:960
+#: .\course\flow.py:997
 msgid ""
 "No in-progress session record found for this flow. Redirected to flow start "
 "page."
 msgstr ""
 
-#: .\course\flow.py:992
+#: .\course\flow.py:1029
 msgid "not allowed to view flow"
 msgstr ""
 
-#: .\course\flow.py:1004
+#: .\course\flow.py:1041
 msgid "Answer submission not allowed."
 msgstr ""
 
-#: .\course\flow.py:1013
+#: .\course\flow.py:1050
 msgid "Already have final answer."
 msgstr ""
 
-#: .\course\flow.py:1026
+#: .\course\flow.py:1070
 msgid "Answer saved."
 msgstr ""
 
-#: .\course\flow.py:1242
+#: .\course\flow.py:1154
+msgid "Failed to submit answer."
+msgstr ""
+
+#: .\course\flow.py:1281
 msgid "only POST allowed"
 msgstr ""
 
-#: .\course\flow.py:1248
+#: .\course\flow.py:1287
 msgid "may only change your own flow sessions"
 msgstr ""
 
-#: .\course\flow.py:1251
+#: .\course\flow.py:1290
 msgid "may only change in-progress flow sessions"
 msgstr ""
 
-#: .\course\flow.py:1256
+#: .\course\flow.py:1295
 msgid "invalid expiration mode"
 msgstr ""
 
-#: .\course\flow.py:1327
+#: .\course\flow.py:1366
 msgid "odd POST parameters"
 msgstr ""
 
-#: .\course\flow.py:1335
+#: .\course\flow.py:1374
 msgid "not permitted to end session"
 msgstr ""
 
-#: .\course\flow.py:1403
+#: .\course\flow.py:1442
 msgid ""
 "If non-empty, limit the regrading to sessions started under this access "
 "rules tag."
 msgstr ""
 
-#: .\course\flow.py:1405 .\course\models.py:466
+#: .\course\flow.py:1444 .\course\models.py:478
 msgid "Access rules tag"
 msgstr ""
 
-#: .\course\flow.py:1409
+#: .\course\flow.py:1448
 msgid "Regrade in-progress and not-in-progress sessions"
 msgstr ""
 
-#: .\course\flow.py:1411
+#: .\course\flow.py:1450
 msgid "Regrade in-progress sessions only"
 msgstr ""
 
-#: .\course\flow.py:1413
+#: .\course\flow.py:1452
 msgid "Regrade not-in-progress sessions only"
 msgstr ""
 
-#: .\course\flow.py:1415
+#: .\course\flow.py:1454
 msgid "Regraded session in progress"
 msgstr ""
 
-#: .\course\flow.py:1418 .\course\templates\course\gradebook-single.html:248
+#: .\course\flow.py:1457 .\course\templates\course\gradebook-single.html:248
 msgid "Regrade"
 msgstr ""
 
-#: .\course\flow.py:1436
+#: .\course\flow.py:1475
 msgid "must be instructor to regrade flows"
 msgstr ""
 
-#: .\course\flow.py:1466
+#: .\course\flow.py:1505
 #, python-format
 msgid "%d sessions regraded."
 msgstr ""
 
-#: .\course\flow.py:1474
+#: .\course\flow.py:1513
 msgid ""
 "This regrading process is only intended for flows that donot show up in the "
 "grade book. If you would like to regradefor-credit flows, use the "
 "corresponding functionality in the grade book."
 msgstr ""
 
-#: .\course\flow.py:1479
+#: .\course\flow.py:1518
 msgid "Regrade not-for-credit Flow Sessions"
 msgstr ""
 
@@ -930,8 +952,8 @@ msgstr ""
 msgid "opportunity from wrong course"
 msgstr ""
 
-#: .\course\grades.py:499 .\course\views.py:343 .\course\views.py:370
-#: .\course\views.py:418
+#: .\course\grades.py:499 .\course\views.py:393 .\course\views.py:420
+#: .\course\views.py:468
 msgid "invalid operation"
 msgstr ""
 
@@ -956,17 +978,17 @@ msgid "Grade recalculated for %d session(s)."
 msgstr ""
 
 #: .\course\grades.py:549 .\course\grades.py:869 .\course\grades.py:1176
-#: .\course\versioning.py:424
+#: .\course\versioning.py:438
 msgctxt "Starting of Error message"
 msgid "Error"
 msgstr ""
 
-#: .\course\grades.py:660 .\course\views.py:718
+#: .\course\grades.py:660 .\course\views.py:768
 msgid "Set access rules tag"
 msgstr ""
 
-#: .\course\grades.py:664 .\course\models.py:844 .\course\models.py:892
-#: .\course\models.py:1055 .\course\views.py:762
+#: .\course\grades.py:664 .\course\models.py:856 .\course\models.py:904
+#: .\course\models.py:1069 .\course\views.py:812
 msgid "Comment"
 msgstr ""
 
@@ -1037,7 +1059,7 @@ msgctxt "Field name in Import grades form"
 msgid "Grading opportunity"
 msgstr ""
 
-#: .\course\grades.py:968 .\course\models.py:1046
+#: .\course\grades.py:968 .\course\models.py:1060
 msgid "Attempt ID"
 msgstr ""
 
@@ -1081,13 +1103,13 @@ msgid "Feedback column"
 msgstr ""
 
 #. Translators: "Max point" refers to full credit in points.
-#: .\course\grades.py:997 .\course\models.py:693 .\course\models.py:1052
+#: .\course\grades.py:997 .\course\models.py:705 .\course\models.py:1066
 msgid "Max points"
 msgstr ""
 
 #: .\course\grades.py:1000 .\course\sandbox.py:70
 #: .\course\templates\course\grade-import-preview.html:14
-#: .\course\versioning.py:376
+#: .\course\versioning.py:382
 msgid "Preview"
 msgstr ""
 
@@ -1189,7 +1211,7 @@ msgid "Send instant message"
 msgstr ""
 
 #. Translators: name format of ParticipationTag
-#: .\course\models.py:60 .\course\models.py:324
+#: .\course\models.py:60 .\course\models.py:334
 msgid "Format is lower-case-with-hyphens. Do not use spaces."
 msgstr ""
 
@@ -1222,7 +1244,7 @@ msgstr ""
 msgid "Facility IP range"
 msgstr ""
 
-#: .\course\models.py:117 .\course\models.py:349
+#: .\course\models.py:119 .\course\models.py:361
 #: .\course\templates\course\gradebook-by-opp.html:63
 #: .\course\templates\course\gradebook-participant-list.html:24
 #: .\course\templates\course\gradebook-participant.html:31
@@ -1230,884 +1252,896 @@ msgstr ""
 msgid "User ID"
 msgstr ""
 
-#: .\course\models.py:120 .\course\models.py:143
+#: .\course\models.py:122 .\course\models.py:145
 msgid "User status"
 msgstr ""
 
-#: .\course\models.py:122
+#: .\course\models.py:124
 msgid "The sign in token sent out in email."
 msgstr ""
 
 #. Translators: the sign in token of the user.
-#: .\course\models.py:125
+#: .\course\models.py:127
 msgid "Sign in key"
 msgstr ""
 
-#: .\course\models.py:127
+#: .\course\models.py:129
 msgid "The time stamp of the sign in token."
 msgstr ""
 
 #. Translators: the time when the token is sent out.
-#: .\course\models.py:129
+#: .\course\models.py:131
 msgid "Key time"
 msgstr ""
 
-#: .\course\models.py:133
+#: .\course\models.py:135
 msgid "Default"
 msgstr ""
 
 #. Translators: the text editor used by participants
-#: .\course\models.py:140
+#: .\course\models.py:142
 msgid "Editor mode"
 msgstr ""
 
-#: .\course\models.py:144
+#: .\course\models.py:146
 msgid "User statuses"
 msgstr ""
 
-#: .\course\models.py:148
+#: .\course\models.py:150
 #, python-format
 msgid "User status for %(user)s"
 msgstr ""
 
-#: .\course\models.py:157
+#: .\course\models.py:159
 msgid ""
 "A course identifier. Alphanumeric with dashes, no spaces. This is visible in "
 "URLs and determines the location on your file system where the course's git "
 "repository lives."
 msgstr ""
 
-#: .\course\models.py:160 .\course\models.py:279 .\course\models.py:321
-#: .\course\models.py:351 .\course\models.py:398 .\course\models.py:425
-#: .\course\models.py:446 .\course\models.py:973
+#: .\course\models.py:162 .\course\models.py:289 .\course\models.py:331
+#: .\course\models.py:363 .\course\models.py:410 .\course\models.py:437
+#: .\course\models.py:458 .\course\models.py:987
 msgid "Course identifier"
 msgstr ""
 
-#: .\course\models.py:166
+#: .\course\models.py:168
 msgid "Identifier may only contain letters, numbers, and hypens ('-')."
 msgstr ""
 
-#: .\course\models.py:173
+#: .\course\models.py:175
 msgid "Is the course only accessible to course staff?"
 msgstr ""
 
-#: .\course\models.py:174
-msgid "Hidden to student"
+#: .\course\models.py:176
+msgid "Only visible to course staff"
 msgstr ""
 
-#: .\course\models.py:177
+#: .\course\models.py:179
 msgid "Should the course be listed on the main page?"
 msgstr ""
 
-#: .\course\models.py:178
+#: .\course\models.py:180
 msgid "Listed on main page"
 msgstr ""
 
-#: .\course\models.py:181
+#: .\course\models.py:183
 msgid "Accepts enrollment"
 msgstr ""
 
-#: .\course\models.py:184
+#: .\course\models.py:186
 msgid "Whether the course content has passed validation."
 msgstr ""
 
-#: .\course\models.py:185
+#: .\course\models.py:187
 msgid "Valid"
 msgstr ""
 
-#: .\course\models.py:188
+#: .\course\models.py:190
 msgid ""
 "A Git URL from which to pull course updates. If you're just starting out, "
 "enter <tt>git://github.com/inducer/relate-sample</tt> to get some sample "
 "content."
 msgstr ""
 
-#: .\course\models.py:192
+#: .\course\models.py:194
 msgid "git source"
 msgstr ""
 
-#: .\course\models.py:194
+#: .\course\models.py:196
 msgid ""
 "An SSH private key to use for Git authentication. Not needed for the sample "
-"URL above."
-msgstr ""
-
-#: .\course\models.py:196
-msgid "SSH private key"
+"URL above.You may use <a href='/generate-ssh-key'>this tool</a> to generate "
+"a key pair."
 msgstr ""
 
 #: .\course\models.py:200
+msgid "SSH private key"
+msgstr ""
+
+#: .\course\models.py:203
+msgid ""
+"Subdirectory in git repository to use as course root directory. Should not "
+"include trailing slash."
+msgstr ""
+
+#: .\course\models.py:206
+msgid "Course root directory"
+msgstr ""
+
+#: .\course\models.py:210
 msgid ""
 "Name of a YAML file in the git repository that contains the root course "
 "descriptor."
 msgstr ""
 
-#: .\course\models.py:202
+#: .\course\models.py:212
 msgid "Course file"
 msgstr ""
 
-#: .\course\models.py:205
+#: .\course\models.py:215
 msgid ""
 "Name of a YAML file in the git repository that contains calendar information."
 msgstr ""
 
-#: .\course\models.py:207
+#: .\course\models.py:217
 msgid "Events file"
 msgstr ""
 
-#: .\course\models.py:211
+#: .\course\models.py:221
 msgid "If set, each enrolling student must be individually approved."
 msgstr ""
 
-#: .\course\models.py:213
+#: .\course\models.py:223
 msgid "Enrollment approval required"
 msgstr ""
 
-#: .\course\models.py:216
+#: .\course\models.py:226
 msgid ""
 "Enrollee's email addresses must end in the specified suffix, such as "
 "'@illinois.edu'."
 msgstr ""
 
-#: .\course\models.py:218
+#: .\course\models.py:228
 msgid "Enrollment required email suffix"
 msgstr ""
 
 #. Translators: replace "RELATE" with the brand name of your
 #. website if necessary.
-#: .\course\models.py:223
+#: .\course\models.py:233
 msgid ""
 "This email address will be used in the 'From' line of automated emails sent "
 "by RELATE."
 msgstr ""
 
-#: .\course\models.py:225
+#: .\course\models.py:235
 msgid "From email"
 msgstr ""
 
-#: .\course\models.py:228
+#: .\course\models.py:238
 msgid "This email address will receive notifications about the course."
 msgstr ""
 
-#: .\course\models.py:230
+#: .\course\models.py:240
 msgid "Notify email"
 msgstr ""
 
-#: .\course\models.py:235
+#: .\course\models.py:245
 msgid ""
 "(Required only if the instant message feature is desired.) The Jabber/XMPP "
 "ID (JID) the course will use to sign in to an XMPP server."
 msgstr ""
 
-#: .\course\models.py:238
+#: .\course\models.py:248
 msgid "Course xmpp ID"
 msgstr ""
 
-#: .\course\models.py:240
+#: .\course\models.py:250
 msgid ""
 "(Required only if the instant message feature is desired.) The password to "
 "go with the JID above."
 msgstr ""
 
-#: .\course\models.py:242
+#: .\course\models.py:252
 msgid "Course xmpp password"
 msgstr ""
 
-#: .\course\models.py:245
+#: .\course\models.py:255
 msgid ""
 "(Required only if the instant message feature is desired.) The JID to which "
 "instant messages will be sent."
 msgstr ""
 
-#: .\course\models.py:247
+#: .\course\models.py:257
 msgid "Recipient xmpp ID"
 msgstr ""
 
-#: .\course\models.py:253 .\course\models.py:452
+#: .\course\models.py:263 .\course\models.py:464
 msgid "Active git commit SHA"
 msgstr ""
 
-#: .\course\models.py:260
+#: .\course\models.py:270
 msgid "Courses"
 msgstr ""
 
-#: .\course\models.py:284
+#: .\course\models.py:294
 msgid "Kind of event"
 msgstr ""
 
 #. Translators: ordinal of event of the same kind
-#: .\course\models.py:287
+#: .\course\models.py:297
 msgid "Ordinal of event"
 msgstr ""
 
-#: .\course\models.py:289 .\course\models.py:429 .\course\models.py:456
+#: .\course\models.py:299 .\course\models.py:441 .\course\models.py:468
 #: .\course\templates\course\flow-start.html:23
 msgid "Start time"
 msgstr ""
 
-#: .\course\models.py:291 .\course\models.py:431
+#: .\course\models.py:301 .\course\models.py:443
 msgid "End time"
 msgstr ""
 
 #. Translators: for when the due time is "All day", how the webpage
 #. of a event is displayed.
-#: .\course\models.py:295
+#: .\course\models.py:305
 msgid ""
 "Only affects the rendering in the class calendar, in that a start time is "
 "not shown"
 msgstr ""
 
-#: .\course\models.py:297
+#: .\course\models.py:307
 msgid "All day"
 msgstr ""
 
-#: .\course\models.py:300
+#: .\course\models.py:310
 msgid "Shown in calendar"
 msgstr ""
 
-#: .\course\models.py:303
+#: .\course\models.py:313
 msgid "Event"
 msgstr ""
 
-#: .\course\models.py:304
+#: .\course\models.py:314
 msgid "Events"
 msgstr ""
 
-#: .\course\models.py:326
+#: .\course\models.py:336
 msgid "Name of participation tag"
 msgstr ""
 
-#: .\course\models.py:335
+#: .\course\models.py:347
 msgid "Name contains invalid characters."
 msgstr ""
 
-#: .\course\models.py:341
+#: .\course\models.py:353
 msgid "Participation tag"
 msgstr ""
 
-#: .\course\models.py:342
+#: .\course\models.py:354
 msgid "Participation tags"
 msgstr ""
 
-#: .\course\models.py:354
+#: .\course\models.py:366
 msgid "Enroll time"
 msgstr ""
 
-#: .\course\models.py:357
+#: .\course\models.py:369
 msgid ""
 "Instructors may update course content. Teaching assistants may access and "
 "change grade data. Observers may access analytics. Each role includes "
 "privileges from subsequent roles."
 msgstr ""
 
-#: .\course\models.py:361
+#: .\course\models.py:373
 msgid "Participation role"
 msgstr ""
 
-#: .\course\models.py:364
+#: .\course\models.py:376
 msgid "Participation status"
 msgstr ""
 
-#: .\course\models.py:369
+#: .\course\models.py:381
 msgid ""
 "Multiplier for time available on time-limited flows (time-limited flows are "
 "currently unimplemented)."
 msgstr ""
 
-#: .\course\models.py:371
+#: .\course\models.py:383
 msgid "Time factor"
 msgstr ""
 
-#: .\course\models.py:375
+#: .\course\models.py:387
 msgid "Preview git commit SHA"
 msgstr ""
 
-#: .\course\models.py:378
+#: .\course\models.py:390
 msgid "Tags"
 msgstr ""
 
 #. Translators: displayed format of Participation: some user in some
 #. course as some role
-#: .\course\models.py:383
+#: .\course\models.py:395
 #, python-format
 msgid "%(user)s in %(course)s as %(role)s"
 msgstr ""
 
-#: .\course\models.py:388 .\course\models.py:450 .\course\models.py:812
-#: .\course\models.py:882 .\course\models.py:1033 .\course\models.py:1289
+#: .\course\models.py:400 .\course\models.py:462 .\course\models.py:824
+#: .\course\models.py:894 .\course\models.py:1047 .\course\models.py:1305
 #: .\course\templates\course\course-base.html:100
 msgid "Participation"
 msgstr ""
 
-#: .\course\models.py:389
+#: .\course\models.py:401
 msgid "Participations"
 msgstr ""
 
-#: .\course\models.py:404 .\course\models.py:830 .\course\models.py:887
-#: .\course\models.py:1061
+#: .\course\models.py:416 .\course\models.py:842 .\course\models.py:899
+#: .\course\models.py:1075
 msgid "Creator"
 msgstr ""
 
-#: .\course\models.py:406 .\course\models.py:832 .\course\models.py:889
-#: .\course\models.py:998
+#: .\course\models.py:418 .\course\models.py:844 .\course\models.py:901
+#: .\course\models.py:1012
 msgid "Creation time"
 msgstr ""
 
 #. Translators: somebody's email in some course in Particiaption
 #. Preapproval
-#: .\course\models.py:411
+#: .\course\models.py:423
 #, python-format
 msgid "%(email)s in %(course)s"
 msgstr ""
 
-#: .\course\models.py:415
+#: .\course\models.py:427
 msgid "Participation preapproval"
 msgstr ""
 
-#: .\course\models.py:416
+#: .\course\models.py:428
 msgid "Participation preapprovals"
 msgstr ""
 
-#: .\course\models.py:433
+#: .\course\models.py:445
 msgid "Cancelled"
 msgstr ""
 
-#: .\course\models.py:436
+#: .\course\models.py:448
 msgid "Instant flow request"
 msgstr ""
 
-#: .\course\models.py:437 .\course\templates\course\course-base.html:104
+#: .\course\models.py:449 .\course\templates\course\course-base.html:104
 msgid "Instant flow requests"
 msgstr ""
 
-#: .\course\models.py:458
+#: .\course\models.py:470
 msgid "Completition time"
 msgstr ""
 
-#: .\course\models.py:460
+#: .\course\models.py:472
 msgid "Page count"
 msgstr ""
 
-#: .\course\models.py:463
+#: .\course\models.py:475
 msgid "In progress"
 msgstr ""
 
-#: .\course\models.py:470
+#: .\course\models.py:482
 msgid "Expiration mode"
 msgstr ""
 
-#: .\course\models.py:479 .\course\models.py:1050
+#: .\course\models.py:491 .\course\models.py:1064
 #: .\course\templates\course\gradebook-single.html:218
 msgid "Points"
 msgstr ""
 
-#: .\course\models.py:482
+#: .\course\models.py:494
 msgid "Max point"
 msgstr ""
 
-#: .\course\models.py:484
+#: .\course\models.py:496
 msgid "Result comment"
 msgstr ""
 
-#: .\course\models.py:487 .\course\models.py:543 .\course\models.py:587
-#: .\course\models.py:1067 .\course\templates\course\grade-flow-page.html:58
+#: .\course\models.py:499 .\course\models.py:555 .\course\models.py:599
+#: .\course\models.py:1081 .\course\templates\course\grade-flow-page.html:58
 msgid "Flow session"
 msgstr ""
 
-#: .\course\models.py:488 .\course\templates\course\gradebook-single.html:127
+#: .\course\models.py:500 .\course\templates\course\gradebook-single.html:127
 msgid "Flow sessions"
 msgstr ""
 
-#: .\course\models.py:493
+#: .\course\models.py:505
 #, python-format
 msgid "anonymous session %(session_id)d on '%(flow_id)s'"
 msgstr ""
 
-#: .\course\models.py:497
+#: .\course\models.py:509
 #, python-format
 msgid "%(user)s's session %(session_id)d on '%(flow_id)s'"
 msgstr ""
 
-#: .\course\models.py:545
+#: .\course\models.py:557
 msgid "Ordinal"
 msgstr ""
 
-#: .\course\models.py:548
+#: .\course\models.py:560
 msgid "Group ID"
 msgstr ""
 
-#: .\course\models.py:555
+#: .\course\models.py:567
 msgid "Data"
 msgstr ""
 
-#: .\course\models.py:558 .\course\models.py:559
+#: .\course\models.py:570 .\course\models.py:571
 msgid "Flow page data"
 msgstr ""
 
-#: .\course\models.py:563
+#: .\course\models.py:575
 #, python-format
 msgid ""
 "Data for page '%(group_id)s/%(page_id)s' (ordinal %(ordinal)s) in %"
 "(flow_session)s"
 msgstr ""
 
-#: .\course\models.py:590 .\course\models.py:743
+#: .\course\models.py:602 .\course\models.py:755
 msgid "Page data"
 msgstr ""
 
-#: .\course\models.py:592
+#: .\course\models.py:604
 msgid "Visit time"
 msgstr ""
 
-#: .\course\models.py:594
+#: .\course\models.py:606
 msgid "Remote address"
 msgstr ""
 
-#: .\course\models.py:597
+#: .\course\models.py:609
 msgid ""
 "Synthetic flow page visits are generated for unvisited pages once a flow is "
 "finished. This is needed since grade information is attached to a visit, and "
 "it needs a place to go."
 msgstr ""
 
-#: .\course\models.py:601
+#: .\course\models.py:613
 msgid "Is synthetic"
 msgstr ""
 
 #. Translators: "Answer" is a Noun.
-#: .\course\models.py:607 .\course\page\code.py:59 .\course\page\text.py:97
+#: .\course\models.py:619 .\course\page\code.py:59 .\course\page\text.py:97
 msgid "Answer"
 msgstr ""
 
 #. Translators: determine whether the answer is a final,
 #. submitted answer fit for grading.
-#: .\course\models.py:620
+#: .\course\models.py:632
 msgid "Is submitted answer"
 msgstr ""
 
 #. Translators: flow page visit
-#: .\course\models.py:625
+#: .\course\models.py:637
 #, python-format
 msgid "'%(group_id)s/%(page_id)s' in '%(session)s' on %(time)s"
 msgstr ""
 
 #. Translators: flow page visit: if an answer is
 #. provided by user then append the string.
-#: .\course\models.py:635
+#: .\course\models.py:647
 msgid " (with answer)"
 msgstr ""
 
-#: .\course\models.py:640
+#: .\course\models.py:652
 msgid "Flow page visit"
 msgstr ""
 
-#: .\course\models.py:641
+#: .\course\models.py:653
 msgid "Flow page visits"
 msgstr ""
 
-#: .\course\models.py:668
+#: .\course\models.py:680
 msgid "Visit"
 msgstr ""
 
-#: .\course\models.py:672 .\course\templates\course\gradebook-single.html:219
+#: .\course\models.py:684 .\course\templates\course\gradebook-single.html:219
 msgid "Grader"
 msgstr ""
 
-#: .\course\models.py:674 .\course\models.py:1063
+#: .\course\models.py:686 .\course\models.py:1077
 msgid "Grade time"
 msgstr ""
 
-#: .\course\models.py:678
+#: .\course\models.py:690
 msgid "Graded at git commit SHA"
 msgstr ""
 
-#: .\course\models.py:683
+#: .\course\models.py:695
 msgid "Grade data"
 msgstr ""
 
 #. Translators: max point in grade
-#: .\course\models.py:691
+#: .\course\models.py:703
 msgid "Point value of this question when receiving full credit."
 msgstr ""
 
 #. Translators: correctness in grade
-#: .\course\models.py:696
+#: .\course\models.py:708
 msgid ""
 "Real number between zero and one (inclusively) indicating the degree of "
 "correctness of the answer."
 msgstr ""
 
-#: .\course\models.py:698
+#: .\course\models.py:710
 msgid "Correctness"
 msgstr ""
 
 #. Translators: "Feedback" stands for the feedback of answers.
-#: .\course\models.py:709
+#: .\course\models.py:721
 #: .\course\templates\course\grade-import-preview.html:20
 msgid "Feedback"
 msgstr ""
 
-#: .\course\models.py:724
+#: .\course\models.py:736
 msgid "Flow page visit grade"
 msgstr ""
 
-#: .\course\models.py:725
+#: .\course\models.py:737
 msgid "Flow page visit grades"
 msgstr ""
 
 #. Translators: return the information of the grade of a user
 #. by percentage.
-#: .\course\models.py:735
+#: .\course\models.py:747
 #, python-format
 msgid "grade of %(visit)s: %(percentage)s"
 msgstr ""
 
-#: .\course\models.py:745
+#: .\course\models.py:757
 #: .\course\templates\course\grade-import-preview.html:19
 #: .\course\templates\course\gradebook-participant.html:51
 #: .\course\templates\course\gradebook-single.html:66
 msgid "Grade"
 msgstr ""
 
-#: .\course\models.py:750
+#: .\course\models.py:762
 msgid "Bulk feedback"
 msgstr ""
 
-#: .\course\models.py:786
+#: .\course\models.py:798
 msgid "stipulations must be a dictionary"
 msgstr ""
 
-#: .\course\models.py:791
+#: .\course\models.py:803
 msgid "unrecognized keys in stipulations"
 msgstr ""
 
-#: .\course\models.py:797
+#: .\course\models.py:809
 msgid "credit_percent must be a float"
 msgstr ""
 
-#: .\course\models.py:803
+#: .\course\models.py:815
 msgid "'allowed_session_count' must be a non-negative integer"
 msgstr ""
 
-#: .\course\models.py:816 .\course\models.py:884
+#: .\course\models.py:828 .\course\models.py:896
 msgid "Expiration"
 msgstr ""
 
 #. Translators: help text for stipulations in FlowAccessException
 #. (deprecated)
-#: .\course\models.py:821
+#: .\course\models.py:833
 msgid ""
 "A dictionary of the same things that can be added to a flow access rule, "
 "such as allowed_session_count or credit_percent. If not specified here, "
 "values will default to the stipulations in the course content."
 msgstr ""
 
-#: .\course\models.py:827
+#: .\course\models.py:839
 msgid "Stipulations"
 msgstr ""
 
 #. Translators: deprecated
-#: .\course\models.py:837
+#: .\course\models.py:849
 msgid ""
 "Check if a flow started under this exception rule set should stay under this "
 "rule set until it is expired."
 msgstr ""
 
 #. Translators: deprecated
-#: .\course\models.py:841
+#: .\course\models.py:853
 msgid "Is sticky"
 msgstr ""
 
 #. Translators: flow access exception in admin (deprecated)
-#: .\course\models.py:849
+#: .\course\models.py:861
 #, python-format
 msgid "Access exception for '%(user)s' to '%(flow_id)s' in '%(course)s'"
 msgstr ""
 
-#: .\course\models.py:863
+#: .\course\models.py:875
 msgid "Exception"
 msgstr ""
 
-#: .\course\models.py:866
+#: .\course\models.py:878
 msgid "Permission"
 msgstr ""
 
 #. Translators: FlowAccessExceptionEntry (deprecated)
-#: .\course\models.py:870
+#: .\course\models.py:882
 msgid "Flow access exception entries"
 msgstr ""
 
-#: .\course\models.py:896
+#: .\course\models.py:908
 msgid "Kind"
 msgstr ""
 
-#: .\course\models.py:898
+#: .\course\models.py:910
 msgid "Rule"
 msgstr ""
 
-#: .\course\models.py:901
+#: .\course\models.py:913
 msgctxt "Is the flow rule exception activated?"
 msgid "Active"
 msgstr ""
 
 #. Translators: For FlowRuleException
-#: .\course\models.py:906
+#: .\course\models.py:918
 #, python-format
 msgid "%(kind)s exception for '%(user)s' to '%(flow_id)s'in '%(course)s'"
 msgstr ""
 
-#: .\course\models.py:917
+#: .\course\models.py:931
 msgid "grading rules may not expire"
 msgstr ""
 
-#: .\course\models.py:956
+#: .\course\models.py:970
 msgid "invalid rule kind: "
 msgstr ""
 
-#: .\course\models.py:960
+#: .\course\models.py:974
 msgid "invalid existing_session_rules: "
 msgstr ""
 
-#: .\course\models.py:963
+#: .\course\models.py:977
 msgid "Flow rule exception"
 msgstr ""
 
-#: .\course\models.py:964
+#: .\course\models.py:978
 msgid "Flow rule exceptions"
 msgstr ""
 
 #. Translators: format of identifier for GradingOpportunity
-#: .\course\models.py:977
+#: .\course\models.py:991
 msgid "A symbolic name for this grade. lower_case_with_underscores, no spaces."
 msgstr ""
 
-#: .\course\models.py:979
+#: .\course\models.py:993
 msgid "Grading opportunity ID"
 msgstr ""
 
 #. Translators: name for GradingOpportunity
-#: .\course\models.py:982
+#: .\course\models.py:996
 msgid "A human-readable identifier for the grade."
 msgstr ""
 
-#: .\course\models.py:983
+#: .\course\models.py:997
 msgid "Grading opportunity name"
 msgstr ""
 
-#: .\course\models.py:985
+#: .\course\models.py:999
 msgid "Flow identifier that this grading opportunity is linked to, if any"
 msgstr ""
 
 #. Translators: strategy on how the grading of mutiple sessioins
 #. are aggregated.
-#: .\course\models.py:993 .\course\templates\course\gradebook-by-opp.html:36
+#: .\course\models.py:1007 .\course\templates\course\gradebook-by-opp.html:36
 #: .\course\templates\course\gradebook-opp-list.html:27
 msgid "Aggregation strategy"
 msgstr ""
 
-#: .\course\models.py:996 .\course\models.py:1058
-#: .\course\templates\course\gradebook-opp-list.html:28 .\course\views.py:751
+#: .\course\models.py:1010 .\course\models.py:1072
+#: .\course\templates\course\gradebook-opp-list.html:28 .\course\views.py:801
 msgid "Due time"
 msgstr ""
 
-#: .\course\models.py:1001
+#: .\course\models.py:1015
 msgid "Shown in grade book"
 msgstr ""
 
-#: .\course\models.py:1003
+#: .\course\models.py:1017
 msgid "Shown in student grade book"
 msgstr ""
 
-#: .\course\models.py:1006 .\course\models.py:1030
+#: .\course\models.py:1020 .\course\models.py:1044
 msgid "Grading opportunity"
 msgstr ""
 
-#: .\course\models.py:1007
+#: .\course\models.py:1021
 msgid "Grading opportunities"
 msgstr ""
 
 #. Translators: For GradingOpportunity
-#: .\course\models.py:1014
+#: .\course\models.py:1028
 #, python-format
 msgid "%(opportunity_name)s (%(opportunity_id)s) in %(course)s"
 msgstr ""
 
 #. Translators: something like 'status'.
-#: .\course\models.py:1038 .\course\templates\course\flow-start.html:24
+#: .\course\models.py:1052 .\course\templates\course\flow-start.html:24
 #: .\course\templates\course\gradebook-single.html:135
 msgid "State"
 msgstr ""
 
 #. Translators: help text of "attempt_id" in GradeChange class
-#: .\course\models.py:1043
+#: .\course\models.py:1057
 msgid ""
 "Grade changes are grouped by their 'attempt ID' where later grades with the "
 "same attempt ID supersede earlier ones."
 msgstr ""
 
-#: .\course\models.py:1070
+#: .\course\models.py:1084
 msgid "Grade change"
 msgstr ""
 
-#: .\course\models.py:1071
+#: .\course\models.py:1085
 msgid "Grade changes"
 msgstr ""
 
 #. Translators: information for GradeChange
-#: .\course\models.py:1076
+#: .\course\models.py:1090
 #, python-format
 msgid "%(participation)s %(state)s on %(opportunityname)s"
 msgstr ""
 
-#: .\course\models.py:1083
+#: .\course\models.py:1099
 msgid "Participation and opportunity must live in the same course"
 msgstr ""
 
-#: .\course\models.py:1131
+#: .\course\models.py:1147
 msgid "cannot accept grade once opportunity has been marked 'unavailable'"
 msgstr ""
 
-#: .\course\models.py:1135
+#: .\course\models.py:1151
 msgid "cannot accept grade once opportunity has been marked 'exempt'"
 msgstr ""
 
-#: .\course\models.py:1178
+#: .\course\models.py:1194
 #, python-format
 msgid "invalid grade change state '%s'"
 msgstr ""
 
-#: .\course\models.py:1220
+#: .\course\models.py:1236
 #, python-format
 msgid "invalid grade aggregation strategy '%s'"
 msgstr ""
 
 #. Translators: display the name of a flow
-#: .\course\models.py:1274
+#: .\course\models.py:1290
 #, python-format
 msgid "Flow: %(flow_desc_title)s"
 msgstr ""
 
-#: .\course\models.py:1291
+#: .\course\models.py:1307
 msgid "Text"
 msgstr ""
 
-#: .\course\models.py:1293 .\course\templates\course\gradebook-single.html:63
-#: .\course\views.py:226
+#: .\course\models.py:1309 .\course\templates\course\gradebook-single.html:63
+#: .\course\views.py:276
 msgid "Time"
 msgstr ""
 
-#: .\course\models.py:1296
+#: .\course\models.py:1312
 msgid "Instant message"
 msgstr ""
 
-#: .\course\models.py:1297
+#: .\course\models.py:1313
 msgid "Instant messages"
 msgstr ""
 
-#: .\course\page\base.py:80
+#: .\course\page\base.py:101
 msgid "Your answer is not correct."
 msgstr ""
 
-#: .\course\page\base.py:82
+#: .\course\page\base.py:103
 msgid "Your answer is correct."
 msgstr ""
 
-#: .\course\page\base.py:86
+#: .\course\page\base.py:107
 msgid "Your answer is mostly correct."
 msgstr ""
 
-#: .\course\page\base.py:90
+#: .\course\page\base.py:111
 msgid "No information on correctness of answer."
 msgstr ""
 
-#: .\course\page\base.py:94
+#: .\course\page\base.py:115
 msgid "Your answer is somewhat correct."
 msgstr ""
 
-#: .\course\page\base.py:123
+#: .\course\page\base.py:144
 msgid "Invalid correctness value"
 msgstr ""
 
-#: .\course\page\base.py:498
+#: .\course\page\base.py:533
 #, python-format
 msgid ""
 "PageBaseWithTitle subclass '%s' does not implement markdown_body_for_title()"
 msgstr ""
 
-#: .\course\page\base.py:508
+#: .\course\page\base.py:543
 msgid "no title found in body or title attribute"
 msgstr ""
 
-#: .\course\page\base.py:548
+#: .\course\page\base.py:583
 msgid "Whether the grade and feedback below are to be shown to student"
 msgstr ""
 
-#: .\course\page\base.py:550
+#: .\course\page\base.py:585
 msgid "Released"
 msgstr ""
 
-#: .\course\page\base.py:554
+#: .\course\page\base.py:589
 msgid "Grade assigned, in percent"
 msgstr ""
 
-#: .\course\page\base.py:559
+#: .\course\page\base.py:594
 msgid "Grade percent"
 msgstr ""
 
-#: .\course\page\base.py:565
+#: .\course\page\base.py:600
 #, python-format
 msgid ""
 "Grade assigned, as points out of %.1f. Fill out either this or 'grade "
 "percent'."
 msgstr ""
 
-#: .\course\page\base.py:572
+#: .\course\page\base.py:607
 msgid "Grade points"
 msgstr ""
 
-#: .\course\page\base.py:578
+#: .\course\page\base.py:613
 msgid ""
 "Feedback to be shown to student, using <a href='http://documen.tician.de/"
 "relate/content.html#relate-markup'>RELATE-flavored Markdown</a>"
 msgstr ""
 
-#: .\course\page\base.py:582
+#: .\course\page\base.py:617
 msgid "Feedback text"
 msgstr ""
 
-#: .\course\page\base.py:585
+#: .\course\page\base.py:620
 msgid ""
 "Checking this box and submitting the form will notify the participant with a "
 "generic message containing the feedback text"
 msgstr ""
 
-#: .\course\page\base.py:588
+#: .\course\page\base.py:623
 msgid "Notify"
 msgstr ""
 
-#: .\course\page\base.py:591
+#: .\course\page\base.py:626
 msgid "Internal notes, not shown to student"
 msgstr ""
 
-#: .\course\page\base.py:593
+#: .\course\page\base.py:628
 msgid "Notes"
 msgstr ""
 
-#: .\course\page\base.py:606 .\course\page\base.py:620
+#: .\course\page\base.py:641 .\course\page\base.py:655
 msgid "Grade (percent) and Grade (points) disagree"
 msgstr ""
 
-#: .\course\page\base.py:696
+#: .\course\page\base.py:731
 msgid "New notification"
 msgstr ""
 
-#: .\course\page\base.py:726 .\course\page\choice.py:217
-#: .\course\page\choice.py:321 .\course\page\code.py:529
-#: .\course\page\code.py:828 .\course\page\text.py:754
+#: .\course\page\base.py:761 .\course\page\choice.py:223
+#: .\course\page\choice.py:333 .\course\page\code.py:530
+#: .\course\page\code.py:831 .\course\page\inline.py:822
+#: .\course\page\text.py:887
 msgid "No answer provided."
 msgstr ""
 
-#: .\course\page\base.py:742
+#: .\course\page\base.py:777
 msgid "The following feedback was provided"
 msgstr ""
 
@@ -2122,26 +2156,31 @@ msgstr ""
 msgid "Choices"
 msgstr ""
 
-#: .\course\page\choice.py:125 .\course\page\choice.py:433
+#: .\course\page\choice.py:125 .\course\page\choice.py:445
+#: .\course\page\inline.py:427
 #, python-format
 msgid "choice %(idx)d: unable to convert to string"
 msgstr ""
 
-#: .\course\page\choice.py:231
+#: .\course\page\choice.py:140
 #, python-format
-msgid "A correct answer is: %s"
+msgid "one or more correct answer(s) expected, %(n_correct)d found"
 msgstr ""
 
-#: .\course\page\choice.py:365
-#, python-format
-msgid "The correct answer is: %s"
+#: .\course\page\choice.py:237 .\course\page\inline.py:794
+#: .\course\page\text.py:908
+msgid "A correct answer is"
 msgstr ""
 
-#: .\course\page\code.py:609
+#: .\course\page\choice.py:377
+msgid "The correct answer is"
+msgstr ""
+
+#: .\course\page\code.py:610
 msgid "code question execution failed"
 msgstr ""
 
-#: .\course\page\code.py:640
+#: .\course\page\code.py:642
 msgid ""
 "The grading code failed. Sorry about that. The staff has been informed, and "
 "if this problem is due to an issue with the grading code, it will be fixed "
@@ -2149,112 +2188,192 @@ msgid ""
 "help you figure out what went wrong."
 msgstr ""
 
-#: .\course\page\code.py:651
+#: .\course\page\code.py:654
 #, python-format
 msgid ""
 "Your code took too long to execute. The problem specifies that your code may "
 "take at most %s seconds to run. It took longer than that and was aborted."
 msgstr ""
 
-#: .\course\page\code.py:663
+#: .\course\page\code.py:666
 msgid "Your code failed to compile. An error message is below."
 msgstr ""
 
-#: .\course\page\code.py:671
+#: .\course\page\code.py:674
 msgid "Your code failed with an exception. A traceback is below."
 msgstr ""
 
-#: .\course\page\code.py:682
+#: .\course\page\code.py:685
 msgid "Here is some feedback on your code"
 msgstr ""
 
-#: .\course\page\code.py:691
+#: .\course\page\code.py:694
 msgid "This is the exception traceback"
 msgstr ""
 
-#: .\course\page\code.py:698
+#: .\course\page\code.py:701
 msgid "Your code printed the following output"
 msgstr ""
 
-#: .\course\page\code.py:705
+#: .\course\page\code.py:708
 msgid "Your code printed the following error messages"
 msgstr ""
 
-#: .\course\page\code.py:711
+#: .\course\page\code.py:714
 msgid "Your code produced the following plots"
 msgstr ""
 
-#: .\course\page\code.py:720
+#: .\course\page\code.py:723
 msgid "Figure"
 msgstr ""
 
-#: .\course\page\code.py:742
+#: .\course\page\code.py:745
 msgid "The following code is a valid answer"
 msgstr ""
 
-#: .\course\page\code.py:810
+#: .\course\page\code.py:813
 msgid "human_feedback_value greater than overall value of question"
 msgstr ""
 
-#: .\course\page\text.py:143
+#: .\course\page\inline.py:134
+#, python-format
+msgid "unknown embeded question type '%(type)s'"
+msgstr ""
+
+#: .\course\page\inline.py:148
+msgid "must be struct"
+msgstr ""
+
+#: .\course\page\inline.py:239
+#, python-format
+msgid "unrecogonized width attribute string: '%(width_attr)s'"
+msgstr ""
+
+#: .\course\page\inline.py:250
+#, python-format
+msgid ""
+"unsupported length unit '%(length_unit)s', expected length unit can be %"
+"(allowed_length_unit)s"
+msgstr ""
+
+#: .\course\page\inline.py:293 .\course\page\text.py:857
+msgid "at least one answer must be provided"
+msgstr ""
+
+#. Translators: refers to optional
+#. correct answer for checking
+#. correctness sumbitted by students.
+#: .\course\page\inline.py:316
+msgid "answer"
+msgstr ""
+
+#: .\course\page\inline.py:326 .\course\page\text.py:872
+msgid "no matcher is able to provide a plain-text correct answer"
+msgstr ""
+
+#: .\course\page\inline.py:444
+#, python-format
+msgid ""
+"one or more correct answer(s) expected  for question '%(question_name)s', %"
+"(n_correct)d found"
+msgstr ""
+
+#: .\course\page\inline.py:622
+#, python-format
+msgid "invalid answers name %s. "
+msgstr ""
+
+#: .\course\page\inline.py:623 .\course\page\inline.py:641
+msgid ""
+"A valid name should start with letters. Alphanumeric with underscores. Do "
+"not use spaces."
+msgstr ""
+
+#: .\course\page\inline.py:640
+#, python-format
+msgid "invalid embeded question name %s. "
+msgstr ""
+
+#: .\course\page\inline.py:658
+#, python-format
+msgid "embeded question name %s not unique."
+msgstr ""
+
+#: .\course\page\inline.py:669
+#, python-format
+msgid "correct answer(s) not provided for question %s."
+msgstr ""
+
+#: .\course\page\inline.py:677
+#, python-format
+msgid "redundant answers %s provided for non-existing question(s)."
+msgstr ""
+
+#: .\course\page\inline.py:710
+#, python-format
+msgid "have unpaired '%s'."
+msgstr ""
+
+#: .\course\page\text.py:152
 #, python-format
 msgid "page must be of type '%s'"
 msgstr ""
 
-#: .\course\page\text.py:167
+#: .\course\page\text.py:175
 msgid "unknown validator type"
 msgstr ""
 
-#: .\course\page\text.py:177 .\course\page\text.py:489
+#: .\course\page\text.py:185 .\course\page\text.py:576
 msgid "must be struct or string"
 msgstr ""
 
-#: .\course\page\text.py:263
+#: .\course\page\text.py:284
 #, python-format
 msgid "regex '%(pattern)s' did not compile"
 msgstr ""
 
-#: .\course\page\text.py:318
+#: .\course\page\text.py:339
 msgid "unable to check symbolic expression"
 msgstr ""
 
-#: .\course\page\text.py:436
+#: .\course\page\text.py:434 .\course\page\text.py:445
+#: .\course\page\text.py:455
+msgid "does not provide a valid float literal"
+msgstr ""
+
+#: .\course\page\text.py:465
+msgid ""
+"Float match should have either rtol or atol--otherwise it will match any "
+"number"
+msgstr ""
+
+#. Translators: a "matcher" is used to determine
+#. if the answer to text question (blank filling
+#. question) is correct.
+#: .\course\page\text.py:523
 #, python-format
 msgid "%(matcherclassname)s only accepts '%(matchertype)s' patterns"
 msgstr ""
 
-#: .\course\page\text.py:448
+#: .\course\page\text.py:535
 #, python-format
 msgid "unknown match type '%(matchertype)s'"
 msgstr ""
 
-#: .\course\page\text.py:467
+#: .\course\page\text.py:554
 msgid "does not specify match type"
 msgstr ""
 
-#: .\course\page\text.py:475
+#: .\course\page\text.py:562
 msgid "uses deprecated 'matcher:answer' style"
 msgstr ""
 
-#: .\course\page\text.py:496
+#: .\course\page\text.py:583
 msgid "matcher must supply 'type'"
 msgstr ""
 
-#: .\course\page\text.py:547
+#: .\course\page\text.py:634
 msgid "unrecognized widget type"
-msgstr ""
-
-#: .\course\page\text.py:724
-msgid "at least one answer must be provided"
-msgstr ""
-
-#: .\course\page\text.py:739
-msgid "no matcher is able to provide a plain-text correct answer"
-msgstr ""
-
-#: .\course\page\text.py:767
-#, python-format
-msgid "A correct answer is: '%s'."
 msgstr ""
 
 #: .\course\page\upload.py:43
@@ -2288,29 +2407,29 @@ msgstr ""
 msgid "Content"
 msgstr ""
 
-#: .\course\sandbox.py:87
+#: .\course\sandbox.py:84 .\course\sandbox.py:141
+msgid "must be instructor or TA to access sandbox"
+msgstr ""
+
+#: .\course\sandbox.py:93
 msgid ""
 "Enter <a href=\"http://documen.tician.de/relate/content.html#relate-markup"
 "\">RELATE markup</a>."
 msgstr ""
 
-#: .\course\sandbox.py:109
+#: .\course\sandbox.py:115
 msgid "Markup failed to render"
 msgstr ""
 
-#: .\course\sandbox.py:135
-msgid "must be instructor or TA to access sandbox"
-msgstr ""
-
-#: .\course\sandbox.py:158
+#: .\course\sandbox.py:166
 msgid "Enter YAML markup for a flow page."
 msgstr ""
 
-#: .\course\sandbox.py:181
+#: .\course\sandbox.py:196 .\course\sandbox.py:225
 msgid "Page failed to load/validate"
 msgstr ""
 
-#: .\course\sandbox.py:264
+#: .\course\sandbox.py:298
 msgid "Submit answer"
 msgstr ""
 
@@ -2842,15 +2961,15 @@ msgid_plural "%(max_points)s points"
 msgstr[0] ""
 msgstr[1] ""
 
-#: .\course\templates\course\flow-page.html:101
+#: .\course\templates\course\flow-page.html:105
 msgid "(You may still change your answer after you submit it.)"
 msgstr ""
 
-#: .\course\templates\course\flow-page.html:174
+#: .\course\templates\course\flow-page.html:178
 msgid "You have unsaved changes on this page."
 msgstr ""
 
-#: .\course\templates\course\flow-page.html:232
+#: .\course\templates\course\flow-page.html:236
 msgid "Saved."
 msgstr ""
 
@@ -3015,7 +3134,7 @@ msgstr ""
 msgid "for %(last_name)s, %(first_name)s (%(username)s)"
 msgstr ""
 
-#: .\course\templates\course\grade-flow-page.html:86 .\course\views.py:559
+#: .\course\templates\course\grade-flow-page.html:86 .\course\views.py:609
 msgid "Session"
 msgstr ""
 
@@ -3311,7 +3430,7 @@ msgstr ""
 msgid "<a href=\"%(relate-sign_in_by_user_pw)s\">Sign in</a> to get started."
 msgstr ""
 
-#: .\course\templates\course\home.html:41 .\course\versioning.py:241
+#: .\course\templates\course\home.html:41 .\course\versioning.py:248
 msgid "Set up new course"
 msgstr ""
 
@@ -3341,6 +3460,30 @@ msgstr ""
 
 #: .\course\templates\course\invalid-datespec-list.html:37
 msgid "No unrecognized events were found."
+msgstr ""
+
+#: .\course\templates\course\keypair.html:7
+msgid "SSH Key Pair"
+msgstr ""
+
+#: .\course\templates\course\keypair.html:9
+msgid "Private key:"
+msgstr ""
+
+#: .\course\templates\course\keypair.html:10
+msgid ""
+"Copy and paste this block of text into the 'private key' field in RELATE."
+msgstr ""
+
+#: .\course\templates\course\keypair.html:15
+msgid "Public key:"
+msgstr ""
+
+#: .\course\templates\course\keypair.html:16
+msgid ""
+"On Bitbucket, GitHub, or an other repository hosting site, add this snippet "
+"as an \"SSH Key\" to your user profile or as a \"Deployment key\" to your "
+"repository."
 msgstr ""
 
 #: .\course\templates\course\login-by-email.html:7
@@ -3425,7 +3568,11 @@ msgid ""
 "make sure to retain a copy."
 msgstr ""
 
-#: .\course\templates\course\sandbox-page.html:75
+#: .\course\templates\course\sandbox-page.html:39
+msgid "Warnings were encountered when validating the page:"
+msgstr ""
+
+#: .\course\templates\course\sandbox-page.html:87
 msgid "(Page preview appears here)"
 msgstr ""
 
@@ -3465,135 +3612,135 @@ msgstr ""
 msgid "invalid role '%(role)s'"
 msgstr ""
 
-#: .\course\validation.py:113
+#: .\course\validation.py:117
 #, python-format
 msgid "attribute '%(attr)s' missing"
 msgstr ""
 
-#: .\course\validation.py:131
+#: .\course\validation.py:135
 #, python-format
 msgid ""
 "attribute '%(attr)s' has wrong type: got '%(name)s', expected '%(allowed)s'"
 msgstr ""
 
-#: .\course\validation.py:146
+#: .\course\validation.py:150
 #, python-format
 msgid "extraneous attribute(s) '%(attr)s'"
 msgstr ""
 
-#: .\course\validation.py:248
+#: .\course\validation.py:252
 msgid "Uses deprecated 'start' attribute--use 'if_after' instead"
 msgstr ""
 
-#: .\course\validation.py:254
+#: .\course\validation.py:258
 msgid "Uses deprecated 'end' attribute--use 'if_before' instead"
 msgstr ""
 
-#: .\course\validation.py:260
+#: .\course\validation.py:264
 msgid "Uses deprecated 'roles' attribute--use 'if_has_role' instead"
 msgstr ""
 
-#: .\course\validation.py:320
+#: .\course\validation.py:324
 #, python-format
 msgid "chunk id '%(chunkid)s' not unique"
 msgstr ""
 
-#: .\course\validation.py:337
+#: .\course\validation.py:341
 msgid "flow page has no ID"
 msgstr ""
 
-#: .\course\validation.py:355
+#: .\course\validation.py:359
 msgid "could not instantiate flow page"
 msgstr ""
 
-#: .\course\validation.py:391
+#: .\course\validation.py:395
 #, python-format
 msgid "group '%(group_id)s': group is empty"
 msgstr ""
 
-#: .\course\validation.py:398
+#: .\course\validation.py:402
 #, python-format
 msgid "group '%(group_id)s': max_page_count is not positive"
 msgstr ""
 
-#: .\course\validation.py:411
+#: .\course\validation.py:415
 #, python-format
 msgid "page id '%(page_desc_id)s' not unique"
 msgstr ""
 
-#: .\course\validation.py:460
+#: .\course\validation.py:464
 msgid "attribute 'may_start_new_session' is not present"
 msgstr ""
 
-#: .\course\validation.py:464
+#: .\course\validation.py:468
 msgid "attribute 'may_list_existing_sessions' is not present"
 msgstr ""
 
-#: .\course\validation.py:475 .\course\validation.py:515
-#: .\course\validation.py:576
+#: .\course\validation.py:480 .\course\validation.py:520
+#: .\course\validation.py:581
 #, python-format
 msgid "invalid tag '%(tag)s'"
 msgstr ""
 
-#: .\course\validation.py:524
+#: .\course\validation.py:529
 #, python-format
 msgid "invalid expiration mode '%(expiremode)s'"
 msgstr ""
 
-#: .\course\validation.py:589
+#: .\course\validation.py:594
 #, python-format
 msgid ""
 "grading rule that have a grade identifier (%(type)s: %(identifier)s) must "
 "have a grade_aggregation_strategy"
 msgstr ""
 
-#: .\course\validation.py:601
+#: .\course\validation.py:606
 msgid "invalid grade aggregation strategy"
 msgstr ""
 
-#: .\course\validation.py:662
+#: .\course\validation.py:667
 msgid "rules/grading: last grading rule must be unconditional"
 msgstr ""
 
-#: .\course\validation.py:672
+#: .\course\validation.py:677
 msgid ""
 "Uses deprecated 'modify' permission--replace by 'submit_answer' and "
 "'end_session'"
 msgstr ""
 
-#: .\course\validation.py:678
+#: .\course\validation.py:683
 msgid ""
 "Uses deprecated 'see_answer' permission--replace by "
 "'see_answer_after_submission'"
 msgstr ""
 
-#: .\course\validation.py:685
+#: .\course\validation.py:690
 #, python-format
 msgid "invalid flow permission '%(permission)s'"
 msgstr ""
 
-#: .\course\validation.py:724
+#: .\course\validation.py:729
 #, python-format
 msgid "group %(group_index)d ('%(group_id)d'): no pages found"
 msgstr ""
 
-#: .\course\validation.py:732
+#: .\course\validation.py:737
 #, python-format
 msgid "%s: no pages found"
 msgstr ""
 
-#: .\course\validation.py:745
+#: .\course\validation.py:750
 #, python-format
 msgid "group id '%(group_id)s' not unique"
 msgstr ""
 
-#: .\course\validation.py:840
+#: .\course\validation.py:883
 msgid ""
 "invalid flow name. Flow names may only contain (roman) letters, numbers, "
 "dashes and underscores."
 msgstr ""
 
-#: .\course\validation.py:935
+#: .\course\validation.py:983
 msgid "WARNINGS: "
 msgstr ""
 
@@ -3605,236 +3752,236 @@ msgstr ""
 msgid "only staff may create courses"
 msgstr ""
 
-#: .\course\versioning.py:190
+#: .\course\versioning.py:197
 msgid "Course content validated, creation succeeded."
 msgstr ""
 
-#: .\course\versioning.py:216
+#: .\course\versioning.py:223
 #, python-format
 msgid "Failed to delete unused repository directory '%s'."
 msgstr ""
 
-#: .\course\versioning.py:228
+#: .\course\versioning.py:235
 msgid "Course creation failed"
 msgstr ""
 
-#: .\course\versioning.py:276
+#: .\course\versioning.py:282
 msgid "no git source URL specified"
 msgstr ""
 
-#: .\course\versioning.py:285
+#: .\course\versioning.py:291
 msgid "fetch would discard commits, refusing"
 msgstr ""
 
-#: .\course\versioning.py:289
+#: .\course\versioning.py:295
 msgid "Fetch successful."
 msgstr ""
 
-#: .\course\versioning.py:295
+#: .\course\versioning.py:301
 msgid "Preview ended."
 msgstr ""
 
-#: .\course\versioning.py:310
+#: .\course\versioning.py:316
 #, python-format
 msgid "Course content did not validate successfully. (%s) Update not applied."
 msgstr ""
 
-#: .\course\versioning.py:317
+#: .\course\versioning.py:323
 msgid "Course content validated successfully."
 msgstr ""
 
-#: .\course\versioning.py:321
+#: .\course\versioning.py:327
 msgid "Course content validated OK, with warnings: "
 msgstr ""
 
-#: .\course\versioning.py:332
+#: .\course\versioning.py:338
 msgid "Preview activated."
 msgstr ""
 
-#: .\course\versioning.py:343
+#: .\course\versioning.py:349
 msgid "Update applied. "
 msgstr ""
 
-#: .\course\versioning.py:346 .\course\versioning.py:412 .\course\views.py:649
+#: .\course\versioning.py:352 .\course\versioning.py:425 .\course\views.py:699
 msgid "invalid command"
 msgstr ""
 
-#: .\course\versioning.py:353
+#: .\course\versioning.py:359
 msgctxt "new git SHA for revision of course contents"
 msgid "New git SHA"
 msgstr ""
 
-#: .\course\versioning.py:369
+#: .\course\versioning.py:375
 msgid "Fetch and update"
 msgstr ""
 
-#: .\course\versioning.py:373
+#: .\course\versioning.py:379
 msgid "End preview"
 msgstr ""
 
-#: .\course\versioning.py:375
+#: .\course\versioning.py:381
 msgid "Fetch and preview"
 msgstr ""
 
-#: .\course\versioning.py:387
+#: .\course\versioning.py:393
 msgid "must be instructor or TA to update course"
 msgstr ""
 
-#: .\course\versioning.py:439
+#: .\course\versioning.py:453
 msgid "Current git HEAD"
 msgstr ""
 
-#: .\course\versioning.py:446
+#: .\course\versioning.py:460
 msgid "Public active git SHA"
 msgstr ""
 
-#: .\course\versioning.py:459 .\course\versioning.py:471
+#: .\course\versioning.py:473 .\course\versioning.py:485
 msgid "Current preview git SHA"
 msgstr ""
 
-#: .\course\versioning.py:473
+#: .\course\versioning.py:487
 msgid "None"
 msgstr ""
 
-#: .\course\versioning.py:481
+#: .\course\versioning.py:495
 msgid "Update Course Revision"
 msgstr ""
 
-#: .\course\views.py:123
+#: .\course\views.py:124
 msgid "only course staff have access"
 msgstr ""
 
-#: .\course\views.py:126
+#: .\course\views.py:127
 msgid "only the instructor has access"
 msgstr ""
 
-#: .\course\views.py:148
+#: .\course\views.py:149
 msgid ""
 "Your enrollment request is pending. You will be notified once it has been "
 "acted upon."
 msgstr ""
 
 #. Translators: "set" fake time.
-#: .\course\views.py:233
+#: .\course\views.py:283
 msgid "Set"
 msgstr ""
 
 #. Translators: "unset" fake time.
-#: .\course\views.py:236
+#: .\course\views.py:286
 msgid "Unset"
 msgstr ""
 
-#: .\course\views.py:264
+#: .\course\views.py:314
 msgid "only staff may set fake time"
 msgstr ""
 
-#: .\course\views.py:288 .\relate\templates\base.html:80
+#: .\course\views.py:338 .\relate\templates\base.html:80
 msgid "Set fake time"
 msgstr ""
 
-#: .\course\views.py:313
+#: .\course\views.py:363
 msgctxt "Duration for instant flow"
 msgid "Duration in minutes"
 msgstr ""
 
-#: .\course\views.py:318
+#: .\course\views.py:368
 msgctxt "Add an instant flow"
 msgid "Add"
 msgstr ""
 
-#: .\course\views.py:323
+#: .\course\views.py:373
 msgctxt "Cancel all instant flow(s)"
 msgid "Cancel all"
 msgstr ""
 
-#: .\course\views.py:330
+#: .\course\views.py:380
 msgid "must be instructor to manage instant flow requests"
 msgstr ""
 
-#: .\course\views.py:377
+#: .\course\views.py:427
 msgid "Manage Instant Flow Requests"
 msgstr ""
 
-#: .\course\views.py:399
+#: .\course\views.py:449
 msgctxt "Start an activity"
 msgid "Go"
 msgstr ""
 
-#: .\course\views.py:409
+#: .\course\views.py:459
 msgid "must be instructor or TA to test flows"
 msgstr ""
 
-#: .\course\views.py:430
+#: .\course\views.py:480
 msgid "Test Flow"
 msgstr ""
 
-#: .\course\views.py:462
+#: .\course\views.py:512
 msgid "Select participant for whom exception is to be granted."
 msgstr ""
 
-#: .\course\views.py:475 .\course\views.py:566
+#: .\course\views.py:525 .\course\views.py:616
 msgctxt "Next step"
 msgid "Next"
 msgstr ""
 
-#: .\course\views.py:486 .\course\views.py:577 .\course\views.py:789
+#: .\course\views.py:536 .\course\views.py:627 .\course\views.py:839
 msgid "must be instructor or TA to grant exceptions"
 msgstr ""
 
-#: .\course\views.py:506 .\course\views.py:684 .\course\views.py:956
+#: .\course\views.py:556 .\course\views.py:734 .\course\views.py:1006
 msgid "Grant Exception"
 msgstr ""
 
 #. Translators: %s is the string of the start time of a session.
-#: .\course\views.py:513
+#: .\course\views.py:563
 #, python-format
 msgid "started at %s"
 msgstr ""
 
-#: .\course\views.py:530
+#: .\course\views.py:580
 msgid ""
 "If you click 'Create session', this tag will be applied to the new session."
 msgstr ""
 
-#: .\course\views.py:532
+#: .\course\views.py:582
 msgid "Access rules tag for new session"
 msgstr ""
 
-#: .\course\views.py:538
+#: .\course\views.py:588
 msgid "Create session (override rules)"
 msgstr ""
 
-#: .\course\views.py:544
+#: .\course\views.py:594
 msgid "Create session"
 msgstr ""
 
-#: .\course\views.py:556
+#: .\course\views.py:606
 msgid ""
 "The rules that currently apply to selected session will provide the default "
 "values for the rules on the next page."
 msgstr ""
 
-#: .\course\views.py:586
+#: .\course\views.py:636
 #, python-format
 msgid "Granting exception to '%(participation)s' for '%(flow_id)s'."
 msgstr ""
 
-#: .\course\views.py:607 .\course\views.py:611
+#: .\course\views.py:657 .\course\views.py:661
 msgid "NONE"
 msgstr ""
 
-#: .\course\views.py:621
+#: .\course\views.py:671
 msgid ""
 "Creating a new session is (technically) not allowed by course rules. "
 "Clicking 'Create Session' anyway will override this rule."
 msgstr ""
 
-#: .\course\views.py:694
+#: .\course\views.py:744
 msgctxt "Time when access expires"
 msgid "Access expires"
 msgstr ""
 
-#: .\course\views.py:695
+#: .\course\views.py:745
 msgid ""
 "At the specified time, the special access granted below will expire and "
 "revert to being the same as for the rest of the class. This field may be "
@@ -3843,59 +3990,63 @@ msgid ""
 "remain valid indefinitely, unless overridden by another exception."
 msgstr ""
 
-#: .\course\views.py:720
+#: .\course\views.py:770
 msgid "Exception only applies to sessions with the above tag"
 msgstr ""
 
-#: .\course\views.py:739
+#: .\course\views.py:789
 msgid "If set, the 'Due' field will be disregarded."
 msgstr ""
 
-#: .\course\views.py:742
+#: .\course\views.py:792
 msgid "Due same as access expiration"
 msgstr ""
 
-#: .\course\views.py:747
+#: .\course\views.py:797
 msgid ""
 "The due time shown to the student. Also, the time after which any session "
 "under these rules is subject to expiration."
 msgstr ""
 
-#: .\course\views.py:755
+#: .\course\views.py:805
 msgid "Credit percent"
 msgstr ""
 
-#: .\course\views.py:768
+#: .\course\views.py:818
 msgid "Save"
 msgstr ""
 
-#: .\course\views.py:778
+#: .\course\views.py:828
 msgid ""
 "Must specify access expiration if 'due same as access expiration' is set."
 msgstr ""
 
-#: .\course\views.py:850 .\course\views.py:917
+#: .\course\views.py:900 .\course\views.py:967
 msgid "newly created exception"
 msgstr ""
 
-#: .\course\views.py:879
+#: .\course\views.py:929
 msgid "Granted excecption"
 msgstr ""
 
-#: .\course\views.py:881
+#: .\course\views.py:931
 msgid "credit"
 msgstr ""
 
-#: .\course\views.py:933
+#: .\course\views.py:983
 #, python-format
 msgid "Exception granted to '%(participation)s' for '%(flow_id)s'."
 msgstr ""
 
-#: .\course\views.py:959
+#: .\course\views.py:1009
 #, python-format
 msgid ""
 "Granting exception to '%(participation)s' for '%(flow_id)s' (session %"
 "(session)s)."
+msgstr ""
+
+#: .\course\views.py:1026
+msgid "only staff may use this tool"
 msgstr ""
 
 #: .\relate\templates\403.html:5

--- a/locale/zh_CN/LC_MESSAGES/django.po
+++ b/locale/zh_CN/LC_MESSAGES/django.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-08-08 16:21+0800\n"
+"POT-Creation-Date: 2015-08-25 16:12+0800\n"
 "Last-Translator:  Dong Zhuang <dzhuang.scut@gmail.com>\n"
 "Language-Team: Dong Zhuang <dzhuang.scut@gmail.com>\n"
 "MIME-Version: 1.0\n"
@@ -17,55 +17,56 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: \n"
 
-#: .\course\admin.py:104 .\course\admin.py:278
+#: .\course\admin.py:104 .\course\admin.py:280
 msgid "First name"
 msgstr "名"
 
-#: .\course\admin.py:110 .\course\admin.py:284
+#: .\course\admin.py:110 .\course\admin.py:286
 msgid "Last name"
 msgstr "姓"
 
-#: .\course\admin.py:268
+#: .\course\admin.py:270
 msgid "Tags must belong to same course as participation."
 msgstr "Tags必须与同一课程中的participation一致. "
 
-#: .\course\admin.py:387 .\course\admin.py:505 .\course\admin.py:589
-#: .\course\admin.py:702 .\course\admin.py:776
-#: .\course\templates\course\gradebook-single.html:17 .\course\views.py:464
+#: .\course\admin.py:389 .\course\admin.py:507 .\course\admin.py:591
+#: .\course\admin.py:704 .\course\admin.py:778
+#: .\course\templates\course\gradebook-single.html:17 .\course\views.py:514
 msgid "Participant"
 msgstr "参与者"
 
-#: .\course\admin.py:482 .\course\admin.py:584 .\course\admin.py:692
-#: .\course\admin.py:771 .\course\models.py:259
+#: .\course\admin.py:484 .\course\admin.py:586 .\course\admin.py:694
+#: .\course\admin.py:773 .\course\models.py:269
 msgid "Course"
 msgstr "课程"
 
-#: .\course\admin.py:487 .\course\flow.py:1400 .\course\models.py:427
-#: .\course\models.py:454 .\course\models.py:814 .\course\models.py:880
-#: .\course\models.py:987 .\course\templates\course\gradebook-opp-list.html:26
-#: .\course\templates\course\gradebook-single.html:134 .\course\views.py:309
-#: .\course\views.py:392 .\course\views.py:468
+#: .\course\admin.py:489 .\course\flow.py:1439 .\course\models.py:439
+#: .\course\models.py:466 .\course\models.py:826 .\course\models.py:892
+#: .\course\models.py:1001
+#: .\course\templates\course\gradebook-opp-list.html:26
+#: .\course\templates\course\gradebook-single.html:134 .\course\views.py:359
+#: .\course\views.py:442 .\course\views.py:518
 msgid "Flow ID"
 msgstr ""
 
-#: .\course\admin.py:496 .\course\models.py:550
+#: .\course\admin.py:498 .\course\models.py:562
 #: .\course\templates\course\gradebook-single.html:216
 msgid "Page ID"
 msgstr ""
 
-#: .\course\admin.py:503
+#: .\course\admin.py:505
 msgid "anonymous"
 msgstr "匿名"
 
-#: .\course\admin.py:510
+#: .\course\admin.py:512
 msgid "Has answer"
 msgstr "已经回答"
 
-#: .\course\admin.py:515
+#: .\course\admin.py:517
 msgid "Flow Session ID"
 msgstr ""
 
-#: .\course\admin.py:697
+#: .\course\admin.py:699
 msgid "Opportunity"
 msgstr "机会"
 
@@ -104,91 +105,105 @@ msgstr "分钟"
 msgid "Course module"
 msgstr "课程模块"
 
-#: .\course\auth.py:112
+#: .\course\auth.py:113
 msgid "Error while impersonating."
 msgstr "虚拟用户时出现错误. "
 
-#. Translators: information displayed when selecting user
-#. for impersonating. Customize how the name is shown, but
-#. leave email first to retain usability of form sorted by
-#. last name.
-#: .\course\auth.py:128 .\course\views.py:442
+#. Translators: information displayed when selecting
+#. userfor impersonating. Customize how the name is
+#. shown, but leave email first to retain usability
+#. of form sorted by last name.
+#: .\course\auth.py:129 .\course\views.py:492
 #, python-format
 msgid "%(user_email)s - %(user_lastname)s, %(user_firstname)s"
 msgstr "%(user_lastname)s%(user_firstname)s(%(user_email)s)"
 
-#: .\course\auth.py:139
+#: .\course\auth.py:140
 msgid "Select user to impersonate."
 msgstr "选择您想模拟的用户. "
 
-#: .\course\auth.py:140 .\course\templates\course\grade-import-preview.html:18
+#: .\course\auth.py:141 .\course\templates\course\grade-import-preview.html:18
 msgid "User"
 msgstr "用户"
 
-#: .\course\auth.py:142
+#: .\course\auth.py:143
 msgid "Impersonate"
 msgstr "用户模拟"
 
-#: .\course\auth.py:150
+#: .\course\auth.py:151
 msgid "Already impersonating someone."
 msgstr "已经模拟了某个用户. "
 
-#: .\course\auth.py:159
+#: .\course\auth.py:160
 #, python-format
 msgid "Now impersonating '%s'."
 msgstr "正在模拟用户\"%s\". "
 
-#: .\course\auth.py:168 .\relate\templates\base.html:78
+#: .\course\auth.py:169 .\relate\templates\base.html:78
 msgid "Impersonate user"
 msgstr "用户模拟"
 
-#: .\course\auth.py:178 .\relate\templates\base.html:76
+#: .\course\auth.py:179 .\relate\templates\base.html:76
 msgid "Stop impersonating"
 msgstr "停止模拟用户"
 
-#: .\course\auth.py:184
+#: .\course\auth.py:185
 msgid "Not currently impersonating anyone."
 msgstr "当前未模拟任何用户. "
 
-#: .\course\auth.py:191
+#: .\course\auth.py:192
 msgid "No longer impersonating anyone."
 msgstr "未模拟任何用户. "
 
-#: .\course\auth.py:200
+#: .\course\auth.py:201
 msgid "Stop impersonating user"
 msgstr "停止模拟用户"
 
-#: .\course\auth.py:272 .\course\templates\course\course-page.html:38
+#: .\course\auth.py:273 .\course\templates\course\course-page.html:38
 #: .\course\templates\course\flow-start.html:186
 #: .\course\templates\course\login.html:7 .\relate\templates\403.html:14
 #: .\relate\templates\base.html:104
 msgid "Sign in"
 msgstr "登录"
 
-#: .\course\auth.py:286
+#: .\course\auth.py:287
 msgid "Username"
 msgstr "用户名"
 
-#: .\course\auth.py:296 .\course\auth.py:381
+#: .\course\auth.py:288
+msgid "Required. 30 characters or fewer. Letters, digits and @/./+/-/_ only."
+msgstr ""
+
+#: .\course\auth.py:293
+msgid "Enter a valid username."
+msgstr ""
+
+#: .\course\auth.py:294
+msgid ""
+"Enter a valid username. This value may contain only letters, numbers and @/./"
+msgstr ""
+
+#: .\course\auth.py:308 .\course\auth.py:393
 msgid "Send email"
 msgstr "发送邮件"
 
-#: .\course\auth.py:303 .\course\auth.py:387
+#: .\course\auth.py:315 .\course\auth.py:399
 msgid "password-based sign-in is not being used"
 msgstr "用户名密码模式未启用"
 
-#: .\course\auth.py:313
-msgid "That user name is already taken."
-msgstr "该用户名已经被使用. "
+#: .\course\auth.py:325
+msgid "A user with that username already exists."
+msgstr ""
 
-#: .\course\auth.py:318
+#: .\course\auth.py:330
 #, python-format
 msgid ""
 "That email address is already in use. Would you like to <a href='%s'>reset "
 "your password</a> instead?"
 msgstr "该电子邮件已经注册, 您是否需要 <a href='%s'>重置密码</a> ？"
 
-#: .\course\auth.py:353 .\course\auth.py:420 .\course\auth.py:565
+#: .\course\auth.py:365 .\course\auth.py:434 .\course\auth.py:450
+#: .\course\auth.py:523 .\course\auth.py:582
 #: .\course\templates\course\analytics-flow.html:5
 #: .\course\templates\course\analytics-flows.html:5
 #: .\course\templates\course\analytics-page.html:5
@@ -217,93 +232,96 @@ msgstr "该电子邮件已经注册, 您是否需要 <a href='%s'>重置密码</
 msgid "RELATE"
 msgstr "RELATE"
 
-#: .\course\auth.py:354
+#: .\course\auth.py:366
 msgid "Verify your email"
 msgstr "验证您的电子邮件"
 
-#: .\course\auth.py:360 .\course\auth.py:427 .\course\auth.py:571
+#: .\course\auth.py:372 .\course\auth.py:441 .\course\auth.py:588
 msgid "Email sent. Please check your email and click the link."
 msgstr "Email已发送, 请进入邮箱并点击相关的链接. "
 
-#: .\course\auth.py:369
+#: .\course\auth.py:381
 msgid "Sign up"
 msgstr "注册"
 
-#: .\course\auth.py:375 .\course\auth.py:516 .\course\models.py:396
+#: .\course\auth.py:387 .\course\auth.py:533 .\course\models.py:408
 msgid "Email"
 msgstr "Email"
 
-#: .\course\auth.py:402
-msgid "Email address is not known."
-msgstr "Email未知. "
+#: .\course\auth.py:414
+msgid ""
+"That email address doesn't have an associated user account. Are you sure "
+"you've registered?"
+msgstr ""
 
-#: .\course\auth.py:421
+#: .\course\auth.py:435
 msgid "Password reset"
 msgstr "密码重置"
 
-#: .\course\auth.py:435 .\course\auth.py:506
-msgid "Reset Password"
-msgstr "重置密码"
+#: .\course\auth.py:449 .\course\auth.py:522
+#, python-format
+msgid "Password reset on %(site_name)s"
+msgstr ""
 
-#: .\course\auth.py:442
+#: .\course\auth.py:457
 msgid "Password"
 msgstr "密码"
 
-#: .\course\auth.py:444
-msgid "Password repeat"
-msgstr "再次输入密码"
+#: .\course\auth.py:459
+msgid "Password confirmation"
+msgstr ""
 
-#: .\course\auth.py:450 .\course\auth.py:629 .\course\auth.py:642
+#: .\course\auth.py:465 .\course\auth.py:646 .\course\auth.py:659
 #: .\course\templates\course\course-page.html:30
-#: .\course\templates\course\home.html:22 .\course\versioning.py:370
+#: .\course\templates\course\home.html:22 .\course\versioning.py:376
 msgid "Update"
 msgstr "更新"
 
-#: .\course\auth.py:458
-msgid "Passwords do not match"
-msgstr "密码不匹配"
+#: .\course\auth.py:474
+msgid "The two password fields didn't match."
+msgstr ""
 
-#: .\course\auth.py:463 .\course\auth.py:528 .\course\auth.py:585
+#: .\course\auth.py:479 .\course\auth.py:545 .\course\auth.py:602
 msgid "email-based sign-in is not being used"
 msgstr "基于邮件链接登录的方式未启用"
 
-#: .\course\auth.py:467 .\course\auth.py:591
+#: .\course\auth.py:483 .\course\auth.py:608
 msgid "Invalid sign-in token. Perhaps you've used an old token email?"
 msgstr "登录链接无效, 您可能使用了一个旧邮件中的链接？"
 
-#: .\course\auth.py:469 .\course\auth.py:477 .\course\auth.py:482
-#: .\course\auth.py:593 .\course\auth.py:598
+#: .\course\auth.py:485 .\course\auth.py:493 .\course\auth.py:498
+#: .\course\auth.py:610 .\course\auth.py:615
 msgid "invalid sign-in token"
 msgstr "登录链接无效"
 
-#: .\course\auth.py:481 .\course\auth.py:597
+#: .\course\auth.py:497 .\course\auth.py:614
 msgid "Account disabled."
 msgstr "帐户已禁用. "
 
-#: .\course\auth.py:492 .\course\auth.py:604
+#: .\course\auth.py:508 .\course\auth.py:621
 msgid ""
 "Successfully signed in. Please complete your registration information below."
 msgstr "成功登录, 请在下面完善您的注册信息. "
 
-#: .\course\auth.py:499 .\course\auth.py:611
+#: .\course\auth.py:515 .\course\auth.py:628
 msgid "Successfully signed in."
 msgstr "成功登录. "
 
-#: .\course\auth.py:522
+#: .\course\auth.py:539
 msgid "Send sign-in email"
 msgstr "发送登录邮件"
 
-#: .\course\auth.py:565
+#: .\course\auth.py:582
 #, python-format
 msgid "Your %(RELATE)s sign-in link"
 msgstr "您的%(RELATE)s登录链接"
 
-#: .\course\auth.py:663 .\course\auth.py:673
+#: .\course\auth.py:680 .\course\auth.py:690
 msgid "Profile data saved."
 msgstr "用户信息已更新. "
 
 #. Translators: format of event kind in Event model
-#: .\course\calendar.py:48 .\course\calendar.py:190 .\course\models.py:282
+#: .\course\calendar.py:48 .\course\calendar.py:190 .\course\models.py:292
 msgid "Should be lower_case_with_underscores, no spaces allowed."
 msgstr "只允许小写字母和下划线, 不允许有空格. "
 
@@ -455,151 +473,151 @@ msgstr "保持session并应用新的规则"
 msgid "unknown expiration mode"
 msgstr "未知的过期模式"
 
-#: .\course\constants.py:172
+#: .\course\constants.py:195
 msgctxt "Flow permission"
 msgid "View the flow"
 msgstr "查看flow"
 
-#: .\course\constants.py:174
+#: .\course\constants.py:197
 msgctxt "Flow permission"
 msgid "Submit answers"
 msgstr "提交回答"
 
-#: .\course\constants.py:176
+#: .\course\constants.py:199
 msgctxt "Flow permission"
 msgid "End session"
 msgstr "结束session"
 
-#: .\course\constants.py:178
+#: .\course\constants.py:201
 msgctxt "Flow permission"
 msgid "Change already-graded answer"
 msgstr "修改已经评分的回答"
 
-#: .\course\constants.py:181
+#: .\course\constants.py:204
 msgctxt "Flow permission"
 msgid "See whether an answer is correct"
 msgstr "查看答案是否正确"
 
-#: .\course\constants.py:184
+#: .\course\constants.py:207
 msgctxt "Flow permission"
 msgid "See the correct answer before answering"
 msgstr "在回答前查看正确的答案"
 
-#: .\course\constants.py:187
+#: .\course\constants.py:210
 msgctxt "Flow permission"
 msgid "See the correct answer after answering"
 msgstr "在回答后查看正确的答案"
 
-#: .\course\constants.py:190
+#: .\course\constants.py:213
 msgctxt "Flow permission"
 msgid "Set the session to 'roll over' expiration mode"
 msgstr "将这个session设为“展期”的过期模式"
 
-#: .\course\constants.py:202
+#: .\course\constants.py:225
 msgctxt "Flow rule kind choices"
 msgid "Session Start"
 msgstr "session开始"
 
-#: .\course\constants.py:204
+#: .\course\constants.py:227
 msgctxt "Flow rule kind choices"
 msgid "Session Access"
 msgstr "session访问"
 
-#: .\course\constants.py:206
+#: .\course\constants.py:229
 msgctxt "Flow rule kind choices"
 msgid "Grading"
 msgstr "评分"
 
-#: .\course\constants.py:244
+#: .\course\constants.py:267
 msgctxt "Grade aggregation strategy"
 msgid "Use the max grade"
 msgstr "使用最高分"
 
-#: .\course\constants.py:246
+#: .\course\constants.py:269
 msgctxt "Grade aggregation strategy"
 msgid "Use the avg grade"
 msgstr "使用平均分"
 
-#: .\course\constants.py:248
+#: .\course\constants.py:271
 msgctxt "Grade aggregation strategy"
 msgid "Use the min grade"
 msgstr "使用最低分"
 
-#: .\course\constants.py:250
+#: .\course\constants.py:273
 msgctxt "Grade aggregation strategy"
 msgid "Use the earliest grade"
 msgstr "使用最早的得分"
 
-#: .\course\constants.py:252
+#: .\course\constants.py:275
 msgctxt "Grade aggregation strategy"
 msgid "Use the latest grade"
 msgstr "使用最迟的得分"
 
-#: .\course\constants.py:269
+#: .\course\constants.py:292
 msgctxt "Grade state change"
 msgid "Grading started"
 msgstr "评分已经开始"
 
-#: .\course\constants.py:271
+#: .\course\constants.py:294
 msgctxt "Grade state change"
 msgid "Graded"
 msgstr "已评分"
 
-#: .\course\constants.py:273
+#: .\course\constants.py:296
 msgctxt "Grade state change"
 msgid "Retrieved"
 msgstr "已获取"
 
-#: .\course\constants.py:275
+#: .\course\constants.py:298
 msgctxt "Grade state change"
 msgid "Unavailable"
 msgstr "无法获取"
 
-#: .\course\constants.py:277
+#: .\course\constants.py:300
 msgctxt "Grade state change"
 msgid "Extension"
 msgstr "延期"
 
-#: .\course\constants.py:279
+#: .\course\constants.py:302
 msgctxt "Grade state change"
 msgid "Report sent"
 msgstr "报告已发送"
 
-#: .\course\constants.py:281
+#: .\course\constants.py:304
 msgctxt "Grade state change"
 msgid "Do-over"
 msgstr "重新开始"
 
-#: .\course\constants.py:283
+#: .\course\constants.py:306
 msgctxt "Grade state change"
 msgid "Exempt"
 msgstr "剔除"
 
-#: .\course\content.py:75
+#: .\course\content.py:104
 #, python-format
 msgid "resource '%s' not found"
 msgstr "未找到资源\"%s\""
 
-#: .\course\content.py:251
+#: .\course\content.py:280
 msgid "I have no idea what a processing instruction is."
 msgstr "我也不知道处理的指令是什么"
 
-#: .\course\content.py:526
+#: .\course\content.py:571
 #, python-format
 msgid "invalid period: %s"
 msgstr "无效的周期：%s"
 
-#: .\course\content.py:613 .\course\content.py:638
+#: .\course\content.py:658 .\course\content.py:683
 #, python-format
 msgid "unrecognized date/time specification: '%s' (interpreted as 'now')"
 msgstr "无法识别的日期/时间设定: '%s' (被解释为\"现在\")"
 
-#: .\course\content.py:728
+#: .\course\content.py:773
 #, python-format
 msgid "page '%(group_id)s/%(page_id)s' in flow '%(flow_id)s'"
 msgstr "page \"%(group_id)s/%(page_id)s\" (在flow \"%(flow_id)s\"中)"
 
-#: .\course\content.py:781
+#: .\course\content.py:826
 #, python-format
 msgid "repo page class must conist of two dotted components (invalid: '%s')"
 msgstr "repo类型的page必须包括两个dotted组件 (无效: \"%s\")"
@@ -659,7 +677,7 @@ msgstr "批准加入"
 msgid "Deny enrollment"
 msgstr "拒绝加入"
 
-#: .\course\enrollment.py:220 .\course\models.py:401
+#: .\course\enrollment.py:220 .\course\models.py:413
 #: .\course\templates\course\gradebook-participant-list.html:27
 msgid "Role"
 msgstr "在课程中的角色"
@@ -693,7 +711,7 @@ msgstr "用户加入课程预批准"
 msgid "cannot grade ungraded answer"
 msgstr "无法为未评分的回答进行评分"
 
-#: .\course\flow.py:463 .\course\flow.py:1331
+#: .\course\flow.py:463 .\course\flow.py:1370
 msgid "Can't end a session that's already ended"
 msgstr "无法结束已经结束的session"
 
@@ -757,77 +775,81 @@ msgstr "无法识别的POST操作"
 msgid "may not view other people's sessions"
 msgstr "不允许查看其他人的session"
 
-#: .\course\flow.py:895
+#: .\course\flow.py:932
 msgid "Save answer"
 msgstr "保存回答"
 
-#: .\course\flow.py:902
+#: .\course\flow.py:939
 msgid "Submit answer for grading"
 msgstr "提交用于评分的回答"
 
-#: .\course\flow.py:906
+#: .\course\flow.py:943
 msgid "Submit final answer"
 msgstr "提交最终回答"
 
-#: .\course\flow.py:915
+#: .\course\flow.py:952
 msgid "Save answer and move on"
 msgstr "保存回答并继续"
 
-#: .\course\flow.py:923
+#: .\course\flow.py:960
 msgid "Save answer and finish"
 msgstr "保存回答并结束"
 
-#: .\course\flow.py:936
+#: .\course\flow.py:973
 msgid "could not find which button was pressed"
 msgstr "无法找到哪一个按钮被按下"
 
-#: .\course\flow.py:960
+#: .\course\flow.py:997
 msgid ""
 "No in-progress session record found for this flow. Redirected to flow start "
 "page."
 msgstr "本flow没有找到正在进行中的session, 跳转到flow的起始页面. "
 
-#: .\course\flow.py:992
+#: .\course\flow.py:1029
 msgid "not allowed to view flow"
 msgstr "不允许查看该flow"
 
-#: .\course\flow.py:1004
+#: .\course\flow.py:1041
 msgid "Answer submission not allowed."
 msgstr "不允许提交回答. "
 
-#: .\course\flow.py:1013
+#: .\course\flow.py:1050
 msgid "Already have final answer."
 msgstr "已经有最终的回答. "
 
-#: .\course\flow.py:1026
+#: .\course\flow.py:1070
 msgid "Answer saved."
-msgstr "回答已保存. "
+msgstr "回答保存成功. "
 
-#: .\course\flow.py:1242
+#: .\course\flow.py:1154
+msgid "Failed to submit answer."
+msgstr "回答提交失败."
+
+#: .\course\flow.py:1281
 msgid "only POST allowed"
 msgstr "只允许POST操作"
 
-#: .\course\flow.py:1248
+#: .\course\flow.py:1287
 msgid "may only change your own flow sessions"
 msgstr "只允许更改您自己的flow session"
 
-#: .\course\flow.py:1251
+#: .\course\flow.py:1290
 msgid "may only change in-progress flow sessions"
 msgstr "只能更改正在进行中的session"
 
-#: .\course\flow.py:1256
+#: .\course\flow.py:1295
 msgid "invalid expiration mode"
 msgstr "无效的过期模式"
 
-#: .\course\flow.py:1327
+#: .\course\flow.py:1366
 msgid "odd POST parameters"
 msgstr "怪异的POST参数设置"
 
-#: .\course\flow.py:1335
+#: .\course\flow.py:1374
 msgid "not permitted to end session"
 msgstr "不允许结束session"
 
-#: .\course\flow.py:1403
+#: .\course\flow.py:1442
 msgid ""
 "If non-empty, limit the regrading to sessions started under this access "
 "rules tag."
@@ -835,40 +857,40 @@ msgstr ""
 "如果access rules的设置不为空, 则对该规则下开始的session进行重新评分受到该规则"
 "的限制. "
 
-#: .\course\flow.py:1405 .\course\models.py:466
+#: .\course\flow.py:1444 .\course\models.py:478
 msgid "Access rules tag"
 msgstr "访问规则tag"
 
-#: .\course\flow.py:1409
+#: .\course\flow.py:1448
 msgid "Regrade in-progress and not-in-progress sessions"
 msgstr "为进行中的和不在进行中的session重新评分"
 
-#: .\course\flow.py:1411
+#: .\course\flow.py:1450
 msgid "Regrade in-progress sessions only"
 msgstr "仅为进行中的session重新评分"
 
-#: .\course\flow.py:1413
+#: .\course\flow.py:1452
 msgid "Regrade not-in-progress sessions only"
 msgstr "仅为非进行中的session重新评分"
 
-#: .\course\flow.py:1415
+#: .\course\flow.py:1454
 msgid "Regraded session in progress"
 msgstr "为正在进行的session重新评分"
 
-#: .\course\flow.py:1418 .\course\templates\course\gradebook-single.html:248
+#: .\course\flow.py:1457 .\course\templates\course\gradebook-single.html:248
 msgid "Regrade"
 msgstr "重新评分"
 
-#: .\course\flow.py:1436
+#: .\course\flow.py:1475
 msgid "must be instructor to regrade flows"
 msgstr "只有任课老师(instructor)才能为flow重新评分"
 
-#: .\course\flow.py:1466
+#: .\course\flow.py:1505
 #, python-format
 msgid "%d sessions regraded."
 msgstr "%d个session已重新评分. "
 
-#: .\course\flow.py:1474
+#: .\course\flow.py:1513
 msgid ""
 "This regrading process is only intended for flows that donot show up in the "
 "grade book. If you would like to regradefor-credit flows, use the "
@@ -877,7 +899,7 @@ msgstr ""
 "这个重新评分的过程旨在针对不在“成绩册”中显示的的flow. 如果您想对计入成绩的"
 "flow重新评分, 请使用“成绩册”中的对应功能. "
 
-#: .\course\flow.py:1479
+#: .\course\flow.py:1518
 msgid "Regrade not-for-credit Flow Sessions"
 msgstr "为不计入成绩的flow session重新评分"
 
@@ -935,8 +957,8 @@ msgstr "重新计算已结束session的评分"
 msgid "opportunity from wrong course"
 msgstr "机会与课程不符"
 
-#: .\course\grades.py:499 .\course\views.py:343 .\course\views.py:370
-#: .\course\views.py:418
+#: .\course\grades.py:499 .\course\views.py:393 .\course\views.py:420
+#: .\course\views.py:468
 msgid "invalid operation"
 msgstr "无效操作"
 
@@ -961,17 +983,17 @@ msgid "Grade recalculated for %d session(s)."
 msgstr "%d个session已重新计算评分. "
 
 #: .\course\grades.py:549 .\course\grades.py:869 .\course\grades.py:1176
-#: .\course\versioning.py:424
+#: .\course\versioning.py:438
 msgctxt "Starting of Error message"
 msgid "Error"
 msgstr "错误"
 
-#: .\course\grades.py:660 .\course\views.py:718
+#: .\course\grades.py:660 .\course\views.py:768
 msgid "Set access rules tag"
 msgstr "设置访问规则tag"
 
-#: .\course\grades.py:664 .\course\models.py:844 .\course\models.py:892
-#: .\course\models.py:1055 .\course\views.py:762
+#: .\course\grades.py:664 .\course\models.py:856 .\course\models.py:904
+#: .\course\models.py:1069 .\course\views.py:812
 msgid "Comment"
 msgstr "评论"
 
@@ -1044,7 +1066,7 @@ msgctxt "Field name in Import grades form"
 msgid "Grading opportunity"
 msgstr "得分机会"
 
-#: .\course\grades.py:968 .\course\models.py:1046
+#: .\course\grades.py:968 .\course\models.py:1060
 msgid "Attempt ID"
 msgstr ""
 
@@ -1088,13 +1110,13 @@ msgid "Feedback column"
 msgstr "反馈所在列"
 
 #. Translators: "Max point" refers to full credit in points.
-#: .\course\grades.py:997 .\course\models.py:693 .\course\models.py:1052
+#: .\course\grades.py:997 .\course\models.py:705 .\course\models.py:1066
 msgid "Max points"
 msgstr "满分分值"
 
 #: .\course\grades.py:1000 .\course\sandbox.py:70
 #: .\course\templates\course\grade-import-preview.html:14
-#: .\course\versioning.py:376
+#: .\course\versioning.py:382
 msgid "Preview"
 msgstr "预览"
 
@@ -1196,7 +1218,7 @@ msgid "Send instant message"
 msgstr "发送即时信息"
 
 #. Translators: name format of ParticipationTag
-#: .\course\models.py:60 .\course\models.py:324
+#: .\course\models.py:60 .\course\models.py:334
 msgid "Format is lower-case-with-hyphens. Do not use spaces."
 msgstr "格式：只允许小写字母与减号, 不允许有空格."
 
@@ -1229,7 +1251,7 @@ msgstr "IP范围的描述"
 msgid "Facility IP range"
 msgstr "教学设施的IP地址范围"
 
-#: .\course\models.py:117 .\course\models.py:349
+#: .\course\models.py:119 .\course\models.py:361
 #: .\course\templates\course\gradebook-by-opp.html:63
 #: .\course\templates\course\gradebook-participant-list.html:24
 #: .\course\templates\course\gradebook-participant.html:31
@@ -1237,47 +1259,47 @@ msgstr "教学设施的IP地址范围"
 msgid "User ID"
 msgstr "用户ID"
 
-#: .\course\models.py:120 .\course\models.py:143
+#: .\course\models.py:122 .\course\models.py:145
 msgid "User status"
 msgstr "用户状态"
 
-#: .\course\models.py:122
+#: .\course\models.py:124
 msgid "The sign in token sent out in email."
 msgstr "用户登录网站的token(用邮件发送)."
 
 #. Translators: the sign in token of the user.
-#: .\course\models.py:125
+#: .\course\models.py:127
 msgid "Sign in key"
 msgstr "登录key"
 
-#: .\course\models.py:127
+#: .\course\models.py:129
 msgid "The time stamp of the sign in token."
 msgstr "用户登录网站token的时间戳."
 
 #. Translators: the time when the token is sent out.
-#: .\course\models.py:129
+#: .\course\models.py:131
 msgid "Key time"
 msgstr "登录key的时间"
 
-#: .\course\models.py:133
+#: .\course\models.py:135
 msgid "Default"
 msgstr "默认"
 
 #. Translators: the text editor used by participants
-#: .\course\models.py:140
+#: .\course\models.py:142
 msgid "Editor mode"
 msgstr "网页文本编辑器模式"
 
-#: .\course\models.py:144
+#: .\course\models.py:146
 msgid "User statuses"
 msgstr "用户状态"
 
-#: .\course\models.py:148
+#: .\course\models.py:150
 #, python-format
 msgid "User status for %(user)s"
 msgstr "%(user)s的用户状态"
 
-#: .\course\models.py:157
+#: .\course\models.py:159
 msgid ""
 "A course identifier. Alphanumeric with dashes, no spaces. This is visible in "
 "URLs and determines the location on your file system where the course's git "
@@ -1286,45 +1308,45 @@ msgstr ""
 "课程的ID, 只允许字母、数字、减号, 不能有空格. 它将显示在您的链接中, 并确定该"
 "课程的git仓库放在您的系统中的哪个文件夹下. "
 
-#: .\course\models.py:160 .\course\models.py:279 .\course\models.py:321
-#: .\course\models.py:351 .\course\models.py:398 .\course\models.py:425
-#: .\course\models.py:446 .\course\models.py:973
+#: .\course\models.py:162 .\course\models.py:289 .\course\models.py:331
+#: .\course\models.py:363 .\course\models.py:410 .\course\models.py:437
+#: .\course\models.py:458 .\course\models.py:987
 msgid "Course identifier"
 msgstr "课程ID"
 
-#: .\course\models.py:166
+#: .\course\models.py:168
 msgid "Identifier may only contain letters, numbers, and hypens ('-')."
 msgstr "Identifier只能包含英文字母, 数字, 和中划线（即减号\"-\"). "
 
-#: .\course\models.py:173
+#: .\course\models.py:175
 msgid "Is the course only accessible to course staff?"
+msgstr "本课程是否只有管理人员才能访问？"
+
+#: .\course\models.py:176
+msgid "Only visible to course staff"
 msgstr "本课程是否只对课程管理人员显示？"
 
-#: .\course\models.py:174
-msgid "Hidden to student"
-msgstr "对学生隐藏"
-
-#: .\course\models.py:177
+#: .\course\models.py:179
 msgid "Should the course be listed on the main page?"
 msgstr "该课程是否放在主页上？"
 
-#: .\course\models.py:178
+#: .\course\models.py:180
 msgid "Listed on main page"
 msgstr "在主页上显示"
 
-#: .\course\models.py:181
+#: .\course\models.py:183
 msgid "Accepts enrollment"
 msgstr "允许申请加入课程"
 
-#: .\course\models.py:184
+#: .\course\models.py:186
 msgid "Whether the course content has passed validation."
 msgstr "课程内容是否已通过有效性验证. "
 
-#: .\course\models.py:185
+#: .\course\models.py:187
 msgid "Valid"
 msgstr "通过有效性验证"
 
-#: .\course\models.py:188
+#: .\course\models.py:190
 msgid ""
 "A Git URL from which to pull course updates. If you're just starting out, "
 "enter <tt>git://github.com/inducer/relate-sample</tt> to get some sample "
@@ -1333,80 +1355,92 @@ msgstr ""
 "一个git网址, 课程的内容更新将从它pull取得. 如果您刚刚开始使用, 可输入"
 "<tt>git://github.com/inducer/relate-sample</tt>来取得一些示范内容. "
 
-#: .\course\models.py:192
+#: .\course\models.py:194
 msgid "git source"
 msgstr "Git源地址"
 
-#: .\course\models.py:194
+#: .\course\models.py:196
 msgid ""
 "An SSH private key to use for Git authentication. Not needed for the sample "
-"URL above."
+"URL above.You may use <a href='/generate-ssh-key'>this tool</a> to generate "
+"a key pair."
 msgstr ""
 "一个私有的SSH密钥, 用于验证您的git（如果您是采用私有git的话), 对于以上的示范"
-"课程不需设置. "
+"课程不需设置. 你可以使用<a href='/generate-ssh-key'>这个工具</a>来生成一对密"
+"钥. "
 
-#: .\course\models.py:196
+#: .\course\models.py:200
 msgid "SSH private key"
 msgstr "SSH私有密钥"
 
-#: .\course\models.py:200
+#: .\course\models.py:203
+msgid ""
+"Subdirectory in git repository to use as course root directory. Should not "
+"include trailing slash."
+msgstr "一个在git仓库目录下的目录，作为课程的根目录. 不要包含斜杠."
+
+#: .\course\models.py:206
+msgid "Course root directory"
+msgstr ""
+
+#: .\course\models.py:210
 msgid ""
 "Name of a YAML file in the git repository that contains the root course "
 "descriptor."
 msgstr "git仓库中包含了课程内容描述的YAML文件的文件名, 通常为course.xml. "
 
-#: .\course\models.py:202
+#: .\course\models.py:212
 msgid "Course file"
 msgstr "课程主页文件"
 
-#: .\course\models.py:205
+#: .\course\models.py:215
 msgid ""
 "Name of a YAML file in the git repository that contains calendar information."
 msgstr "git仓库中包含了课程教学日历信息的YAML文件的文件名, 通常为event.xml. "
 
-#: .\course\models.py:207
+#: .\course\models.py:217
 msgid "Events file"
 msgstr "event(事件)文件"
 
-#: .\course\models.py:211
+#: .\course\models.py:221
 msgid "If set, each enrolling student must be individually approved."
 msgstr "如果选择该项, 每个加入课程的请求必须单独批准. "
 
-#: .\course\models.py:213
+#: .\course\models.py:223
 msgid "Enrollment approval required"
 msgstr "申请加入课程必须得到批准"
 
-#: .\course\models.py:216
+#: .\course\models.py:226
 msgid ""
 "Enrollee's email addresses must end in the specified suffix, such as "
 "'@illinois.edu'."
 msgstr "申请加入课程的电子邮件必须使用特定的后缀, 比如\"@qq.com\". "
 
-#: .\course\models.py:218
+#: .\course\models.py:228
 msgid "Enrollment required email suffix"
 msgstr "申请加入课程的电子邮件地址必须有的后缀"
 
 #. Translators: replace "RELATE" with the brand name of your
 #. website if necessary.
-#: .\course\models.py:223
+#: .\course\models.py:233
 msgid ""
 "This email address will be used in the 'From' line of automated emails sent "
 "by RELATE."
 msgstr "这个电子邮件地址用于RELATE自动发送电子邮件时的发件人. "
 
-#: .\course\models.py:225
+#: .\course\models.py:235
 msgid "From email"
 msgstr "发送邮件的邮箱"
 
-#: .\course\models.py:228
+#: .\course\models.py:238
 msgid "This email address will receive notifications about the course."
 msgstr "这个电子邮件地址用于接收关于本课程的事务通知. "
 
-#: .\course\models.py:230
+#: .\course\models.py:240
 msgid "Notify email"
 msgstr "接收通知的邮箱"
 
-#: .\course\models.py:235
+#: .\course\models.py:245
 msgid ""
 "(Required only if the instant message feature is desired.) The Jabber/XMPP "
 "ID (JID) the course will use to sign in to an XMPP server."
@@ -1414,101 +1448,101 @@ msgstr ""
 "本课程将使用的Jabber/XMPP ID (JID), 用于登录某个XMPP服务器(仅在需要使用即时通"
 "信功能时才需填写). "
 
-#: .\course\models.py:238
+#: .\course\models.py:248
 msgid "Course xmpp ID"
 msgstr "课程的xmpp ID"
 
-#: .\course\models.py:240
+#: .\course\models.py:250
 msgid ""
 "(Required only if the instant message feature is desired.) The password to "
 "go with the JID above."
 msgstr "以上设置的JID的密码(仅在需要使用即时通信功能时才需填写). "
 
-#: .\course\models.py:242
+#: .\course\models.py:252
 msgid "Course xmpp password"
 msgstr "课程的XMPP密码"
 
-#: .\course\models.py:245
+#: .\course\models.py:255
 msgid ""
 "(Required only if the instant message feature is desired.) The JID to which "
 "instant messages will be sent."
 msgstr "接收即时信息的JID(仅在需要使用即时通信功能时才需填写). "
 
-#: .\course\models.py:247
+#: .\course\models.py:257
 msgid "Recipient xmpp ID"
 msgstr "接收者的xmpp ID"
 
-#: .\course\models.py:253 .\course\models.py:452
+#: .\course\models.py:263 .\course\models.py:464
 msgid "Active git commit SHA"
 msgstr "已启用的git commit SHA"
 
-#: .\course\models.py:260
+#: .\course\models.py:270
 msgid "Courses"
 msgstr "课程"
 
-#: .\course\models.py:284
+#: .\course\models.py:294
 msgid "Kind of event"
 msgstr "event的类型(kind)"
 
 #. Translators: ordinal of event of the same kind
-#: .\course\models.py:287
+#: .\course\models.py:297
 msgid "Ordinal of event"
 msgstr "event的序号(ordinal)"
 
-#: .\course\models.py:289 .\course\models.py:429 .\course\models.py:456
+#: .\course\models.py:299 .\course\models.py:441 .\course\models.py:468
 #: .\course\templates\course\flow-start.html:23
 msgid "Start time"
 msgstr "开始时间"
 
-#: .\course\models.py:291 .\course\models.py:431
+#: .\course\models.py:301 .\course\models.py:443
 msgid "End time"
 msgstr "结束时间"
 
 #. Translators: for when the due time is "All day", how the webpage
 #. of a event is displayed.
-#: .\course\models.py:295
+#: .\course\models.py:305
 msgid ""
 "Only affects the rendering in the class calendar, in that a start time is "
 "not shown"
 msgstr "只会影响课程日历页面的渲染, 其效果为开始时间(start time)不显示. "
 
-#: .\course\models.py:297
+#: .\course\models.py:307
 msgid "All day"
 msgstr "全天"
 
-#: .\course\models.py:300
+#: .\course\models.py:310
 msgid "Shown in calendar"
 msgstr "在日历中显示"
 
-#: .\course\models.py:303
+#: .\course\models.py:313
 msgid "Event"
 msgstr "事件(event)"
 
-#: .\course\models.py:304
+#: .\course\models.py:314
 msgid "Events"
 msgstr "事件(event)"
 
-#: .\course\models.py:326
+#: .\course\models.py:336
 msgid "Name of participation tag"
 msgstr "课程参与tag的名称"
 
-#: .\course\models.py:335
+#: .\course\models.py:347
 msgid "Name contains invalid characters."
 msgstr "名称包含无效字符. "
 
-#: .\course\models.py:341
+#: .\course\models.py:353
 msgid "Participation tag"
 msgstr "课程参与标签"
 
-#: .\course\models.py:342
+#: .\course\models.py:354
 msgid "Participation tags"
 msgstr "课程参与标签"
 
-#: .\course\models.py:354
+#: .\course\models.py:366
 msgid "Enroll time"
 msgstr "加入课程时间"
 
-#: .\course\models.py:357
+#: .\course\models.py:369
 msgid ""
 "Instructors may update course content. Teaching assistants may access and "
 "change grade data. Observers may access analytics. Each role includes "
@@ -1518,151 +1552,151 @@ msgstr ""
 "(observer)可以访问评分分析内容. 以上三者, 排在前面的角色拥有排在后面的角色的"
 "权限. "
 
-#: .\course\models.py:361
+#: .\course\models.py:373
 msgid "Participation role"
 msgstr "参与该课程的角色"
 
-#: .\course\models.py:364
+#: .\course\models.py:376
 msgid "Participation status"
 msgstr "课程参与状态"
 
-#: .\course\models.py:369
+#: .\course\models.py:381
 msgid ""
 "Multiplier for time available on time-limited flows (time-limited flows are "
 "currently unimplemented)."
 msgstr "对于有时限的flow，其可用时间的乘数(有时限的flow目前还未部署)."
 
-#: .\course\models.py:371
+#: .\course\models.py:383
 msgid "Time factor"
 msgstr "时间乘数"
 
-#: .\course\models.py:375
+#: .\course\models.py:387
 msgid "Preview git commit SHA"
 msgstr "预览的git commit SHA"
 
-#: .\course\models.py:378
+#: .\course\models.py:390
 msgid "Tags"
 msgstr "标签"
 
 #. Translators: displayed format of Participation: some user in some
 #. course as some role
-#: .\course\models.py:383
+#: .\course\models.py:395
 #, python-format
 msgid "%(user)s in %(course)s as %(role)s"
 msgstr "%(user)s在课程%(course)s中(作为%(role)s)"
 
-#: .\course\models.py:388 .\course\models.py:450 .\course\models.py:812
-#: .\course\models.py:882 .\course\models.py:1033 .\course\models.py:1289
+#: .\course\models.py:400 .\course\models.py:462 .\course\models.py:824
+#: .\course\models.py:894 .\course\models.py:1047 .\course\models.py:1305
 #: .\course\templates\course\course-base.html:100
 msgid "Participation"
 msgstr "课程参与"
 
-#: .\course\models.py:389
+#: .\course\models.py:401
 msgid "Participations"
 msgstr "课程参与"
 
-#: .\course\models.py:404 .\course\models.py:830 .\course\models.py:887
-#: .\course\models.py:1061
+#: .\course\models.py:416 .\course\models.py:842 .\course\models.py:899
+#: .\course\models.py:1075
 msgid "Creator"
 msgstr "创建者"
 
-#: .\course\models.py:406 .\course\models.py:832 .\course\models.py:889
-#: .\course\models.py:998
+#: .\course\models.py:418 .\course\models.py:844 .\course\models.py:901
+#: .\course\models.py:1012
 msgid "Creation time"
 msgstr "创建时间"
 
 #. Translators: somebody's email in some course in Particiaption
 #. Preapproval
-#: .\course\models.py:411
+#: .\course\models.py:423
 #, python-format
 msgid "%(email)s in %(course)s"
 msgstr "%(email)s在课程%(course)s中"
 
-#: .\course\models.py:415
+#: .\course\models.py:427
 msgid "Participation preapproval"
 msgstr "用户加入课程预批准"
 
-#: .\course\models.py:416
+#: .\course\models.py:428
 msgid "Participation preapprovals"
 msgstr "用户加入课程预批准"
 
-#: .\course\models.py:433
+#: .\course\models.py:445
 msgid "Cancelled"
 msgstr "已取消的"
 
-#: .\course\models.py:436
+#: .\course\models.py:448
 msgid "Instant flow request"
 msgstr "即时flow"
 
-#: .\course\models.py:437 .\course\templates\course\course-base.html:104
+#: .\course\models.py:449 .\course\templates\course\course-base.html:104
 msgid "Instant flow requests"
 msgstr "即时flow"
 
-#: .\course\models.py:458
+#: .\course\models.py:470
 msgid "Completition time"
 msgstr "完成时间"
 
-#: .\course\models.py:460
+#: .\course\models.py:472
 msgid "Page count"
 msgstr "page数"
 
-#: .\course\models.py:463
+#: .\course\models.py:475
 msgid "In progress"
 msgstr "进行中的"
 
-#: .\course\models.py:470
+#: .\course\models.py:482
 msgid "Expiration mode"
 msgstr "过期模式"
 
-#: .\course\models.py:479 .\course\models.py:1050
+#: .\course\models.py:491 .\course\models.py:1064
 #: .\course\templates\course\gradebook-single.html:218
 msgid "Points"
 msgstr "分值"
 
-#: .\course\models.py:482
+#: .\course\models.py:494
 msgid "Max point"
 msgstr "满分"
 
-#: .\course\models.py:484
+#: .\course\models.py:496
 msgid "Result comment"
 msgstr "结果评论"
 
-#: .\course\models.py:487 .\course\models.py:543 .\course\models.py:587
-#: .\course\models.py:1067 .\course\templates\course\grade-flow-page.html:58
+#: .\course\models.py:499 .\course\models.py:555 .\course\models.py:599
+#: .\course\models.py:1081 .\course\templates\course\grade-flow-page.html:58
 msgid "Flow session"
 msgstr ""
 
-#: .\course\models.py:488 .\course\templates\course\gradebook-single.html:127
+#: .\course\models.py:500 .\course\templates\course\gradebook-single.html:127
 msgid "Flow sessions"
 msgstr ""
 
-#: .\course\models.py:493
+#: .\course\models.py:505
 #, python-format
 msgid "anonymous session %(session_id)d on '%(flow_id)s'"
 msgstr "flow \"%(flow_id)s\"中匿名的session %(session_id)d "
 
-#: .\course\models.py:497
+#: .\course\models.py:509
 #, python-format
 msgid "%(user)s's session %(session_id)d on '%(flow_id)s'"
 msgstr "%(user)s在flow \"%(flow_id)s\"的session %(session_id)d"
 
-#: .\course\models.py:545
+#: .\course\models.py:557
 msgid "Ordinal"
 msgstr "序号"
 
-#: .\course\models.py:548
+#: .\course\models.py:560
 msgid "Group ID"
 msgstr ""
 
-#: .\course\models.py:555
+#: .\course\models.py:567
 msgid "Data"
 msgstr "数据"
 
-#: .\course\models.py:558 .\course\models.py:559
+#: .\course\models.py:570 .\course\models.py:571
 msgid "Flow page data"
 msgstr "flow page的数据"
 
-#: .\course\models.py:563
+#: .\course\models.py:575
 #, python-format
 msgid ""
 "Data for page '%(group_id)s/%(page_id)s' (ordinal %(ordinal)s) in %"
@@ -1670,19 +1704,19 @@ msgid ""
 msgstr ""
 "%(flow_session)s中page %(group_id)s/%(page_id)s(序号为%(ordinal)s)的数据"
 
-#: .\course\models.py:590 .\course\models.py:743
+#: .\course\models.py:602 .\course\models.py:755
 msgid "Page data"
 msgstr "page数据"
 
-#: .\course\models.py:592
+#: .\course\models.py:604
 msgid "Visit time"
 msgstr "访问时间"
 
-#: .\course\models.py:594
+#: .\course\models.py:606
 msgid "Remote address"
 msgstr "来访的ip地址"
 
-#: .\course\models.py:597
+#: .\course\models.py:609
 msgid ""
 "Synthetic flow page visits are generated for unvisited pages once a flow is "
 "finished. This is needed since grade information is attached to a visit, and "
@@ -1691,276 +1725,276 @@ msgstr ""
 "如果一个flow结束，则对未访问的page生成\"合成\"的flow page访问。这是因为评分信"
 "息是附在访问中的，它需要有一个去处。"
 
-#: .\course\models.py:601
+#: .\course\models.py:613
 msgid "Is synthetic"
 msgstr "是否合成"
 
 #. Translators: "Answer" is a Noun.
-#: .\course\models.py:607 .\course\page\code.py:59 .\course\page\text.py:97
+#: .\course\models.py:619 .\course\page\code.py:59 .\course\page\text.py:97
 msgid "Answer"
 msgstr "回答"
 
 #. Translators: determine whether the answer is a final,
 #. submitted answer fit for grading.
-#: .\course\models.py:620
+#: .\course\models.py:632
 msgid "Is submitted answer"
 msgstr "是否为用于评分的回答"
 
 #. Translators: flow page visit
-#: .\course\models.py:625
+#: .\course\models.py:637
 #, python-format
 msgid "'%(group_id)s/%(page_id)s' in '%(session)s' on %(time)s"
 msgstr "在%(time)s时, \"%(session)s'中的'%(group_id)s/%(page_id)s\""
 
 #. Translators: flow page visit: if an answer is
 #. provided by user then append the string.
-#: .\course\models.py:635
+#: .\course\models.py:647
 msgid " (with answer)"
 msgstr "（和回答）"
 
-#: .\course\models.py:640
+#: .\course\models.py:652
 msgid "Flow page visit"
 msgstr "flow page访问"
 
-#: .\course\models.py:641
+#: .\course\models.py:653
 msgid "Flow page visits"
 msgstr "flow page访问"
 
-#: .\course\models.py:668
+#: .\course\models.py:680
 msgid "Visit"
 msgstr "访问"
 
-#: .\course\models.py:672 .\course\templates\course\gradebook-single.html:219
+#: .\course\models.py:684 .\course\templates\course\gradebook-single.html:219
 msgid "Grader"
 msgstr "评分者"
 
-#: .\course\models.py:674 .\course\models.py:1063
+#: .\course\models.py:686 .\course\models.py:1077
 msgid "Grade time"
 msgstr "评分时间"
 
-#: .\course\models.py:678
+#: .\course\models.py:690
 msgid "Graded at git commit SHA"
 msgstr "评分，于git commit SHA"
 
-#: .\course\models.py:683
+#: .\course\models.py:695
 msgid "Grade data"
 msgstr "评分数据"
 
 #. Translators: max point in grade
-#: .\course\models.py:691
+#: .\course\models.py:703
 msgid "Point value of this question when receiving full credit."
 msgstr "该问题取得满分时取得的分值. "
 
 #. Translators: correctness in grade
-#: .\course\models.py:696
+#: .\course\models.py:708
 msgid ""
 "Real number between zero and one (inclusively) indicating the degree of "
 "correctness of the answer."
 msgstr "属于范围[0,1]的数值, 用于表示回答的正确性. "
 
-#: .\course\models.py:698
+#: .\course\models.py:710
 msgid "Correctness"
 msgstr "正确性"
 
 #. Translators: "Feedback" stands for the feedback of answers.
-#: .\course\models.py:709
+#: .\course\models.py:721
 #: .\course\templates\course\grade-import-preview.html:20
 msgid "Feedback"
 msgstr "反馈"
 
-#: .\course\models.py:724
+#: .\course\models.py:736
 msgid "Flow page visit grade"
 msgstr "flow page 访问的得分"
 
-#: .\course\models.py:725
+#: .\course\models.py:737
 msgid "Flow page visit grades"
 msgstr "flow page 访问的得分"
 
 #. Translators: return the information of the grade of a user
 #. by percentage.
-#: .\course\models.py:735
+#: .\course\models.py:747
 #, python-format
 msgid "grade of %(visit)s: %(percentage)s"
 msgstr "%(visit)s的得分(百分比): %(percentage)s"
 
-#: .\course\models.py:745
+#: .\course\models.py:757
 #: .\course\templates\course\grade-import-preview.html:19
 #: .\course\templates\course\gradebook-participant.html:51
 #: .\course\templates\course\gradebook-single.html:66
 msgid "Grade"
 msgstr "得分"
 
-#: .\course\models.py:750
+#: .\course\models.py:762
 msgid "Bulk feedback"
 msgstr "批量反馈"
 
-#: .\course\models.py:786
+#: .\course\models.py:798
 msgid "stipulations must be a dictionary"
 msgstr "规定必须为一个字典型数据，即：(项目, 项目的值)"
 
-#: .\course\models.py:791
+#: .\course\models.py:803
 msgid "unrecognized keys in stipulations"
 msgstr "无法识别的规定"
 
-#: .\course\models.py:797
+#: .\course\models.py:809
 msgid "credit_percent must be a float"
 msgstr "credit_percent必须是一个浮点数"
 
-#: .\course\models.py:803
+#: .\course\models.py:815
 msgid "'allowed_session_count' must be a non-negative integer"
 msgstr "allowed_session_count必须是一个非负的整数"
 
-#: .\course\models.py:816 .\course\models.py:884
+#: .\course\models.py:828 .\course\models.py:896
 msgid "Expiration"
 msgstr "过期"
 
 #. Translators: help text for stipulations in FlowAccessException
 #. (deprecated)
-#: .\course\models.py:821
+#: .\course\models.py:833
 msgid ""
 "A dictionary of the same things that can be added to a flow access rule, "
 "such as allowed_session_count or credit_percent. If not specified here, "
 "values will default to the stipulations in the course content."
 msgstr ""
 
-#: .\course\models.py:827
+#: .\course\models.py:839
 msgid "Stipulations"
 msgstr "条款"
 
 #. Translators: deprecated
-#: .\course\models.py:837
+#: .\course\models.py:849
 msgid ""
 "Check if a flow started under this exception rule set should stay under this "
 "rule set until it is expired."
 msgstr ""
 
 #. Translators: deprecated
-#: .\course\models.py:841
+#: .\course\models.py:853
 msgid "Is sticky"
 msgstr ""
 
 #. Translators: flow access exception in admin (deprecated)
-#: .\course\models.py:849
+#: .\course\models.py:861
 #, python-format
 msgid "Access exception for '%(user)s' to '%(flow_id)s' in '%(course)s'"
 msgstr "对用户\"%(user)s'破例访问课程'%(course)s'中的'%(flow_id)s\". "
 
-#: .\course\models.py:863
+#: .\course\models.py:875
 msgid "Exception"
 msgstr "破例处理"
 
-#: .\course\models.py:866
+#: .\course\models.py:878
 msgid "Permission"
 msgstr "权限"
 
 #. Translators: FlowAccessExceptionEntry (deprecated)
-#: .\course\models.py:870
+#: .\course\models.py:882
 msgid "Flow access exception entries"
 msgstr "破例访问flow的条目"
 
-#: .\course\models.py:896
+#: .\course\models.py:908
 msgid "Kind"
 msgstr "类型"
 
-#: .\course\models.py:898
+#: .\course\models.py:910
 msgid "Rule"
 msgstr "规则"
 
-#: .\course\models.py:901
+#: .\course\models.py:913
 msgctxt "Is the flow rule exception activated?"
 msgid "Active"
 msgstr "生效"
 
 #. Translators: For FlowRuleException
-#: .\course\models.py:906
+#: .\course\models.py:918
 #, python-format
 msgid "%(kind)s exception for '%(user)s' to '%(flow_id)s'in '%(course)s'"
 msgstr "在课程%(course)s的%(flow_id)s中, 给予%(user)s破例的类型%(kind)s"
 
-#: .\course\models.py:917
+#: .\course\models.py:931
 msgid "grading rules may not expire"
 msgstr "评分规则不会过期"
 
-#: .\course\models.py:956
+#: .\course\models.py:970
 msgid "invalid rule kind: "
 msgstr "无效的规则类型："
 
-#: .\course\models.py:960
+#: .\course\models.py:974
 msgid "invalid existing_session_rules: "
 msgstr "无效的existing_session_rules:"
 
-#: .\course\models.py:963
+#: .\course\models.py:977
 msgid "Flow rule exception"
 msgstr "flow rule破例"
 
-#: .\course\models.py:964
+#: .\course\models.py:978
 msgid "Flow rule exceptions"
 msgstr "flow rule破例"
 
 #. Translators: format of identifier for GradingOpportunity
-#: .\course\models.py:977
+#: .\course\models.py:991
 msgid "A symbolic name for this grade. lower_case_with_underscores, no spaces."
 msgstr "这个评分的字符化名称, 只允许小写字母和下划线, 不允许有空格. "
 
-#: .\course\models.py:979
+#: .\course\models.py:993
 msgid "Grading opportunity ID"
 msgstr "得分机会ID"
 
 #. Translators: name for GradingOpportunity
-#: .\course\models.py:982
+#: .\course\models.py:996
 msgid "A human-readable identifier for the grade."
 msgstr "一个易于理解的标识, 用于评分. "
 
-#: .\course\models.py:983
+#: .\course\models.py:997
 msgid "Grading opportunity name"
 msgstr "得分机会的名称"
 
-#: .\course\models.py:985
+#: .\course\models.py:999
 msgid "Flow identifier that this grading opportunity is linked to, if any"
 msgstr "这个评分机会所属的Flow ID, 如果有评分机会的话"
 
 #. Translators: strategy on how the grading of mutiple sessioins
 #. are aggregated.
-#: .\course\models.py:993 .\course\templates\course\gradebook-by-opp.html:36
+#: .\course\models.py:1007 .\course\templates\course\gradebook-by-opp.html:36
 #: .\course\templates\course\gradebook-opp-list.html:27
 msgid "Aggregation strategy"
 msgstr "多session评分累积策略"
 
-#: .\course\models.py:996 .\course\models.py:1058
-#: .\course\templates\course\gradebook-opp-list.html:28 .\course\views.py:751
+#: .\course\models.py:1010 .\course\models.py:1072
+#: .\course\templates\course\gradebook-opp-list.html:28 .\course\views.py:801
 msgid "Due time"
 msgstr "截止时间"
 
-#: .\course\models.py:1001
+#: .\course\models.py:1015
 msgid "Shown in grade book"
 msgstr "在成绩册中显示"
 
-#: .\course\models.py:1003
+#: .\course\models.py:1017
 msgid "Shown in student grade book"
 msgstr "在在学生的成绩册中显示"
 
-#: .\course\models.py:1006 .\course\models.py:1030
+#: .\course\models.py:1020 .\course\models.py:1044
 msgid "Grading opportunity"
 msgstr "得分机会"
 
-#: .\course\models.py:1007
+#: .\course\models.py:1021
 msgid "Grading opportunities"
 msgstr "得分机会"
 
 #. Translators: For GradingOpportunity
-#: .\course\models.py:1014
+#: .\course\models.py:1028
 #, python-format
 msgid "%(opportunity_name)s (%(opportunity_id)s) in %(course)s"
 msgstr "课程%(course)s中的评分机会%(opportunity_name)s (%(opportunity_id)s) "
 
 #. Translators: something like 'status'.
-#: .\course\models.py:1038 .\course\templates\course\flow-start.html:24
+#: .\course\models.py:1052 .\course\templates\course\flow-start.html:24
 #: .\course\templates\course\gradebook-single.html:135
 msgid "State"
 msgstr "状态"
 
 #. Translators: help text of "attempt_id" in GradeChange class
-#: .\course\models.py:1043
+#: .\course\models.py:1057
 msgid ""
 "Grade changes are grouped by their 'attempt ID' where later grades with the "
 "same attempt ID supersede earlier ones."
@@ -1968,127 +2002,127 @@ msgstr ""
 "评分的变化是根据它们的\"attempt ID'进行分组, 在相同的'attempt ID\"下, 后面的"
 "评分将覆盖前面的评分. "
 
-#: .\course\models.py:1070
+#: .\course\models.py:1084
 msgid "Grade change"
 msgstr "评分变更"
 
-#: .\course\models.py:1071
+#: .\course\models.py:1085
 msgid "Grade changes"
 msgstr "评分变更"
 
 #. Translators: information for GradeChange
-#: .\course\models.py:1076
+#: .\course\models.py:1090
 #, python-format
 msgid "%(participation)s %(state)s on %(opportunityname)s"
 msgstr "%(opportunityname)s中, %(participation)s %(state)s"
 
-#: .\course\models.py:1083
+#: .\course\models.py:1099
 msgid "Participation and opportunity must live in the same course"
 msgstr "参与(Participation)和评分机会(opportunity)必须属于同一门课程"
 
-#: .\course\models.py:1131
+#: .\course\models.py:1147
 msgid "cannot accept grade once opportunity has been marked 'unavailable'"
 msgstr "一旦评分机会被标记为\"无效(unavailable)\", 将无法进行评分"
 
-#: .\course\models.py:1135
+#: .\course\models.py:1151
 msgid "cannot accept grade once opportunity has been marked 'exempt'"
 msgstr "一旦评分机会被标记为\"剔除(exempt)\", 将无法进行评分"
 
-#: .\course\models.py:1178
+#: .\course\models.py:1194
 #, python-format
 msgid "invalid grade change state '%s'"
 msgstr "无效的评分改变状态 \"%s\""
 
-#: .\course\models.py:1220
+#: .\course\models.py:1236
 #, python-format
 msgid "invalid grade aggregation strategy '%s'"
 msgstr "无效的多session评分累积策略 \"%s\""
 
 #. Translators: display the name of a flow
-#: .\course\models.py:1274
+#: .\course\models.py:1290
 #, python-format
 msgid "Flow: %(flow_desc_title)s"
 msgstr ""
 
-#: .\course\models.py:1291
+#: .\course\models.py:1307
 msgid "Text"
 msgstr "文字"
 
-#: .\course\models.py:1293 .\course\templates\course\gradebook-single.html:63
-#: .\course\views.py:226
+#: .\course\models.py:1309 .\course\templates\course\gradebook-single.html:63
+#: .\course\views.py:276
 msgid "Time"
 msgstr "时间"
 
-#: .\course\models.py:1296
+#: .\course\models.py:1312
 msgid "Instant message"
 msgstr "即时信息"
 
-#: .\course\models.py:1297
+#: .\course\models.py:1313
 msgid "Instant messages"
 msgstr "即时信息"
 
-#: .\course\page\base.py:80
+#: .\course\page\base.py:101
 msgid "Your answer is not correct."
 msgstr "您的回答不正确. "
 
-#: .\course\page\base.py:82
+#: .\course\page\base.py:103
 msgid "Your answer is correct."
 msgstr "您的回答是正确的. "
 
-#: .\course\page\base.py:86
+#: .\course\page\base.py:107
 msgid "Your answer is mostly correct."
 msgstr "您的回答基本正确. "
 
-#: .\course\page\base.py:90
+#: .\course\page\base.py:111
 msgid "No information on correctness of answer."
 msgstr "未知回答正确与否. "
 
-#: .\course\page\base.py:94
+#: .\course\page\base.py:115
 msgid "Your answer is somewhat correct."
 msgstr "您的回答在一定程度上正确. "
 
-#: .\course\page\base.py:123
+#: .\course\page\base.py:144
 msgid "Invalid correctness value"
 msgstr "无效的正确性数值"
 
-#: .\course\page\base.py:498
+#: .\course\page\base.py:533
 #, python-format
 msgid ""
 "PageBaseWithTitle subclass '%s' does not implement markdown_body_for_title()"
-msgstr "PageBaseWithTitle的子类'%s'中未使用markdown_body_for_title()方法"
+msgstr "PageBaseWithTitle的子类\"%s\"未使用markdown_body_for_title()方法"
 
-#: .\course\page\base.py:508
+#: .\course\page\base.py:543
 msgid "no title found in body or title attribute"
 msgstr "没有在body中找到title，也没有title属性"
 
-#: .\course\page\base.py:548
+#: .\course\page\base.py:583
 msgid "Whether the grade and feedback below are to be shown to student"
 msgstr "是否允许学生看到分数和反馈"
 
-#: .\course\page\base.py:550
+#: .\course\page\base.py:585
 msgid "Released"
 msgstr "已发布"
 
-#: .\course\page\base.py:554
+#: .\course\page\base.py:589
 msgid "Grade assigned, in percent"
 msgstr "给予的评分（百分比）"
 
-#: .\course\page\base.py:559
+#: .\course\page\base.py:594
 msgid "Grade percent"
 msgstr "得分的百分比"
 
-#: .\course\page\base.py:565
+#: .\course\page\base.py:600
 #, python-format
 msgid ""
 "Grade assigned, as points out of %.1f. Fill out either this or 'grade "
 "percent'."
 msgstr "给予的评分, %.1f分中取得的分值. 填入此项或者\"得分的百分比\". "
 
-#: .\course\page\base.py:572
+#: .\course\page\base.py:607
 msgid "Grade points"
 msgstr "得分的分值"
 
-#: .\course\page\base.py:578
+#: .\course\page\base.py:613
 msgid ""
 "Feedback to be shown to student, using <a href='http://documen.tician.de/"
 "relate/content.html#relate-markup'>RELATE-flavored Markdown</a>"
@@ -2096,43 +2130,44 @@ msgstr ""
 "将反馈给学生的信息, 建议使用<a href='http://documen.tician.de/relate/content."
 "html#relate-markup'>RELATE方式的Markdown模式</a>. "
 
-#: .\course\page\base.py:582
+#: .\course\page\base.py:617
 msgid "Feedback text"
 msgstr "反馈文字"
 
-#: .\course\page\base.py:585
+#: .\course\page\base.py:620
 msgid ""
 "Checking this box and submitting the form will notify the participant with a "
 "generic message containing the feedback text"
 msgstr "勾选此项并提交这个表单, 将会向参与者发送一个包含了反馈信息的消息. "
 
-#: .\course\page\base.py:588
+#: .\course\page\base.py:623
 msgid "Notify"
 msgstr "发送通知"
 
-#: .\course\page\base.py:591
+#: .\course\page\base.py:626
 msgid "Internal notes, not shown to student"
 msgstr "内部注释, 学生不可见"
 
-#: .\course\page\base.py:593
+#: .\course\page\base.py:628
 msgid "Notes"
 msgstr "注释"
 
-#: .\course\page\base.py:606 .\course\page\base.py:620
+#: .\course\page\base.py:641 .\course\page\base.py:655
 msgid "Grade (percent) and Grade (points) disagree"
 msgstr "百分比评分与分值评分不一致"
 
-#: .\course\page\base.py:696
+#: .\course\page\base.py:731
 msgid "New notification"
 msgstr "一条新的通知"
 
-#: .\course\page\base.py:726 .\course\page\choice.py:217
-#: .\course\page\choice.py:321 .\course\page\code.py:529
-#: .\course\page\code.py:828 .\course\page\text.py:754
+#: .\course\page\base.py:761 .\course\page\choice.py:223
+#: .\course\page\choice.py:333 .\course\page\code.py:530
+#: .\course\page\code.py:831 .\course\page\inline.py:822
+#: .\course\page\text.py:887
 msgid "No answer provided."
 msgstr "未回答. "
 
-#: .\course\page\base.py:742
+#: .\course\page\base.py:777
 msgid "The following feedback was provided"
 msgstr "有以下的反馈信息"
 
@@ -2147,25 +2182,31 @@ msgstr "选项"
 msgid "Choices"
 msgstr "多项选择"
 
-#: .\course\page\choice.py:125 .\course\page\choice.py:433
+#: .\course\page\choice.py:125 .\course\page\choice.py:445
+#: .\course\page\inline.py:427
 #, python-format
 msgid "choice %(idx)d: unable to convert to string"
 msgstr "选项%(idx)d: 无法转换为字符串"
 
-#: .\course\page\choice.py:231
+#: .\course\page\choice.py:140
 #, python-format
-msgid "A correct answer is: %s"
-msgstr "正确答案是: %s"
+msgid "one or more correct answer(s) expected, %(n_correct)d found"
+msgstr "需要至少1个参考答案，找到%(n_correct)d个"
 
-#: .\course\page\choice.py:365
-msgid "The correct answer is: %s"
-msgstr "正确答案是: %s"
+#: .\course\page\choice.py:237 .\course\page\inline.py:794
+#: .\course\page\text.py:908
+msgid "A correct answer is"
+msgstr "参考答案"
 
-#: .\course\page\code.py:609
+#: .\course\page\choice.py:377
+msgid "The correct answer is"
+msgstr "正确答案"
+
+#: .\course\page\code.py:610
 msgid "code question execution failed"
 msgstr "编程问题执行失败"
 
-#: .\course\page\code.py:640
+#: .\course\page\code.py:642
 msgid ""
 "The grading code failed. Sorry about that. The staff has been informed, and "
 "if this problem is due to an issue with the grading code, it will be fixed "
@@ -2176,7 +2217,7 @@ msgstr ""
 "动评分的代码引起的，我们将尽快地修复它。同时，你也可以在下面查看traceback信"
 "息，它将帮助你了解是哪里出了问题。"
 
-#: .\course\page\code.py:651
+#: .\course\page\code.py:654
 #, python-format
 msgid ""
 "Your code took too long to execute. The problem specifies that your code may "
@@ -2185,106 +2226,189 @@ msgstr ""
 "你的代码执行时间过长。本问题要求你的代码执行时间不得超过%s秒钟，由于超时所以"
 "代码执行被取消。"
 
-#: .\course\page\code.py:663
+#: .\course\page\code.py:666
 msgid "Your code failed to compile. An error message is below."
 msgstr "你的代码编译失败，下面是错误信息。"
 
-#: .\course\page\code.py:671
+#: .\course\page\code.py:674
 msgid "Your code failed with an exception. A traceback is below."
 msgstr "你的代码执行失败且有一条exception，下面是traceback信息。"
 
-#: .\course\page\code.py:682
+#: .\course\page\code.py:685
 msgid "Here is some feedback on your code"
 msgstr "这是关于你的代码的反馈"
 
-#: .\course\page\code.py:691
+#: .\course\page\code.py:694
 msgid "This is the exception traceback"
 msgstr "这是exception traceback"
 
-#: .\course\page\code.py:698
+#: .\course\page\code.py:701
 msgid "Your code printed the following output"
 msgstr "你的代码打印出以下的输出结果"
 
-#: .\course\page\code.py:705
+#: .\course\page\code.py:708
 msgid "Your code printed the following error messages"
 msgstr "你的代码打印出以下的错误信息"
 
-#: .\course\page\code.py:711
+#: .\course\page\code.py:714
 msgid "Your code produced the following plots"
 msgstr "你的代码得到以下的图"
 
-#: .\course\page\code.py:720
+#: .\course\page\code.py:723
 msgid "Figure"
 msgstr "图"
 
-#: .\course\page\code.py:742
+#: .\course\page\code.py:745
 msgid "The following code is a valid answer"
 msgstr "以下的代码是一个有效的回答"
 
-#: .\course\page\code.py:810
+#: .\course\page\code.py:813
 msgid "human_feedback_value greater than overall value of question"
 msgstr "人工评分(human_feedback_value)大于这个问题的总分值"
 
-#: .\course\page\text.py:143
+#: .\course\page\inline.py:134
+#, python-format
+msgid "unknown embeded question type '%(type)s'"
+msgstr "未知的嵌入型问题类型\"%(type)s\""
+
+#: .\course\page\inline.py:148
+msgid "must be struct"
+msgstr "必须是一个struct型的数据"
+
+#: .\course\page\inline.py:239
+#, python-format
+msgid "unrecogonized width attribute string: '%(width_attr)s'"
+msgstr "无法识别的宽度字符串: '%(width_attr)s'"
+
+#: .\course\page\inline.py:250
+#, python-format
+msgid ""
+"unsupported length unit '%(length_unit)s', expected length unit can be %"
+"(allowed_length_unit)s"
+msgstr ""
+"不支持的长度单位'%(length_unit)s', 可使用的长度单位包括%(allowed_length_unit)"
+"s"
+
+#: .\course\page\inline.py:293 .\course\page\text.py:857
+msgid "at least one answer must be provided"
+msgstr "至少要提供一个回答"
+
+#. Translators: refers to optional
+#. correct answer for checking
+#. correctness sumbitted by students.
+#: .\course\page\inline.py:316
+msgid "answer"
+msgstr "回答"
+
+#: .\course\page\inline.py:326 .\course\page\text.py:872
+msgid "no matcher is able to provide a plain-text correct answer"
+msgstr "现有的匹配类无法提供一个普通文本型的标准答案"
+
+#: .\course\page\inline.py:444
+#, python-format
+msgid ""
+"one or more correct answer(s) expected  for question '%(question_name)s', %"
+"(n_correct)d found"
+msgstr "问题'%(question_name)s'至少要有1个答案，找到%(n_correct)d个"
+
+#: .\course\page\inline.py:622
+#, python-format
+msgid "invalid answers name %s. "
+msgstr "无效的答案名称%s. "
+
+#: .\course\page\inline.py:623 .\course\page\inline.py:641
+msgid ""
+"A valid name should start with letters. Alphanumeric with underscores. Do "
+"not use spaces."
+msgstr "一个有效的名称应以字母开头，允许包含数字和下划线, 不允许有空格. "
+
+#: .\course\page\inline.py:640
+#, python-format
+msgid "invalid embeded question name %s. "
+msgstr "无效的嵌入型问题名称%s. "
+
+#: .\course\page\inline.py:658
+#, python-format
+msgid "embeded question name %s not unique."
+msgstr "嵌入问题的名称%s不是唯一的."
+
+#: .\course\page\inline.py:669
+#, python-format
+msgid "correct answer(s) not provided for question %s."
+msgstr "未为问题%s提供正确答案. "
+
+#: .\course\page\inline.py:677
+#, python-format
+msgid "redundant answers %s provided for non-existing question(s)."
+msgstr "为不存在的问题提供了多余的答案%s. "
+
+#: .\course\page\inline.py:710
+#, python-format
+msgid "have unpaired '%s'."
+msgstr "有未配对的\"%s\"."
+
+#: .\course\page\text.py:152
 #, python-format
 msgid "page must be of type '%s'"
 msgstr "page必须是\"%s\"类型"
 
-#: .\course\page\text.py:167
+#: .\course\page\text.py:175
 msgid "unknown validator type"
 msgstr "未知的验证器类型"
 
-#: .\course\page\text.py:177 .\course\page\text.py:489
+#: .\course\page\text.py:185 .\course\page\text.py:576
 msgid "must be struct or string"
 msgstr "必须是一个struct或string型的数据"
 
-#: .\course\page\text.py:263
+#: .\course\page\text.py:284
 #, python-format
 msgid "regex '%(pattern)s' did not compile"
 msgstr "正则表达式(regex)\"%(pattern)s\"无法编译"
 
-#: .\course\page\text.py:318
+#: .\course\page\text.py:339
 msgid "unable to check symbolic expression"
 msgstr "无法检查symbolic表达式"
 
-#: .\course\page\text.py:436
+#: .\course\page\text.py:434 .\course\page\text.py:445
+#: .\course\page\text.py:455
+msgid "does not provide a valid float literal"
+msgstr "提供了一个无效的float字符串"
+
+#: .\course\page\text.py:465
+msgid ""
+"Float match should have either rtol or atol--otherwise it will match any "
+"number"
+msgstr ""
+"float匹配器需至少包括'rtol'或'atol'中的一项，否则任何数字都将被视为正确答案. "
+
+#. Translators: a "matcher" is used to determine
+#. if the answer to text question (blank filling
+#. question) is correct.
+#: .\course\page\text.py:523
 #, python-format
 msgid "%(matcherclassname)s only accepts '%(matchertype)s' patterns"
 msgstr "%(matcherclassname)s 只接受 \"%(matchertype)s\" 模式"
 
-#: .\course\page\text.py:448
+#: .\course\page\text.py:535
 #, python-format
 msgid "unknown match type '%(matchertype)s'"
 msgstr "未知的匹配(match)类型\"%(matchertype)s\""
 
-#: .\course\page\text.py:467
+#: .\course\page\text.py:554
 msgid "does not specify match type"
 msgstr "无法确定匹配(match)类型"
 
-#: .\course\page\text.py:475
+#: .\course\page\text.py:562
 msgid "uses deprecated 'matcher:answer' style"
 msgstr "使用了已淘汰了的(deprecated) \"matcher:answer\" 类型"
 
-#: .\course\page\text.py:496
+#: .\course\page\text.py:583
 msgid "matcher must supply 'type'"
 msgstr "matcher必须提供\"type\""
 
-#: .\course\page\text.py:547
+#: .\course\page\text.py:634
 msgid "unrecognized widget type"
 msgstr "无法识别的构件(widget)类型"
-
-#: .\course\page\text.py:724
-msgid "at least one answer must be provided"
-msgstr "至少要提供一个回答"
-
-#: .\course\page\text.py:739
-msgid "no matcher is able to provide a plain-text correct answer"
-msgstr "对于普通文本型回答, 无法提供匹配"
-
-#: .\course\page\text.py:767
-#, python-format
-msgid "A correct answer is: '%s'."
-msgstr "正确答案是“%s”. "
 
 #: .\course\page\upload.py:43
 msgid "Uploaded file"
@@ -2317,7 +2441,11 @@ msgstr "按下 Alt/Cmd+(Shift+)P 进行预览."
 msgid "Content"
 msgstr "内容"
 
-#: .\course\sandbox.py:87
+#: .\course\sandbox.py:84 .\course\sandbox.py:141
+msgid "must be instructor or TA to access sandbox"
+msgstr "只有任课老师(instructor)或助教(TA)才能访问沙箱"
+
+#: .\course\sandbox.py:93
 msgid ""
 "Enter <a href=\"http://documen.tician.de/relate/content.html#relate-markup"
 "\">RELATE markup</a>."
@@ -2325,23 +2453,19 @@ msgstr ""
 "使用<a href='http://documen.tician.de/relate/content.html#relate-"
 "markup'>RELATE方式的Markdown模式</a>. "
 
-#: .\course\sandbox.py:109
+#: .\course\sandbox.py:115
 msgid "Markup failed to render"
 msgstr "Markup渲染失败"
 
-#: .\course\sandbox.py:135
-msgid "must be instructor or TA to access sandbox"
-msgstr "只有任课老师(instructor)或助教(TA)才能访问沙箱"
-
-#: .\course\sandbox.py:158
+#: .\course\sandbox.py:166
 msgid "Enter YAML markup for a flow page."
 msgstr "输入flow page的YAML markup. "
 
-#: .\course\sandbox.py:181
+#: .\course\sandbox.py:196 .\course\sandbox.py:225
 msgid "Page failed to load/validate"
 msgstr "page加载/验证失败"
 
-#: .\course\sandbox.py:264
+#: .\course\sandbox.py:298
 msgid "Submit answer"
 msgstr "提交回答"
 
@@ -2893,15 +3017,15 @@ msgid_plural "%(max_points)s points"
 msgstr[0] "%(max_points)s分"
 msgstr[1] "%(max_points)s分"
 
-#: .\course\templates\course\flow-page.html:101
+#: .\course\templates\course\flow-page.html:105
 msgid "(You may still change your answer after you submit it.)"
 msgstr "(您仍然可以在提交<b>本问题</b>后修改回答)"
 
-#: .\course\templates\course\flow-page.html:174
+#: .\course\templates\course\flow-page.html:178
 msgid "You have unsaved changes on this page."
-msgstr "您在本页上的修改还未保存. "
+msgstr "您在本页还有未保存的修订. "
 
-#: .\course\templates\course\flow-page.html:232
+#: .\course\templates\course\flow-page.html:236
 msgid "Saved."
 msgstr "已保存"
 
@@ -3075,7 +3199,7 @@ msgstr "值"
 msgid "for %(last_name)s, %(first_name)s (%(username)s)"
 msgstr "%(last_name)s%(first_name)s (%(username)s)"
 
-#: .\course\templates\course\grade-flow-page.html:86 .\course\views.py:559
+#: .\course\templates\course\grade-flow-page.html:86 .\course\views.py:609
 msgid "Session"
 msgstr ""
 
@@ -3377,7 +3501,7 @@ msgstr "本(%(RELATE)s)网站还没有挂载课程. "
 msgid "<a href=\"%(relate-sign_in_by_user_pw)s\">Sign in</a> to get started."
 msgstr "<a href=\"%(relate-sign_in_by_user_pw)s\">登录</a> 以开始使用. "
 
-#: .\course\templates\course\home.html:41 .\course\versioning.py:241
+#: .\course\templates\course\home.html:41 .\course\versioning.py:248
 msgid "Set up new course"
 msgstr "设置新课程"
 
@@ -3408,6 +3532,32 @@ msgstr "检查“任课老师”菜单中的“课程日程”功能以添加缺
 #: .\course\templates\course\invalid-datespec-list.html:37
 msgid "No unrecognized events were found."
 msgstr "没有可识别的events. "
+
+#: .\course\templates\course\keypair.html:7
+msgid "SSH Key Pair"
+msgstr ""
+
+#: .\course\templates\course\keypair.html:9
+msgid "Private key:"
+msgstr "私有密钥:"
+
+#: .\course\templates\course\keypair.html:10
+msgid ""
+"Copy and paste this block of text into the 'private key' field in RELATE."
+msgstr "将这块文本复制粘贴到网站的\"私有密钥\"字段中."
+
+#: .\course\templates\course\keypair.html:15
+msgid "Public key:"
+msgstr "公共密钥:"
+
+#: .\course\templates\course\keypair.html:16
+msgid ""
+"On Bitbucket, GitHub, or an other repository hosting site, add this snippet "
+"as an \"SSH Key\" to your user profile or as a \"Deployment key\" to your "
+"repository."
+msgstr ""
+"在Bitbucket, Github或其它代码仓库托管网站，把这段代码设为你的用户\"SSH Key"
+"\"，或者作为你的仓库一个的\"Deployment key\"."
 
 #: .\course\templates\course\login-by-email.html:7
 msgid "Sign in or create account"
@@ -3499,11 +3649,16 @@ msgid ""
 "make sure to retain a copy."
 msgstr "一旦您离开这个页面，您输入的内容将不会保存, 请保证您保留了一个副本. "
 
-#: .\course\templates\course\sandbox-page.html:75
+#: .\course\templates\course\sandbox-page.html:39
+msgid "Warnings were encountered when validating the page:"
+msgstr "验证页面时遇到了如下的警告:"
+
+#: .\course\templates\course\sandbox-page.html:87
 msgid "(Page preview appears here)"
 msgstr "(在这里预览Page)"
 
 #: .\course\templates\course\sign-in-email.txt:2
+#, python-format
 msgid ""
 "\n"
 "Welcome to %(RELATE)s! Please click this link to sign in:\n"
@@ -3545,82 +3700,82 @@ msgstr "无效的identifier"
 msgid "invalid role '%(role)s'"
 msgstr "无效的角色 \"%(role)s\""
 
-#: .\course\validation.py:113
+#: .\course\validation.py:117
 #, python-format
 msgid "attribute '%(attr)s' missing"
 msgstr "缺少\"%(attr)s\"属性"
 
-#: .\course\validation.py:131
+#: .\course\validation.py:135
 #, python-format
 msgid ""
 "attribute '%(attr)s' has wrong type: got '%(name)s', expected '%(allowed)s'"
 msgstr "属性\"%(attr)s\"的类型错误: 设置为\"%(name)s\", 应该为\"%(allowed)s\""
 
-#: .\course\validation.py:146
+#: .\course\validation.py:150
 #, python-format
 msgid "extraneous attribute(s) '%(attr)s'"
 msgstr "冗余的外部属性 \"%(attr)s\""
 
-#: .\course\validation.py:248
+#: .\course\validation.py:252
 msgid "Uses deprecated 'start' attribute--use 'if_after' instead"
 msgstr "使用了已淘汰的(deprecated)\"start'属性 -- 建议改为使用'if_after\""
 
-#: .\course\validation.py:254
+#: .\course\validation.py:258
 msgid "Uses deprecated 'end' attribute--use 'if_before' instead"
 msgstr "使用了已淘汰的(deprecated)\"end'属性 -- 建议改为使用'if_before\""
 
-#: .\course\validation.py:260
+#: .\course\validation.py:264
 msgid "Uses deprecated 'roles' attribute--use 'if_has_role' instead"
 msgstr "使用了已淘汰的(deprecated)\"roles'属性 -- 建议改为使用'if_has_role\""
 
-#: .\course\validation.py:320
+#: .\course\validation.py:324
 #, python-format
 msgid "chunk id '%(chunkid)s' not unique"
 msgstr "chunk id \"%(chunkid)s\" 应是唯一的"
 
-#: .\course\validation.py:337
+#: .\course\validation.py:341
 msgid "flow page has no ID"
 msgstr "flow page没有ID"
 
-#: .\course\validation.py:355
+#: .\course\validation.py:359
 msgid "could not instantiate flow page"
 msgstr "无法初始化flow page"
 
-#: .\course\validation.py:391
+#: .\course\validation.py:395
 #, python-format
 msgid "group '%(group_id)s': group is empty"
 msgstr "group \"%(group_id)s\": group 是空的"
 
-#: .\course\validation.py:398
+#: .\course\validation.py:402
 #, python-format
 msgid "group '%(group_id)s': max_page_count is not positive"
 msgstr "group \"%(group_id)s\": max_page_count 不是正数"
 
-#: .\course\validation.py:411
+#: .\course\validation.py:415
 #, python-format
 msgid "page id '%(page_desc_id)s' not unique"
 msgstr "page id \"%(page_desc_id)s\" 应是唯一的"
 
-#: .\course\validation.py:460
+#: .\course\validation.py:464
 msgid "attribute 'may_start_new_session' is not present"
 msgstr "没有找到\"may_start_new_session\"属性"
 
-#: .\course\validation.py:464
+#: .\course\validation.py:468
 msgid "attribute 'may_list_existing_sessions' is not present"
 msgstr "没有找到\"may_list_existing_sessions\"属性"
 
-#: .\course\validation.py:475 .\course\validation.py:515
-#: .\course\validation.py:576
+#: .\course\validation.py:480 .\course\validation.py:520
+#: .\course\validation.py:581
 #, python-format
 msgid "invalid tag '%(tag)s'"
 msgstr "无效的 tag \"%(tag)s\""
 
-#: .\course\validation.py:524
+#: .\course\validation.py:529
 #, python-format
 msgid "invalid expiration mode '%(expiremode)s'"
 msgstr "无效的过期模式 \"%(expiremode)s\""
 
-#: .\course\validation.py:589
+#: .\course\validation.py:594
 #, python-format
 msgid ""
 "grading rule that have a grade identifier (%(type)s: %(identifier)s) must "
@@ -3628,15 +3783,15 @@ msgid ""
 msgstr ""
 "设置了(%(type)s %(identifier)s)的评分规则, 必须有grade_aggregation_strategy"
 
-#: .\course\validation.py:601
+#: .\course\validation.py:606
 msgid "invalid grade aggregation strategy"
 msgstr "无效的多session评分累积策略"
 
-#: .\course\validation.py:662
+#: .\course\validation.py:667
 msgid "rules/grading: last grading rule must be unconditional"
 msgstr "rules/grading: 最后一个grading rule必须是无条件的"
 
-#: .\course\validation.py:672
+#: .\course\validation.py:677
 msgid ""
 "Uses deprecated 'modify' permission--replace by 'submit_answer' and "
 "'end_session'"
@@ -3644,7 +3799,7 @@ msgstr ""
 "使用了已淘汰的(deprecated)权限\"modify\" -- 请改为"
 "\"submit_answer'和'end_session\""
 
-#: .\course\validation.py:678
+#: .\course\validation.py:683
 msgid ""
 "Uses deprecated 'see_answer' permission--replace by "
 "'see_answer_after_submission'"
@@ -3652,33 +3807,33 @@ msgstr ""
 "使用了已淘汰的(deprecated)权限\"see_answer\" -- 请改为"
 "\"see_answer_after_submission\""
 
-#: .\course\validation.py:685
+#: .\course\validation.py:690
 #, python-format
 msgid "invalid flow permission '%(permission)s'"
 msgstr "无效的flow权限 \"%(permission)s\""
 
-#: .\course\validation.py:724
+#: .\course\validation.py:729
 #, python-format
 msgid "group %(group_index)d ('%(group_id)d'): no pages found"
 msgstr "group %(group_index)d (%(group_id)d): 找不到page"
 
-#: .\course\validation.py:732
+#: .\course\validation.py:737
 #, python-format
 msgid "%s: no pages found"
 msgstr "%s: 找不到page"
 
-#: .\course\validation.py:745
+#: .\course\validation.py:750
 #, python-format
 msgid "group id '%(group_id)s' not unique"
 msgstr "group id \"%(group_id)s\" 应该是唯一的"
 
-#: .\course\validation.py:840
+#: .\course\validation.py:883
 msgid ""
 "invalid flow name. Flow names may only contain (roman) letters, numbers, "
 "dashes and underscores."
 msgstr "无效的flow名称. flow的名称只能有英文字母、数字、减号和下划线. "
 
-#: .\course\validation.py:935
+#: .\course\validation.py:983
 msgid "WARNINGS: "
 msgstr "警告："
 
@@ -3690,225 +3845,225 @@ msgstr "验证并创建课程"
 msgid "only staff may create courses"
 msgstr "只有课程管理人员(staff)及以上才能创建课程"
 
-#: .\course\versioning.py:190
+#: .\course\versioning.py:197
 msgid "Course content validated, creation succeeded."
 msgstr "课程内容有效性验证完成, 创建成功. "
 
-#: .\course\versioning.py:216
+#: .\course\versioning.py:223
 #, python-format
 msgid "Failed to delete unused repository directory '%s'."
 msgstr "无法删除未使用的代码仓库目录\"%s\"."
 
-#: .\course\versioning.py:228
+#: .\course\versioning.py:235
 msgid "Course creation failed"
 msgstr "课程创建失败"
 
-#: .\course\versioning.py:276
+#: .\course\versioning.py:282
 msgid "no git source URL specified"
 msgstr "未设定git源的URL"
 
-#: .\course\versioning.py:285
+#: .\course\versioning.py:291
 msgid "fetch would discard commits, refusing"
 msgstr "fetch将会放弃修改, 拒绝fetch"
 
-#: .\course\versioning.py:289
+#: .\course\versioning.py:295
 msgid "Fetch successful."
 msgstr "fetch成功. "
 
-#: .\course\versioning.py:295
+#: .\course\versioning.py:301
 msgid "Preview ended."
 msgstr "预览已结束. "
 
-#: .\course\versioning.py:310
+#: .\course\versioning.py:316
 #, python-format
 msgid "Course content did not validate successfully. (%s) Update not applied."
 msgstr "课程内容有效性验证不成功, (%s) 未应用更新. "
 
-#: .\course\versioning.py:317
+#: .\course\versioning.py:323
 msgid "Course content validated successfully."
 msgstr "课程内容有效性验证成功. "
 
-#: .\course\versioning.py:321
+#: .\course\versioning.py:327
 msgid "Course content validated OK, with warnings: "
 msgstr "课程内容有效性验证成功, 但有警告信息:"
 
-#: .\course\versioning.py:332
+#: .\course\versioning.py:338
 msgid "Preview activated."
 msgstr "预览状态已激活. "
 
-#: .\course\versioning.py:343
+#: .\course\versioning.py:349
 msgid "Update applied. "
 msgstr "更新已应用. "
 
-#: .\course\versioning.py:346 .\course\versioning.py:412 .\course\views.py:649
+#: .\course\versioning.py:352 .\course\versioning.py:425 .\course\views.py:699
 msgid "invalid command"
 msgstr "无效的命令"
 
-#: .\course\versioning.py:353
+#: .\course\versioning.py:359
 msgctxt "new git SHA for revision of course contents"
 msgid "New git SHA"
 msgstr "新的git SHA"
 
-#: .\course\versioning.py:369
+#: .\course\versioning.py:375
 msgid "Fetch and update"
 msgstr "fetch并更新"
 
-#: .\course\versioning.py:373
+#: .\course\versioning.py:379
 msgid "End preview"
 msgstr "结束预览"
 
-#: .\course\versioning.py:375
+#: .\course\versioning.py:381
 msgid "Fetch and preview"
 msgstr "fetch并预览"
 
-#: .\course\versioning.py:387
+#: .\course\versioning.py:393
 msgid "must be instructor or TA to update course"
 msgstr "只有任课老师(instructor)和助理(TA)可以更新课程"
 
-#: .\course\versioning.py:439
+#: .\course\versioning.py:453
 msgid "Current git HEAD"
 msgstr "当前的git HEAD"
 
-#: .\course\versioning.py:446
+#: .\course\versioning.py:460
 msgid "Public active git SHA"
 msgstr "公开运行的git SHA"
 
-#: .\course\versioning.py:459 .\course\versioning.py:471
+#: .\course\versioning.py:473 .\course\versioning.py:485
 msgid "Current preview git SHA"
 msgstr "当前预览的git SHA"
 
-#: .\course\versioning.py:473
+#: .\course\versioning.py:487
 msgid "None"
 msgstr "无"
 
-#: .\course\versioning.py:481
+#: .\course\versioning.py:495
 msgid "Update Course Revision"
 msgstr "更新对课程内容的修订"
 
-#: .\course\views.py:123
+#: .\course\views.py:124
 msgid "only course staff have access"
 msgstr "只有课程管理人员(staff)可以访问"
 
-#: .\course\views.py:126
+#: .\course\views.py:127
 msgid "only the instructor has access"
 msgstr "只有任课老师(instructor)可能访问"
 
-#: .\course\views.py:148
+#: .\course\views.py:149
 msgid ""
 "Your enrollment request is pending. You will be notified once it has been "
 "acted upon."
 msgstr "您的加入课程申请处于等待状态, 如果该申请被受理, 您将会立即收到通知. "
 
 #. Translators: "set" fake time.
-#: .\course\views.py:233
+#: .\course\views.py:283
 msgid "Set"
 msgstr "设定"
 
 #. Translators: "unset" fake time.
-#: .\course\views.py:236
+#: .\course\views.py:286
 msgid "Unset"
 msgstr "恢复正常"
 
-#: .\course\views.py:264
+#: .\course\views.py:314
 msgid "only staff may set fake time"
 msgstr "只有课程管理人员(staff)及以上可以设置虚拟时间"
 
-#: .\course\views.py:288 .\relate\templates\base.html:80
+#: .\course\views.py:338 .\relate\templates\base.html:80
 msgid "Set fake time"
 msgstr "设置虚拟时间"
 
-#: .\course\views.py:313
+#: .\course\views.py:363
 msgctxt "Duration for instant flow"
 msgid "Duration in minutes"
 msgstr "时长(分钟)"
 
-#: .\course\views.py:318
+#: .\course\views.py:368
 msgctxt "Add an instant flow"
 msgid "Add"
 msgstr "添加"
 
-#: .\course\views.py:323
+#: .\course\views.py:373
 msgctxt "Cancel all instant flow(s)"
 msgid "Cancel all"
 msgstr "全部取消"
 
-#: .\course\views.py:330
+#: .\course\views.py:380
 msgid "must be instructor to manage instant flow requests"
 msgstr "只有任课老师(instructor)才能管理即时flow"
 
-#: .\course\views.py:377
+#: .\course\views.py:427
 msgid "Manage Instant Flow Requests"
 msgstr "管理即时Flow"
 
-#: .\course\views.py:399
+#: .\course\views.py:449
 msgctxt "Start an activity"
 msgid "Go"
 msgstr "前往"
 
-#: .\course\views.py:409
+#: .\course\views.py:459
 msgid "must be instructor or TA to test flows"
 msgstr "只有任课老师(instructor)和助理(TA)可以测试flow"
 
-#: .\course\views.py:430
+#: .\course\views.py:480
 msgid "Test Flow"
 msgstr "测试flow"
 
-#: .\course\views.py:462
+#: .\course\views.py:512
 msgid "Select participant for whom exception is to be granted."
 msgstr "选择需要给予破例的用户. "
 
-#: .\course\views.py:475 .\course\views.py:566
+#: .\course\views.py:525 .\course\views.py:616
 msgctxt "Next step"
 msgid "Next"
 msgstr "下一步"
 
-#: .\course\views.py:486 .\course\views.py:577 .\course\views.py:789
+#: .\course\views.py:536 .\course\views.py:627 .\course\views.py:839
 msgid "must be instructor or TA to grant exceptions"
 msgstr "只有任课老师(instructor)和助理(TA)可以进行破例评分"
 
-#: .\course\views.py:506 .\course\views.py:684 .\course\views.py:956
+#: .\course\views.py:556 .\course\views.py:734 .\course\views.py:1006
 msgid "Grant Exception"
 msgstr "给予破例"
 
 #. Translators: %s is the string of the start time of a session.
-#: .\course\views.py:513
+#: .\course\views.py:563
 #, python-format
 msgid "started at %s"
 msgstr "开始于%s"
 
-#: .\course\views.py:530
+#: .\course\views.py:580
 msgid ""
 "If you click 'Create session', this tag will be applied to the new session."
 msgstr "如果您点击\"创建session\", 这个tag将会应用到新的session. "
 
-#: .\course\views.py:532
+#: .\course\views.py:582
 msgid "Access rules tag for new session"
 msgstr "新session的访问规则tag"
 
-#: .\course\views.py:538
+#: .\course\views.py:588
 msgid "Create session (override rules)"
 msgstr "创建session(覆盖rules)"
 
-#: .\course\views.py:544
+#: .\course\views.py:594
 msgid "Create session"
 msgstr "创建session"
 
-#: .\course\views.py:556
+#: .\course\views.py:606
 msgid ""
 "The rules that currently apply to selected session will provide the default "
 "values for the rules on the next page."
 msgstr "选定session所采用的rule将为作为下一个page所采用rule的默认值. "
 
-#: .\course\views.py:586
+#: .\course\views.py:636
 #, python-format
 msgid "Granting exception to '%(participation)s' for '%(flow_id)s'."
 msgstr "对%(participation)s的%(flow_id)s给予破例."
 
-#: .\course\views.py:607 .\course\views.py:611
+#: .\course\views.py:657 .\course\views.py:661
 msgid "NONE"
 msgstr "无"
 
-#: .\course\views.py:621
+#: .\course\views.py:671
 msgid ""
 "Creating a new session is (technically) not allowed by course rules. "
 "Clicking 'Create Session' anyway will override this rule."
@@ -3916,12 +4071,12 @@ msgstr ""
 "根据课程的设定, (从技术上)不允许创建一个新的session. 点击\"创建session\"将覆"
 "盖掉这个规则. "
 
-#: .\course\views.py:694
+#: .\course\views.py:744
 msgctxt "Time when access expires"
 msgid "Access expires"
 msgstr "访问到期时间"
 
-#: .\course\views.py:695
+#: .\course\views.py:745
 msgid ""
 "At the specified time, the special access granted below will expire and "
 "revert to being the same as for the rest of the class. This field may be "
@@ -3934,19 +4089,19 @@ msgstr ""
 "date\"和'credit percent\"也不会过期, 并且始终保持有效, 除非被其它的破例措施覆"
 "盖. "
 
-#: .\course\views.py:720
+#: .\course\views.py:770
 msgid "Exception only applies to sessions with the above tag"
 msgstr "只有有以上tag的session才能采取破例措施. "
 
-#: .\course\views.py:739
+#: .\course\views.py:789
 msgid "If set, the 'Due' field will be disregarded."
 msgstr "如果选定, 则“截止时间”的设定将不被考虑. "
 
-#: .\course\views.py:742
+#: .\course\views.py:792
 msgid "Due same as access expiration"
 msgstr "访问到期，则截止"
 
-#: .\course\views.py:747
+#: .\course\views.py:797
 msgid ""
 "The due time shown to the student. Also, the time after which any session "
 "under these rules is subject to expiration."
@@ -3955,44 +4110,48 @@ msgstr ""
 "date shown to the student. Also, the time after which any session under "
 "these rules is subject to expiration. "
 
-#: .\course\views.py:755
+#: .\course\views.py:805
 msgid "Credit percent"
 msgstr "得分百分比"
 
-#: .\course\views.py:768
+#: .\course\views.py:818
 msgid "Save"
 msgstr "保存"
 
-#: .\course\views.py:778
+#: .\course\views.py:828
 msgid ""
 "Must specify access expiration if 'due same as access expiration' is set."
 msgstr ""
 "如果设定了与访问同时截止(due same as access expiration), 则必须确定访问截止时"
 "间(access expiration). "
 
-#: .\course\views.py:850 .\course\views.py:917
+#: .\course\views.py:900 .\course\views.py:967
 msgid "newly created exception"
 msgstr "新创建的破例"
 
-#: .\course\views.py:879
+#: .\course\views.py:929
 msgid "Granted excecption"
 msgstr "已给予破例"
 
-#: .\course\views.py:881
+#: .\course\views.py:931
 msgid "credit"
 msgstr "应得分"
 
-#: .\course\views.py:933
+#: .\course\views.py:983
 #, python-format
 msgid "Exception granted to '%(participation)s' for '%(flow_id)s'."
 msgstr "已对%(participation)s的%(flow_id)s给予破例. "
 
-#: .\course\views.py:959
+#: .\course\views.py:1009
 #, python-format
 msgid ""
 "Granting exception to '%(participation)s' for '%(flow_id)s' (session %"
 "(session)s)."
 msgstr "对%(participation)s的%(flow_id)s(%(session)s的session)给予破例."
+
+#: .\course\views.py:1026
+msgid "only staff may use this tool"
+msgstr "只有课程管理人员可以使用这个工具"
 
 #: .\relate\templates\403.html:5
 msgid "403 Forbidden"

--- a/locale/zh_CN/LC_MESSAGES/django.po
+++ b/locale/zh_CN/LC_MESSAGES/django.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-08-25 16:12+0800\n"
+"POT-Creation-Date: 2015-08-25 17:02+0800\n"
 "Last-Translator:  Dong Zhuang <dzhuang.scut@gmail.com>\n"
 "Language-Team: Dong Zhuang <dzhuang.scut@gmail.com>\n"
 "MIME-Version: 1.0\n"
@@ -170,40 +170,37 @@ msgstr "登录"
 msgid "Username"
 msgstr "用户名"
 
-#: .\course\auth.py:288
-msgid "Required. 30 characters or fewer. Letters, digits and @/./+/-/_ only."
-msgstr ""
-
-#: .\course\auth.py:293
+#: .\course\auth.py:291
 msgid "Enter a valid username."
 msgstr ""
 
-#: .\course\auth.py:294
-msgid ""
-"Enter a valid username. This value may contain only letters, numbers and @/./"
-msgstr ""
+#: .\course\auth.py:292
+#, fuzzy
+#| msgid "Identifier may only contain letters, numbers, and hypens ('-')."
+msgid "This value may contain only letters, numbers and @/./+/-/_ characters."
+msgstr "Identifier只能包含英文字母, 数字, 和中划线（即减号\"-\"). "
 
-#: .\course\auth.py:308 .\course\auth.py:393
+#: .\course\auth.py:306 .\course\auth.py:391
 msgid "Send email"
 msgstr "发送邮件"
 
-#: .\course\auth.py:315 .\course\auth.py:399
+#: .\course\auth.py:313 .\course\auth.py:397
 msgid "password-based sign-in is not being used"
 msgstr "用户名密码模式未启用"
 
-#: .\course\auth.py:325
+#: .\course\auth.py:323
 msgid "A user with that username already exists."
 msgstr ""
 
-#: .\course\auth.py:330
+#: .\course\auth.py:328
 #, python-format
 msgid ""
 "That email address is already in use. Would you like to <a href='%s'>reset "
 "your password</a> instead?"
 msgstr "该电子邮件已经注册, 您是否需要 <a href='%s'>重置密码</a> ？"
 
-#: .\course\auth.py:365 .\course\auth.py:434 .\course\auth.py:450
-#: .\course\auth.py:523 .\course\auth.py:582
+#: .\course\auth.py:363 .\course\auth.py:432 .\course\auth.py:448
+#: .\course\auth.py:521 .\course\auth.py:580
 #: .\course\templates\course\analytics-flow.html:5
 #: .\course\templates\course\analytics-flows.html:5
 #: .\course\templates\course\analytics-page.html:5
@@ -232,91 +229,91 @@ msgstr "该电子邮件已经注册, 您是否需要 <a href='%s'>重置密码</
 msgid "RELATE"
 msgstr "RELATE"
 
-#: .\course\auth.py:366
+#: .\course\auth.py:364
 msgid "Verify your email"
 msgstr "验证您的电子邮件"
 
-#: .\course\auth.py:372 .\course\auth.py:441 .\course\auth.py:588
+#: .\course\auth.py:370 .\course\auth.py:439 .\course\auth.py:586
 msgid "Email sent. Please check your email and click the link."
 msgstr "Email已发送, 请进入邮箱并点击相关的链接. "
 
-#: .\course\auth.py:381
+#: .\course\auth.py:379
 msgid "Sign up"
 msgstr "注册"
 
-#: .\course\auth.py:387 .\course\auth.py:533 .\course\models.py:408
+#: .\course\auth.py:385 .\course\auth.py:531 .\course\models.py:408
 msgid "Email"
 msgstr "Email"
 
-#: .\course\auth.py:414
+#: .\course\auth.py:412
 msgid ""
 "That email address doesn't have an associated user account. Are you sure "
 "you've registered?"
 msgstr ""
 
-#: .\course\auth.py:435
+#: .\course\auth.py:433
 msgid "Password reset"
 msgstr "密码重置"
 
-#: .\course\auth.py:449 .\course\auth.py:522
+#: .\course\auth.py:447 .\course\auth.py:520
 #, python-format
 msgid "Password reset on %(site_name)s"
 msgstr ""
 
-#: .\course\auth.py:457
+#: .\course\auth.py:455
 msgid "Password"
 msgstr "密码"
 
-#: .\course\auth.py:459
+#: .\course\auth.py:457
 msgid "Password confirmation"
 msgstr ""
 
-#: .\course\auth.py:465 .\course\auth.py:646 .\course\auth.py:659
+#: .\course\auth.py:463 .\course\auth.py:644 .\course\auth.py:657
 #: .\course\templates\course\course-page.html:30
 #: .\course\templates\course\home.html:22 .\course\versioning.py:376
 msgid "Update"
 msgstr "更新"
 
-#: .\course\auth.py:474
+#: .\course\auth.py:472
 msgid "The two password fields didn't match."
 msgstr ""
 
-#: .\course\auth.py:479 .\course\auth.py:545 .\course\auth.py:602
+#: .\course\auth.py:477 .\course\auth.py:543 .\course\auth.py:600
 msgid "email-based sign-in is not being used"
 msgstr "基于邮件链接登录的方式未启用"
 
-#: .\course\auth.py:483 .\course\auth.py:608
+#: .\course\auth.py:481 .\course\auth.py:606
 msgid "Invalid sign-in token. Perhaps you've used an old token email?"
 msgstr "登录链接无效, 您可能使用了一个旧邮件中的链接？"
 
-#: .\course\auth.py:485 .\course\auth.py:493 .\course\auth.py:498
-#: .\course\auth.py:610 .\course\auth.py:615
+#: .\course\auth.py:483 .\course\auth.py:491 .\course\auth.py:496
+#: .\course\auth.py:608 .\course\auth.py:613
 msgid "invalid sign-in token"
 msgstr "登录链接无效"
 
-#: .\course\auth.py:497 .\course\auth.py:614
+#: .\course\auth.py:495 .\course\auth.py:612
 msgid "Account disabled."
 msgstr "帐户已禁用. "
 
-#: .\course\auth.py:508 .\course\auth.py:621
+#: .\course\auth.py:506 .\course\auth.py:619
 msgid ""
 "Successfully signed in. Please complete your registration information below."
 msgstr "成功登录, 请在下面完善您的注册信息. "
 
-#: .\course\auth.py:515 .\course\auth.py:628
+#: .\course\auth.py:513 .\course\auth.py:626
 msgid "Successfully signed in."
 msgstr "成功登录. "
 
-#: .\course\auth.py:539
+#: .\course\auth.py:537
 msgid "Send sign-in email"
 msgstr "发送登录邮件"
 
-#: .\course\auth.py:582
+#: .\course\auth.py:580
 #, python-format
 msgid "Your %(RELATE)s sign-in link"
 msgstr "您的%(RELATE)s登录链接"
 
-#: .\course\auth.py:680 .\course\auth.py:690
+#: .\course\auth.py:678 .\course\auth.py:688
 msgid "Profile data saved."
 msgstr "用户信息已更新. "
 


### PR DESCRIPTION
1. Currently, user name allow any kind of string, including spaces and non-ascii characters. However, that will cause errors in Admin: ``Enter a valid username. This value may contain only letters, numbers and @/./+/-/_ characters.`` The PR use django default validators to fix the problem, from [line 291](https://github.com/inducer/relate/pull/56/files#diff-c2451d72ff86377e6511c9368f632f0bR291). What's more, some literals changed to those of django default, so that stock translations are provided for most languages for those literals (see [here](https://github.com/django/django/tree/8047e3666b0b50bb04e6f16c2a4fb21ddfd5713f/django/contrib/auth/locale)).

1. Fix bug on [line 404](https://github.com/inducer/relate/compare/inducer:master...dzhuang:user_name_validation?expand=1#diff-c2451d72ff86377e6511c9368f632f0bL404) when providing a non-exist email for resetting password, which will cause errors.

1. Update i18n for new literals.
