### PR TITLE
Add attributes role

### DIFF
--- a/course/validation.py
+++ b/course/validation.py
@@ -1000,7 +1000,8 @@ def check_attributes_yml(vctx, repo, path, tree):
 
         loc = path + "/" + ".attributes.yml"
 
-        att_roles = ["public", "in_exam", "student"]
+        att_roles = ["public", "in_exam", "student", "ta",
+                     "unenrolled", "instructor"]
         validate_struct(vctx, loc, att_yml,
                         required_attrs=[],
                         allowed_attrs=[(role, list) for role in att_roles])

--- a/course/views.py
+++ b/course/views.py
@@ -126,9 +126,14 @@ def maintenance(request):
 # {{{ pages
 
 def check_course_state(course, role):
+    """
+    Check to see if the course is hidden.
+
+    If hidden, only allow access to 'ta' and 'instructor' roles
+    """
     if course.hidden:
         if role not in [participation_role.teaching_assistant,
-                participation_role.instructor]:
+                        participation_role.instructor]:
             raise PermissionDenied(_("only course staff have access"))
 
 
@@ -271,13 +276,26 @@ def get_current_repo_file(request, course_identifier, path):
             request, course, role, participation, commit_sha, path)
 
 
-def get_repo_file_backend(request, course, role, participation, commit_sha, path):
+def get_repo_file_backend(request, course, role, participation,
+                          commit_sha, path):
+    """
+    Check if a file should be accessible.  Then call for it if
+    the permission is not denied.
+
+    Order is important here.  An in-exam request takes precedence.
+
+    Note: an access_role of "public" is equal to "unenrolled"
+    """
+
+    # check to see if the course is hidden
     from course.views import check_course_state
     check_course_state(course, role)
 
+    # retrieve local path for the repo for the course
     repo = get_course_repo(course)
 
-    access_kind = "public"
+    # set access to public (or unenrolled), student, etc
+    access_kind = role
     if request.relate_exam_lockdown:
         access_kind = "in_exam"
 
@@ -292,8 +310,8 @@ def get_repo_file_response(repo, path, commit_sha):
     from course.content import get_repo_blob_data_cached
 
     try:
-        data = get_repo_blob_data_cached(
-                repo, path, commit_sha.encode())
+        data = get_repo_blob_data_cached(repo, path,
+                                         commit_sha.encode())
     except ObjectDoesNotExist:
         raise http.Http404()
 

--- a/doc/content.rst
+++ b/doc/content.rst
@@ -194,10 +194,14 @@ a RELATE site:
   In addition to "public", the file can also include the following
   sections:
 
-  * ``public``: Allow access to these files from anywhere on the
+  * ``public`` or ``unenrolled``: Allow access to these files from anywhere on the
     Internet, except for locked-down exam sessions.
   * ``in_exam``: Allow access to these files when a locked-down exam
     is ongoing.
+  * ``student``: Allow access to these files for ``student``, ``ta``, and
+    ``instructor`` roles
+  * ``ta``: Allow access to these files for ``ta`` and ``instructor`` roles
+  * ``instructor``: Allow access to these files only for the ``instructor`` role
 
 * The URL schema ``repocur:some/file/name.png``
   generally works the same way as ``repo:``, with these differences:


### PR DESCRIPTION
@inducer, this adds the ability to include roles in the `.attributes.yml`:
```
public:
    - test1.pdf
student:
    - test2.pdf
```

The roles are hierarchical in that `instructor` would still be able to view both `test1.pdf` and `test2.pdf` above.  And `public` cannot view `test2.pdf`.