### PR TITLE
Add a "retry enroll" button for qualified user to enroll again.

### DIFF
--- a/course/templates/course/course-page.html
+++ b/course/templates/course/course-page.html
@@ -29,5 +29,14 @@
       </div>
     {% endif %}
 
-  {% endif %}
+    {% if show_retry_enroll_button %}
+          <div class="well">
+            <form method="POST" action="{% url "relate-enroll" course.identifier %}">
+              {% csrf_token %}
+              <button type="submit" name="enroll" class="btn-lg btn-primary">
+                {% trans "Retry Enroll" %}&nbsp;&raquo;
+              </button>
+            </form>
+          </div>
+    {% endif %}
 {% endblock %}

--- a/course/templates/course/course-page.html
+++ b/course/templates/course/course-page.html
@@ -39,4 +39,6 @@
             </form>
           </div>
     {% endif %}
+
+  {% endif %}
 {% endblock %}


### PR DESCRIPTION
Situations for this PR: 

1. A user had tried to enroll courses which require institutional_id, while he didn't set that value in his profile. He see in the course "Your enrollment request is pending. You will be notified once it has been acted upon." After his profile is updated, however, he has no way to apply for the enrollment, as he still see "Your enrollment request is pending...".

2. A user who has a non-verified institutional_id in his profile, he had applied for enrollment of the course, pending. After his institutional id is verified, the status of this request is still pending.

The solution to this issue (similar with https://github.com/inducer/relate/issues/146) in this PR is to determine whether the user is qualified for the course **when he visit course_page again**, after changes were made to his profile, or course configurations are changed (e.g., preapprovement). If yes, he will get a button on course_page to "retry enrollment".
