### PR TITLE
Fix unique field blank value duplication error in admin.

### DIFF
--- a/accounts/models.py
+++ b/accounts/models.py
@@ -146,6 +146,10 @@ class User(AbstractBaseUser, PermissionsMixin):
         "Returns the short name for the user."
         return self.first_name
 
+    def save(self, *args, **kwargs):
+        self.institutional_id = self.institutional_id or None
+        super(User, self).save(*args, **kwargs)
+
 # }}}
 
 # vim: foldmethod=marker


### PR DESCRIPTION
https://code.djangoproject.com/ticket/4136#comment:33

That is also the case for ``sign_in_key`` field, but that field is not displayed in admin.