### PR TITLE
prevent two sessions in close succession, time interval = 5 sec.

### DIFF
--- a/course/flow.py
+++ b/course/flow.py
@@ -820,20 +820,32 @@ def view_start_flow(pctx, flow_id):
     fctx = FlowContext(pctx.repo, pctx.course, flow_id,
             participation=pctx.participation)
 
+    past_sessions = (FlowSession.objects
+            .filter(
+                participation=pctx.participation,
+                flow_id=fctx.flow_id,
+                participation__isnull=False)
+           .order_by("start_time"))
+
     if request.method == "POST":
-        return post_start_flow(pctx, fctx, flow_id)
+        if past_sessions:
+            latest_session = past_sessions.reverse()[0]
+
+            from datetime import timedelta
+            if ((now_datetime - latest_session.start_time)
+                    < timedelta(seconds = 5)):
+                return redirect("relate-view_flow_page",
+                    pctx.course.identifier, latest_session.id, 0)
+            else:
+                return post_start_flow(pctx, fctx, flow_id)
+        else:
+            return post_start_flow(pctx, fctx, flow_id)
     else:
         session_start_rule = get_session_start_rule(pctx.course, pctx.participation,
                 pctx.role, flow_id, fctx.flow_desc, now_datetime,
                 facilities=pctx.request.relate_facilities)
 
         if session_start_rule.may_list_existing_sessions:
-            past_sessions = (FlowSession.objects
-                    .filter(
-                        participation=pctx.participation,
-                        flow_id=fctx.flow_id,
-                        participation__isnull=False)
-                   .order_by("start_time"))
 
             from collections import namedtuple
             SessionProperties = namedtuple("SessionProperties",  # noqa

--- a/local_settings.py.example
+++ b/local_settings.py.example
@@ -58,7 +58,8 @@ EMAIL_USE_TLS = False
 ROBOT_EMAIL_FROM = "Example Admin <admin@example.com>"
 RELATE_ADMIN_EMAIL_LOCALE = "en_US"
 
-# Cool down time (seconds) before starting a new session of a flow
+# Cool down time (seconds) required before another new session of a flow
+# is allowed to be started.
 RELATE_SESSION_RESTART_COOLDOWN_SECONDS = 10
 
 SERVER_EMAIL = ROBOT_EMAIL_FROM

--- a/local_settings.py.example
+++ b/local_settings.py.example
@@ -58,6 +58,9 @@ EMAIL_USE_TLS = False
 ROBOT_EMAIL_FROM = "Example Admin <admin@example.com>"
 RELATE_ADMIN_EMAIL_LOCALE = "en_US"
 
+# Cool down time (seconds) before starting a new session of a flow
+RELATE_SESSION_RESTART_COOLDOWN_SECONDS = 10
+
 SERVER_EMAIL = ROBOT_EMAIL_FROM
 
 ADMINS = (

--- a/relate/settings.py
+++ b/relate/settings.py
@@ -164,6 +164,8 @@ RELATE_CACHE_MAX_BYTES = 32768
 
 RELATE_ADMIN_EMAIL_LOCALE = "en_US"
 
+RELATE_SESSION_RESTART_COOLDOWN_SECONDS = 10
+
 for name, val in local_settings.items():
     if not name.startswith("_"):
         globals()[name] = val


### PR DESCRIPTION
Works when JS is disabled, and when the student is not intended to multiple post the requests.