### PR TITLE
Raise form ValidationError when importing non-importable csv data

### DIFF
--- a/course/grades.py
+++ b/course/grades.py
@@ -925,6 +925,25 @@ class ImportGradesForm(StyledForm):
         self.helper.add_input(Submit("preview", _("Preview")))
         self.helper.add_input(Submit("import", _("Import")))
 
+    def clean(self):
+        data = super(ImportGradesForm, self).clean()
+        file_contents=data.get("file")
+        from course.utils import csv_data_importable
+        column_idx_list = [
+            data["id_column"],
+            data["points_column"],
+            data["feedback_column"]
+        ]
+        has_header=data.get("format") == "csvhead"
+        header_count = 1 if has_header else 0
+        if file_contents:
+            importable, err_msg = csv_data_importable(
+                    file_contents,
+                    column_idx_list,
+                    header_count)
+
+            if not importable:
+                self.add_error('file', err_msg)
 
 class ParticipantNotFound(ValueError):
     pass

--- a/course/grades.py
+++ b/course/grades.py
@@ -947,6 +947,7 @@ class ImportGradesForm(StyledForm):
             if not importable:
                 self.add_error('file', err_msg)
 
+
 class ParticipantNotFound(ValueError):
     pass
 

--- a/course/grades.py
+++ b/course/grades.py
@@ -928,15 +928,17 @@ class ImportGradesForm(StyledForm):
     def clean(self):
         data = super(ImportGradesForm, self).clean()
         file_contents=data.get("file")
-        from course.utils import csv_data_importable
-        column_idx_list = [
-            data["id_column"],
-            data["points_column"],
-            data["feedback_column"]
-        ]
-        has_header=data.get("format") == "csvhead"
-        header_count = 1 if has_header else 0
         if file_contents:
+            column_idx_list = [
+                data["id_column"],
+                data["points_column"],
+                data["feedback_column"]
+            ]
+            has_header=data["format"] == "csvhead"
+            header_count = 1 if has_header else 0
+
+            from course.utils import csv_data_importable
+
             importable, err_msg = csv_data_importable(
                     file_contents,
                     column_idx_list,

--- a/course/utils.py
+++ b/course/utils.py
@@ -678,4 +678,27 @@ class FacilityFindingMiddleware(object):
 
 # }}}
 
+
+def csv_data_importable(file_contents, column_idx_list, header_count):
+    import csv
+    spamreader = csv.reader(file_contents)
+    n_header_row = 0
+    for row in spamreader:
+        n_header_row += 1
+        if n_header_row <= header_count:
+            continue
+        try:
+            for column_idx in column_idx_list:
+                if column_idx is not None:
+                    six.text_type(row[column_idx-1])
+        except UnicodeDecodeError:
+            return False, (
+                    _("Error: Columns to be imported contain "
+                        "non-ASCII characters. "
+                        "Please save your CSV file as utf-8 encoded "
+                        "and import again.")
+            )
+
+    return True, ""
+
 # vim: foldmethod=marker


### PR DESCRIPTION
I failed to find a satisfying solution that can smartly detect the codec of csv files which are converted from MS Excel. The current solution is to raise form ValidationError, when user are importing csv with columns to be imported containing non-ASCII characters while the csv is not utf-8 encoded.