### PR TITLE
Sandbox: Store the page_data in the session along with the answer_data.

### DIFF
--- a/course/sandbox.py
+++ b/course/sandbox.py
@@ -127,6 +127,28 @@ def view_markup_sandbox(pctx):
 # }}}
 
 
+# {{{ page sandbox data retriever
+
+def get_sandbox_data_for_page(pctx, page_desc, key):
+    stored_data_tuple = pctx.request.session.get(key)
+
+    # Session storage uses JSON and may turn tuples into lists.
+    if (isinstance(stored_data_tuple, (list, tuple))
+            and len(stored_data_tuple) == 3):
+        stored_data_page_type, stored_data_page_id, \
+            stored_data = stored_data_tuple
+
+        if (
+                stored_data_page_type == page_desc.type
+                and
+                stored_data_page_id == page_desc.id):
+            return stored_data
+    # }}}
+    return None
+
+# }}}
+
+
 # {{{ page sandbox
 
 @course_view
@@ -143,8 +165,10 @@ def view_page_sandbox(pctx):
 
     PAGE_SESSION_KEY = (  # noqa
             "cf_validated_sandbox_page:" + pctx.course.identifier)
-    ANSWER_AND_PAGE_DATA_SESSION_KEY = (  # noqa
-        "cf_page_sandbox_answer_and_page_data:" + pctx.course.identifier)
+    ANSWER_DATA_SESSION_KEY = (  # noqa
+        "cf_page_sandbox_answer_data:" + pctx.course.identifier)
+    PAGE_DATA_SESSION_KEY = (  # noqa
+        "cf_page_sandbox_page_data:" + pctx.course.identifier)
 
     request = pctx.request
     page_source = pctx.request.session.get(PAGE_SESSION_KEY)
@@ -223,31 +247,17 @@ def view_page_sandbox(pctx):
             have_valid_page = False
 
     if have_valid_page:
-        # {{{ try to recover page_data, answer_data
+        # Try to recover page_data, answer_data
+        page_data = get_sandbox_data_for_page(
+                pctx, page_desc, PAGE_DATA_SESSION_KEY)
 
-        answer_data = None
-        page_data = None
-
-        stored_data_tuple = \
-                pctx.request.session.get(ANSWER_AND_PAGE_DATA_SESSION_KEY)
-
-        # Session storage uses JSON and may turn tuples into lists.
-        if (isinstance(stored_data_tuple, (list, tuple))
-                and len(stored_data_tuple) == 4):
-            stored_data_page_type, stored_data_page_id, stored_answer_data, \
-                    stored_page_data = stored_data_tuple
-
-            if (
-                    stored_data_page_type == page_desc.type
-                    and
-                    stored_data_page_id == page_desc.id):
-                answer_data = stored_answer_data
-                page_data   = stored_page_data
-
-        # }}}
+        answer_data = get_sandbox_data_for_page(
+                pctx, page_desc, ANSWER_DATA_SESSION_KEY)
 
         if not page_data:
             page_data = page.make_page_data()
+            pctx.request.session[PAGE_DATA_SESSION_KEY] = (
+                    page_desc.type, page_desc.id, page_data)
 
         from course.models import FlowSession
         from course.page import PageContext
@@ -289,8 +299,8 @@ def view_page_sandbox(pctx):
                     feedback = page.grade(page_context, page_data, answer_data,
                             grade_data=None)
 
-                    pctx.request.session[ANSWER_AND_PAGE_DATA_SESSION_KEY] = (
-                            page_desc.type, page_desc.id, answer_data, page_data)
+                    pctx.request.session[ANSWER_DATA_SESSION_KEY] = (
+                            page_desc.type, page_desc.id, answer_data)
 
             else:
                 page_form = page.make_form(page_context, page_data,

--- a/course/sandbox.py
+++ b/course/sandbox.py
@@ -254,7 +254,7 @@ def view_page_sandbox(pctx):
         answer_data = get_sandbox_data_for_page(
                 pctx, page_desc, ANSWER_DATA_SESSION_KEY)
 
-        if not page_data:
+        if page_data is None:
             page_data = page.make_page_data()
             pctx.request.session[PAGE_DATA_SESSION_KEY] = (
                     page_desc.type, page_desc.id, page_data)


### PR DESCRIPTION
Otherwise, the answer_data could be inconsistent with the page_data.
For instance, when sandboxing a choice question that is shuffled, the
answer_data is matched with a particular permutation which is part of
the page_data.