### PR TITLE
Templatetag get_current_js_lang_name and i18n of DataTables.

### DIFF
--- a/course/templates/course/gradebook-by-opp.html
+++ b/course/templates/course/gradebook-by-opp.html
@@ -153,13 +153,14 @@
     </tbody>
   </table>
 
-  {% get_current_language as LANGUAGE_CODE %}
+  {% load coursetags %}
+  {% get_current_js_lang_name as LANG %}
   <script type="text/javascript">
     var tbl = $("table.gradebook-by-opportunity").dataTable({
         "scrollCollapse": true,
         "paging": false,
         "ordering": true,
-        "language": {url: '{% static "datatables-i18n/i18n/" %}{{LANGUAGE_CODE}}.json'},
+        "language": {url: '{% static "datatables-i18n/i18n/" %}{{LANG}}.json'},
     } );
   </script>
 

--- a/course/templates/course/gradebook-opp-list.html
+++ b/course/templates/course/gradebook-opp-list.html
@@ -55,13 +55,14 @@
     </tbody>
   </table>
 
-  {% get_current_language as LANGUAGE_CODE %}
+  {% load coursetags %}
+  {% get_current_js_lang_name as LANG %}
   <script type="text/javascript">
     var tbl = $("table.gradebook-opportunities").dataTable({
         "scrollCollapse": true,
         "paging": false,
         "ordering": true,
-        "language": {url: '{% static "datatables-i18n/i18n/" %}{{LANGUAGE_CODE}}.json'},
+        "language": {url: '{% static "datatables-i18n/i18n/" %}{{LANG}}.json'},
     } );
   </script>
 

--- a/course/templates/course/gradebook-participant.html
+++ b/course/templates/course/gradebook-participant.html
@@ -77,12 +77,13 @@
     </tbody>
   </table>
 
-  {% get_current_language as LANGUAGE_CODE %}
+  {% load coursetags %}
+  {% get_current_js_lang_name as LANG %}
   <script type="text/javascript">
     var tbl = $("table.gradebook-single").dataTable({
         "scrollCollapse": true,
         "paging": false,
-        "language": {url: '{% static "datatables-i18n/i18n/" %}{{LANGUAGE_CODE}}.json'},
+        "language": {url: '{% static "datatables-i18n/i18n/" %}{{LANG}}.json'},
     } );
   </script>
 

--- a/course/templates/course/gradebook.html
+++ b/course/templates/course/gradebook.html
@@ -43,15 +43,15 @@
     </tbody>
   </table>
 
-  {% load static %}
-  {% get_current_language as LANGUAGE_CODE %}
+  {% load static coursetags %}
+  {% get_current_js_lang_name as LANG %}
   <script type="text/javascript">
     var tbl = $("table.gradebook").dataTable({
         "scrollX": true,
         "scrollCollapse": true,
         "paging": true,
         "ordering": false,
-        "language": {url: '{% static "datatables-i18n/i18n/" %}{{LANGUAGE_CODE}}.json'},
+        "language": {url: '{% static "datatables-i18n/i18n/" %}{{LANG}}.json'},
     } );
     new $.fn.dataTable.FixedColumns(tbl);
   </script>

--- a/course/templates/course/participation-table.html
+++ b/course/templates/course/participation-table.html
@@ -25,13 +25,13 @@
   </tbody>
 </table>
 
-{% load static %}
-{% get_current_language as LANGUAGE_CODE %}
+{% load static coursetags %}
+{% get_current_js_lang_name as LANG %}
 <script type="text/javascript">
   var tbl = $("table.gradebook-participants").dataTable({
       "scrollCollapse": true,
       "paging": false,
       "ordering": true,
-      "language": {url: '{% static "datatables-i18n/i18n/" %}{{LANGUAGE_CODE}}.json'},
+      "language": {url: '{% static "datatables-i18n/i18n/" %}{{LANG}}.json'},
   } );
 </script>

--- a/course/templatetags/coursetags.py
+++ b/course/templatetags/coursetags.py
@@ -24,21 +24,11 @@ THE SOFTWARE.
 
 from django.template import Library, Node, TemplateSyntaxError
 from django.utils import translation
+from relate.utils import to_js_lang_name
 
 register = Library()
 
 # {{{ get language_code in JS traditional naming format
-
-def to_js_lang_name(dj_lang_name):
-    """
-    Turns a django language name (en-us) into a js styled language
-    name (en-US).
-    """
-    p = dj_lang_name.find('-')
-    if p >= 0:
-        return dj_lang_name[:p].lower() + '-' + dj_lang_name[p + 1:].upper()
-    else:
-        return dj_lang_name.lower()
 
 class GetCurrentLanguageJsFmtNode(Node):
     def __init__(self, variable):

--- a/course/templatetags/coursetags.py
+++ b/course/templatetags/coursetags.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+
+__copyright__ = "Copyright (C) 2016 Dong Zhuang, Andreas Kloeckner"
+
+__license__ = """
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"""
+
+from django.conf import settings
+from django.template import Library, Node, TemplateSyntaxError, Variable
+from django.template.defaulttags import token_kwargs
+from django.utils import six, translation
+
+register = Library()
+
+# {{{ get language_code in JS traditional naming format
+
+def to_js_lang_name(dj_lang_name):
+    """
+    Turns a django language name (en-us) into a js styled language
+    name (en-US).
+    """
+    p = dj_lang_name.find('-')
+    if p >= 0:
+        return dj_lang_name[:p].lower() + '-' + dj_lang_name[p + 1:].upper()
+    else:
+        return dj_lang_name.lower()
+
+class GetCurrentLanguageJsFmtNode(Node):
+    def __init__(self, variable):
+        self.variable = variable
+
+    def render(self, context):
+        js_lang_name = to_js_lang_name(translation.get_language())
+        context[self.variable] = js_lang_name
+        return ''
+
+@register.tag("get_current_js_lang_name")
+def do_get_current_js_lang_name(parser, token):
+    """
+    This will store the current language in the context, in js lang format.
+    This is different with built-in do_get_current_language, which returns
+    languange name like "en-us", "zh-cn", with the country code using lower
+    case. This method return lang name "en-US", "zh-CN", as most js packages
+    with i18n are providing translations using that naming format.
+
+    Usage::
+
+        {% get_current_language_js_lang_format as language %}
+
+    This will fetch the currently active language name with js tradition and
+    put it's value into the ``language`` context variable.
+    """
+    # token.split_contents() isn't useful here because this tag doesn't accept variable as arguments
+    args = token.contents.split()
+    if len(args) != 3 or args[1] != 'as':
+        raise TemplateSyntaxError("'get_current_js_lang_name' requires 'as variable' (got %r)" % args)
+    return GetCurrentLanguageJsFmtNode(args[2])
+
+# }}}

--- a/course/templatetags/coursetags.py
+++ b/course/templatetags/coursetags.py
@@ -22,10 +22,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
-from django.conf import settings
-from django.template import Library, Node, TemplateSyntaxError, Variable
-from django.template.defaulttags import token_kwargs
-from django.utils import six, translation
+from django.template import Library, Node, TemplateSyntaxError
+from django.utils import translation
 
 register = Library()
 
@@ -67,10 +65,12 @@ def do_get_current_js_lang_name(parser, token):
     This will fetch the currently active language name with js tradition and
     put it's value into the ``language`` context variable.
     """
-    # token.split_contents() isn't useful here because this tag doesn't accept variable as arguments
+    # token.split_contents() isn't useful here because this tag doesn't
+    # accept variable as arguments
     args = token.contents.split()
     if len(args) != 3 or args[1] != 'as':
-        raise TemplateSyntaxError("'get_current_js_lang_name' requires 'as variable' (got %r)" % args)
+        raise TemplateSyntaxError("'get_current_js_lang_name' requires "
+                "'as variable' (got %r)" % args)
     return GetCurrentLanguageJsFmtNode(args[2])
 
 # }}}

--- a/relate/utils.py
+++ b/relate/utils.py
@@ -219,4 +219,20 @@ if 0:
 
 # }}}
 
+
+# {{{ convert django language name to js styled language name
+
+def to_js_lang_name(dj_lang_name):
+    """
+    Turns a django language name (en-us) into a js styled language
+    name (en-US).
+    """
+    p = dj_lang_name.find('-')
+    if p >= 0:
+        return dj_lang_name[:p].lower() + '-' + dj_lang_name[p + 1:].upper()
+    else:
+        return dj_lang_name.lower()
+
+# }}}
+
 # vim: foldmethod=marker


### PR DESCRIPTION
The i18n files of most js packages (not for django) are name using format ll-CC. ll for locale (lower case), and CC for country (Uppercase).  and django's ``get_current_language`` templatetags get a language name ll-cc.  This won't cause problem on windows machine, when loading a static i18n file from a js package, since windows console are not case sensitive. However, for linux server, it will result in 404 because it's case sensitive.

I borrowed from built-in class and created a new templatetag ``get_current_js_lang_name`` to fix the problem. 

What's more, the tag is applied to DataTables in this PR.