### PR TITLE
Add option to preview off of preview

### DIFF
--- a/course/versioning.py
+++ b/course/versioning.py
@@ -497,9 +497,9 @@ class GitUpdateForm(StyledForm):
 
         if previewing:
             add_button("end_preview", _("End preview"))
-        else:
-            add_button("fetch_preview", _("Fetch and preview"))
-            add_button("preview", _("Preview"))
+
+        add_button("fetch_preview", _("Fetch and preview"))
+        add_button("preview", _("Preview"))
 
         add_button("fetch", _("Fetch"))
 


### PR DESCRIPTION
It would be nice to switch directly between previews, rather than pressing "End Preview" and then "Preview", since I often need to switch from preview to preview when debugging homework questions.  

Unless I missed something subtle, this seems to be a simple adjustment.  This patch worked fine in my local testing.