### PR TITLE
i18n of select2

### DIFF
--- a/course/auth.py
+++ b/course/auth.py
@@ -175,10 +175,9 @@ def impersonate(request):
     else:
         form = ImpersonateForm(request.user, language=language)
 
-    return render(request, "generic-form.html", {
+    return render(request, "select2-form.html", {
         "form_description": _("Impersonate user"),
-        "form": form,
-        "select2_i18n": True
+        "form": form
         })
 
 

--- a/course/auth.py
+++ b/course/auth.py
@@ -124,6 +124,7 @@ class ImpersonateMiddleware(object):
 
 class ImpersonateForm(StyledForm):
     def __init__(self, impersonator, *args, **kwargs):
+        language = kwargs.pop("language", None)
         super(ImpersonateForm, self).__init__(*args, **kwargs)
 
         impersonees = whom_may_impersonate(impersonator)
@@ -145,7 +146,7 @@ class ImpersonateForm(StyledForm):
                     ],
                 required=True,
                 help_text=_("Select user to impersonate."),
-                widget=Select2Widget(),
+                widget=Select2Widget(attrs={"data-language": language}),
                 label=_("User"))
 
         self.helper.add_input(Submit("submit", _("Impersonate")))
@@ -153,13 +154,17 @@ class ImpersonateForm(StyledForm):
 
 @user_passes_test(may_impersonate)
 def impersonate(request):
+    from relate.utils import to_js_lang_name
+    language = to_js_lang_name(request.LANGUAGE_CODE)
+
     if hasattr(request, "relate_impersonate_original_user"):
         messages.add_message(request, messages.ERROR,
                 _("Already impersonating someone."))
         return redirect("relate-stop_impersonating")
 
     if request.method == 'POST':
-        form = ImpersonateForm(request.user, request.POST)
+        form = ImpersonateForm(request.user, request.POST,
+                language=language)
         if form.is_valid():
             user = get_user_model().objects.get(id=form.cleaned_data["user"])
 
@@ -168,11 +173,12 @@ def impersonate(request):
             # Because we'll likely no longer have access to this page.
             return redirect("relate-home")
     else:
-        form = ImpersonateForm(request.user)
+        form = ImpersonateForm(request.user, language=language)
 
     return render(request, "generic-form.html", {
         "form_description": _("Impersonate user"),
-        "form": form
+        "form": form,
+        "select2_i18n": True
         })
 
 

--- a/course/exam.py
+++ b/course/exam.py
@@ -170,11 +170,10 @@ def issue_exam_ticket(request):
     else:
         form = IssueTicketForm(language=language)
 
-    return render(request, "generic-form.html", {
+    return render(request, "select2-form.html", {
         "form_description":
             _("Issue Exam Ticket"),
         "form": form,
-        "select2_i18n": True,
         })
 
 # }}}

--- a/course/exam.py
+++ b/course/exam.py
@@ -83,6 +83,7 @@ class UserChoiceField(forms.ModelChoiceField):
 class IssueTicketForm(StyledForm):
     def __init__(self, *args, **kwargs):
         initial_exam = kwargs.pop("initial_exam", None)
+        language = kwargs.pop("language", None)
 
         super(IssueTicketForm, self).__init__(*args, **kwargs)
 
@@ -92,7 +93,7 @@ class IssueTicketForm(StyledForm):
                         is_active=True,
                         )
                     .order_by("last_name")),
-                widget=Select2Widget(),
+                widget=Select2Widget(attrs={"data-language": language}),
                 required=True,
                 help_text=_("Select participant for whom ticket is to "
                 "be issued."),
@@ -118,6 +119,9 @@ class IssueTicketForm(StyledForm):
 
 @permission_required("course.can_issue_exam_tickets")
 def issue_exam_ticket(request):
+    from relate.utils import to_js_lang_name
+    language = to_js_lang_name(request.LANGUAGE_CODE)
+
     if request.method == "POST":
         form = IssueTicketForm(request.POST)
 
@@ -161,15 +165,16 @@ def issue_exam_ticket(request):
                             ) % {"participation": participation,
                                  "ticket_code": ticket.code})
 
-                form = IssueTicketForm(initial_exam=exam)
+                form = IssueTicketForm(initial_exam=exam, language=language)
 
     else:
-        form = IssueTicketForm()
+        form = IssueTicketForm(language=language)
 
     return render(request, "generic-form.html", {
         "form_description":
             _("Issue Exam Ticket"),
         "form": form,
+        "select2_i18n": True,
         })
 
 # }}}

--- a/course/templates/course/gradebook-by-opp.html
+++ b/course/templates/course/gradebook-by-opp.html
@@ -153,13 +153,14 @@
     </tbody>
   </table>
 
-  {% get_current_language as LANGUAGE_CODE %}
+  {% load coursetags %}
+  {% get_current_js_lang_name as LANG %}
   <script type="text/javascript">
     var tbl = $("table.gradebook-by-opportunity").dataTable({
         "scrollCollapse": true,
         "paging": false,
         "ordering": true,
-        "language": {url: '{% static "datatables-i18n/i18n/" %}{{LANGUAGE_CODE}}.json'},
+        "language": {url: '{% static "datatables-i18n/i18n/" %}{{LANG}}.json'},
     } );
   </script>
 

--- a/course/templates/course/gradebook-opp-list.html
+++ b/course/templates/course/gradebook-opp-list.html
@@ -55,13 +55,14 @@
     </tbody>
   </table>
 
-  {% get_current_language as LANGUAGE_CODE %}
+  {% load coursetags %}
+  {% get_current_js_lang_name as LANG %}
   <script type="text/javascript">
     var tbl = $("table.gradebook-opportunities").dataTable({
         "scrollCollapse": true,
         "paging": false,
         "ordering": true,
-        "language": {url: '{% static "datatables-i18n/i18n/" %}{{LANGUAGE_CODE}}.json'},
+        "language": {url: '{% static "datatables-i18n/i18n/" %}{{LANG}}.json'},
     } );
   </script>
 

--- a/course/templates/course/gradebook-participant.html
+++ b/course/templates/course/gradebook-participant.html
@@ -77,12 +77,13 @@
     </tbody>
   </table>
 
-  {% get_current_language as LANGUAGE_CODE %}
+  {% load coursetags %}
+  {% get_current_js_lang_name as LANG %}
   <script type="text/javascript">
     var tbl = $("table.gradebook-single").dataTable({
         "scrollCollapse": true,
         "paging": false,
-        "language": {url: '{% static "datatables-i18n/i18n/" %}{{LANGUAGE_CODE}}.json'},
+        "language": {url: '{% static "datatables-i18n/i18n/" %}{{LANG}}.json'},
     } );
   </script>
 

--- a/course/templates/course/gradebook.html
+++ b/course/templates/course/gradebook.html
@@ -43,15 +43,15 @@
     </tbody>
   </table>
 
-  {% load static %}
-  {% get_current_language as LANGUAGE_CODE %}
+  {% load static coursetags %}
+  {% get_current_js_lang_name as LANG %}
   <script type="text/javascript">
     var tbl = $("table.gradebook").dataTable({
         "scrollX": true,
         "scrollCollapse": true,
         "paging": true,
         "ordering": false,
-        "language": {url: '{% static "datatables-i18n/i18n/" %}{{LANGUAGE_CODE}}.json'},
+        "language": {url: '{% static "datatables-i18n/i18n/" %}{{LANG}}.json'},
     } );
     new $.fn.dataTable.FixedColumns(tbl);
   </script>

--- a/course/templates/course/participation-table.html
+++ b/course/templates/course/participation-table.html
@@ -25,13 +25,13 @@
   </tbody>
 </table>
 
-{% load static %}
-{% get_current_language as LANGUAGE_CODE %}
+{% load static coursetags %}
+{% get_current_js_lang_name as LANG %}
 <script type="text/javascript">
   var tbl = $("table.gradebook-participants").dataTable({
       "scrollCollapse": true,
       "paging": false,
       "ordering": true,
-      "language": {url: '{% static "datatables-i18n/i18n/" %}{{LANGUAGE_CODE}}.json'},
+      "language": {url: '{% static "datatables-i18n/i18n/" %}{{LANG}}.json'},
   } );
 </script>

--- a/course/templates/course/select2-course-form.html
+++ b/course/templates/course/select2-course-form.html
@@ -1,0 +1,8 @@
+{% extends "course/generic-course-form.html" %}
+{% load i18n %}
+
+{% block header_extra %}
+    {% load static coursetags %}
+    {% get_current_js_lang_name as LANG %}
+    <script src='{% static "select2/dist/js/i18n/" %}{{LANG}}.js'></script>
+{% endblock %}

--- a/course/templatetags/coursetags.py
+++ b/course/templatetags/coursetags.py
@@ -24,21 +24,11 @@ THE SOFTWARE.
 
 from django.template import Library, Node, TemplateSyntaxError
 from django.utils import translation
+from relate.utils import to_js_lang_name
 
 register = Library()
 
 # {{{ get language_code in JS traditional naming format
-
-def to_js_lang_name(dj_lang_name):
-    """
-    Turns a django language name (en-us) into a js styled language
-    name (en-US).
-    """
-    p = dj_lang_name.find('-')
-    if p >= 0:
-        return dj_lang_name[:p].lower() + '-' + dj_lang_name[p + 1:].upper()
-    else:
-        return dj_lang_name.lower()
 
 class GetCurrentLanguageJsFmtNode(Node):
     def __init__(self, variable):

--- a/course/templatetags/coursetags.py
+++ b/course/templatetags/coursetags.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+
+__copyright__ = "Copyright (C) 2016 Dong Zhuang, Andreas Kloeckner"
+
+__license__ = """
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"""
+
+from django.conf import settings
+from django.template import Library, Node, TemplateSyntaxError, Variable
+from django.template.defaulttags import token_kwargs
+from django.utils import six, translation
+
+register = Library()
+
+# {{{ get language_code in JS traditional naming format
+
+def to_js_lang_name(dj_lang_name):
+    """
+    Turns a django language name (en-us) into a js styled language
+    name (en-US).
+    """
+    p = dj_lang_name.find('-')
+    if p >= 0:
+        return dj_lang_name[:p].lower() + '-' + dj_lang_name[p + 1:].upper()
+    else:
+        return dj_lang_name.lower()
+
+class GetCurrentLanguageJsFmtNode(Node):
+    def __init__(self, variable):
+        self.variable = variable
+
+    def render(self, context):
+        js_lang_name = to_js_lang_name(translation.get_language())
+        context[self.variable] = js_lang_name
+        return ''
+
+@register.tag("get_current_js_lang_name")
+def do_get_current_js_lang_name(parser, token):
+    """
+    This will store the current language in the context, in js lang format.
+    This is different with built-in do_get_current_language, which returns
+    languange name like "en-us", "zh-cn", with the country code using lower
+    case. This method return lang name "en-US", "zh-CN", as most js packages
+    with i18n are providing translations using that naming format.
+
+    Usage::
+
+        {% get_current_language_js_lang_format as language %}
+
+    This will fetch the currently active language name with js tradition and
+    put it's value into the ``language`` context variable.
+    """
+    # token.split_contents() isn't useful here because this tag doesn't accept variable as arguments
+    args = token.contents.split()
+    if len(args) != 3 or args[1] != 'as':
+        raise TemplateSyntaxError("'get_current_js_lang_name' requires 'as variable' (got %r)" % args)
+    return GetCurrentLanguageJsFmtNode(args[2])
+
+# }}}

--- a/course/templatetags/coursetags.py
+++ b/course/templatetags/coursetags.py
@@ -22,10 +22,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
-from django.conf import settings
-from django.template import Library, Node, TemplateSyntaxError, Variable
-from django.template.defaulttags import token_kwargs
-from django.utils import six, translation
+from django.template import Library, Node, TemplateSyntaxError
+from django.utils import translation
 
 register = Library()
 
@@ -67,10 +65,12 @@ def do_get_current_js_lang_name(parser, token):
     This will fetch the currently active language name with js tradition and
     put it's value into the ``language`` context variable.
     """
-    # token.split_contents() isn't useful here because this tag doesn't accept variable as arguments
+    # token.split_contents() isn't useful here because this tag doesn't
+    # accept variable as arguments
     args = token.contents.split()
     if len(args) != 3 or args[1] != 'as':
-        raise TemplateSyntaxError("'get_current_js_lang_name' requires 'as variable' (got %r)" % args)
+        raise TemplateSyntaxError("'get_current_js_lang_name' requires "
+                "'as variable' (got %r)" % args)
     return GetCurrentLanguageJsFmtNode(args[2])
 
 # }}}

--- a/course/versioning.py
+++ b/course/versioning.py
@@ -618,14 +618,13 @@ def update_course(pctx):
 
     text_lines.append("</table>")
 
-    return render_course_page(pctx, "course/generic-course-form.html", {
+    return render_course_page(pctx, "course/select2-course-form.html", {
         "form": form,
         "form_text": "".join(
             "<p>%s</p>" % line
             for line in text_lines
             ),
         "form_description": ugettext("Update Course Revision"),
-        "select2_i18n": True,
     })
 
 # }}}

--- a/course/versioning.py
+++ b/course/versioning.py
@@ -427,6 +427,7 @@ def run_course_update_command(
 class GitUpdateForm(StyledForm):
 
     def __init__(self, may_update, previewing, repo, *args, **kwargs):
+        language = kwargs.pop("language", None)
         super(GitUpdateForm, self).__init__(*args, **kwargs)
 
         repo_refs = repo.get_refs()
@@ -457,7 +458,7 @@ class GitUpdateForm(StyledForm):
                     for entry in commit_iter
                     ]),
                 required=True,
-                widget=Select2Widget(),
+                widget=Select2Widget(attrs={"data-language": language}),
                 label=pgettext_lazy(
                     "new git SHA for revision of course contents",
                     "New git SHA"))
@@ -510,10 +511,13 @@ def update_course(pctx):
 
     may_update = pctx.role == participation_role.instructor
 
+    from relate.utils import to_js_lang_name
+    language = to_js_lang_name(request.LANGUAGE_CODE)
+
     response_form = None
     if request.method == "POST":
         form = GitUpdateForm(may_update, previewing, repo, request.POST,
-            request.FILES)
+            request.FILES, language=language)
         commands = ["fetch", "fetch_update", "update", "fetch_preview",
                 "preview", "end_preview"]
 
@@ -557,7 +561,7 @@ def update_course(pctx):
                 {
                     "new_sha": repo.head(),
                     "prevent_discarding_revisions": True,
-                    })
+                    }, language=language)
 
     if six.PY2:
         from cgi import escape
@@ -621,6 +625,7 @@ def update_course(pctx):
             for line in text_lines
             ),
         "form_description": ugettext("Update Course Revision"),
+        "select2_i18n": True,
     })
 
 # }}}

--- a/course/views.py
+++ b/course/views.py
@@ -695,7 +695,6 @@ def grant_exception(pctx):
     return render_course_page(pctx, "course/generic-course-form.html", {
         "form": form,
         "form_description": _("Grant Exception"),
-        "select2_i18n": True,
     })
 
 

--- a/course/views.py
+++ b/course/views.py
@@ -633,6 +633,7 @@ class ParticipationChoiceField(forms.ModelChoiceField):
 
 class ExceptionStage1Form(StyledForm):
     def __init__(self, course, flow_ids, *args, **kwargs):
+        language = kwargs.pop("language", None)
         super(ExceptionStage1Form, self).__init__(*args, **kwargs)
 
         self.fields["participation"] = ParticipationChoiceField(
@@ -646,7 +647,7 @@ class ExceptionStage1Form(StyledForm):
                 help_text=_("Select participant for whom exception is to "
                 "be granted."),
                 label=_("Participant"),
-                widget=Select2Widget())
+                widget=Select2Widget(attrs={"data-language": language}))
         self.fields["flow_id"] = forms.ChoiceField(
                 choices=[(fid, fid) for fid in flow_ids],
                 required=True,
@@ -663,6 +664,10 @@ class ExceptionStage1Form(StyledForm):
 
 @course_view
 def grant_exception(pctx):
+
+    from relate.utils import to_js_lang_name
+    language = to_js_lang_name(pctx.request.LANGUAGE_CODE)
+
     if pctx.role not in [
             participation_role.instructor,
             participation_role.teaching_assistant]:
@@ -674,7 +679,8 @@ def grant_exception(pctx):
 
     request = pctx.request
     if request.method == "POST":
-        form = ExceptionStage1Form(pctx.course, flow_ids, request.POST)
+        form = ExceptionStage1Form(pctx.course, flow_ids, request.POST,
+                language=language)
 
         if form.is_valid():
             return redirect("relate-grant_exception_stage_2",
@@ -683,11 +689,13 @@ def grant_exception(pctx):
                     form.cleaned_data["flow_id"])
 
     else:
-        form = ExceptionStage1Form(pctx.course, flow_ids)
+        form = ExceptionStage1Form(pctx.course, flow_ids, 
+                language=language)
 
     return render_course_page(pctx, "course/generic-course-form.html", {
         "form": form,
         "form_description": _("Grant Exception"),
+        "select2_i18n": True,
     })
 
 

--- a/relate/templates/base.html
+++ b/relate/templates/base.html
@@ -39,11 +39,6 @@
     <script type="text/javascript">
       videojs.options.flash.swf = "{% static "videojs/dist/video-js/video-js.swf" %}"
     </script>
-      {% if select2_i18n %}
-        {% load coursetags %}
-        {% get_current_js_lang_name as LANG %}
-        <script src='{% static "select2/dist/js/i18n/" %}{{LANG}}.js'></script>
-      {% endif %}
   </head>
 
   <body>

--- a/relate/templates/base.html
+++ b/relate/templates/base.html
@@ -39,6 +39,11 @@
     <script type="text/javascript">
       videojs.options.flash.swf = "{% static "videojs/dist/video-js/video-js.swf" %}"
     </script>
+      {% if select2_i18n %}
+        {% load coursetags %}
+        {% get_current_js_lang_name as LANG %}
+        <script src='{% static "select2/dist/js/i18n/" %}{{LANG}}.js'></script>
+      {% endif %}
   </head>
 
   <body>

--- a/relate/templates/select2-form.html
+++ b/relate/templates/select2-form.html
@@ -1,0 +1,8 @@
+{% extends "generic-form.html" %}
+{% load i18n %}
+
+{% block header_extra %}
+    {% load static coursetags %}
+    {% get_current_js_lang_name as LANG %}
+    <script src='{% static "select2/dist/js/i18n/" %}{{LANG}}.js'></script>
+{% endblock %}

--- a/relate/utils.py
+++ b/relate/utils.py
@@ -219,4 +219,20 @@ if 0:
 
 # }}}
 
+
+# {{{ convert django language name to js styled language name
+
+def to_js_lang_name(dj_lang_name):
+    """
+    Turns a django language name (en-us) into a js styled language
+    name (en-US).
+    """
+    p = dj_lang_name.find('-')
+    if p >= 0:
+        return dj_lang_name[:p].lower() + '-' + dj_lang_name[p + 1:].upper()
+    else:
+        return dj_lang_name.lower()
+
+# }}}
+
 # vim: foldmethod=marker


### PR DESCRIPTION
The i18n files of most js packages (not for django) are name using format ll-CC. ll for locale (lower case), and CC for country (Uppercase).  and django's ``get_current_language`` templatetags get a language name ll-cc.  This won't cause problem on windows machine, when loading a static i18n file from a js package, since windows console are not case sensitive. However, for linux server, it will result in 404 because it's case sensitive.

I borrowed from built-in class and created a new templatetag ``get_current_js_lang_name`` to fix the problem.