### PR TITLE
Display username in ImpersonateForm.

### DIFF
--- a/course/auth.py
+++ b/course/auth.py
@@ -137,10 +137,11 @@ class ImpersonateForm(StyledForm):
                         # userfor impersonating. Customize how the name is
                         # shown, but leave email first to retain usability
                         # of form sorted by last name.
-                        u.id, "%(user_email)s - %(user_fullname)s"
+                        u.id, "%(full_name)s (%(username)s - %(email)s)"
                         % {
-                            "user_email": u.email,
-                            "user_fullname": u.get_full_name(),
+                            "full_name": u.get_full_name(),
+                            "email": u.email,
+                            "username": u.username
                             })
                     for u in sorted(impersonees,
                         key=lambda user: user.last_name.lower())

--- a/relate/templates/base-page-top.html
+++ b/relate/templates/base-page-top.html
@@ -60,9 +60,7 @@
 {% if currently_impersonating %}
   <div class="alert alert-info">
     <i class="fa fa-info-circle"></i>
-    {% blocktrans trimmed with username=user.username full_name=user.get_full_name email=user.email %}
-    Now impersonating {{ full_name }} (user: {{ username }}, email: {{ email }}).
-    {% endblocktrans %}
+    {% trans "Now impersonating" %} {{ user.get_full_name }} ({{ user.username }} - {{ user.email }}).
     <a class="btn btn-default btn-sm" href="{% url "relate-stop_impersonating" %}" role="button" target="_blank">{% trans "Stop impersonating" %} &raquo;</a>
   </div>
 {% endif %}


### PR DESCRIPTION
Currently, username is not displayed (and consequently not searchable) when impersonating users. That is quite inconvenient when debugging in some circumstances.