### PR TITLE
Gradebook tweaks

### DIFF
--- a/course/flow.py
+++ b/course/flow.py
@@ -287,7 +287,7 @@ def assemble_page_grades(flow_sessions):
         grades_by_answer_visit[grade.visit_id] = grade
 
     def get_grades_for_visit_group(visit_group):
-        return (grades_by_answer_visit.get(visit_id, None)
+        return (grades_by_answer_visit.get(visit_id)
             for visit_id in visit_group)
 
     return [get_grades_for_visit_group(group) for group in answer_visit_ids]

--- a/course/grades.py
+++ b/course/grades.py
@@ -524,13 +524,15 @@ def view_grades_by_opportunity(pctx, opp_id):
             my_flow_sessions = [None]
         else:
             while (
-                    fsess_idx < len(flow_sessions) and
-                    flow_sessions[fsess_idx].participation.id < participation.id):
+                    fsess_idx < len(flow_sessions) and (
+                    flow_sessions[fsess_idx].participation is None or
+                    flow_sessions[fsess_idx].participation.id < participation.id)):
                 fsess_idx += 1
 
             my_flow_sessions = []
             while (
                     fsess_idx < len(flow_sessions) and
+                    flow_sessions[fsess_idx].participation is not None and
                     flow_sessions[fsess_idx].participation.pk == participation.pk):
                 my_flow_sessions.append(flow_sessions[fsess_idx])
                 fsess_idx += 1

--- a/course/grades.py
+++ b/course/grades.py
@@ -559,7 +559,7 @@ def view_grades_by_opportunity(pctx, opp_id):
                         grade_state_machine=state_machine,
                         flow_session=fsession)))
 
-    if view_page_grades:
+    if view_page_grades and len(grade_table) > 0:
         # Query grades for flow pages
         all_flow_sessions = [info.flow_session for _, info in grade_table]
         max_page_count = max(fsess.page_count for fsess in all_flow_sessions)

--- a/course/grades.py
+++ b/course/grades.py
@@ -556,6 +556,8 @@ def view_grades_by_opportunity(pctx, opp_id):
         "grade_state_change_types": grade_state_change_types,
         "grade_table": grade_table,
         "batch_session_ops_form": batch_session_ops_form,
+        "page_numbers": list(range(1, 1+max(
+            fsess.page_count for fsess in flow_sessions))),
 
         "total_sessions": total_sessions,
         "finished_sessions": finished_sessions,

--- a/course/grades.py
+++ b/course/grades.py
@@ -531,13 +531,7 @@ def view_grades_by_opportunity(pctx, opp_id):
                     grade_state_machine=state_machine,
                     flow_sessions=flow_sessions))
 
-    def grade_key(entry):
-        (participation, grades) = entry
-        return (participation.user.last_name.lower(),
-                    participation.user.first_name.lower())
-
-    grade_table = sorted(zip(participations, grade_table),
-            key=grade_key)
+    # No need to sort here, datatables resorts anyhow.
 
     return render_course_page(pctx, "course/gradebook-by-opp.html", {
         "opportunity": opportunity,

--- a/course/grades.py
+++ b/course/grades.py
@@ -521,7 +521,7 @@ def view_grades_by_opportunity(pctx, opp_id):
             gchng_idx += 1
 
         if flow_sessions is None:
-            my_flow_sessions = [None]
+            my_flow_sessions = []
         else:
             while (
                     fsess_idx < len(flow_sessions) and (
@@ -540,9 +540,12 @@ def view_grades_by_opportunity(pctx, opp_id):
         state_machine = GradeStateMachine()
         state_machine.consume(my_grade_changes)
 
+        if not my_flow_sessions:
+            my_flow_sessions = [None]
+
         for fsession in my_flow_sessions:
             total_sessions += 1
-            if not fsession.in_progress:
+            if fsession is not None and not fsession.in_progress:
                 finished_sessions += 1
 
             grade_table.append(

--- a/course/grading.py
+++ b/course/grading.py
@@ -87,7 +87,10 @@ def grade_flow_page(pctx, flow_session_id, page_ordinal):
                 participation__isnull=False,
                 in_progress=flow_session.in_progress)
             .order_by(
-                "participation__user__last_name",
+                # Datatables will default to sorting the user list
+                # by the first column, which happens to be the username.
+                # Match that sorting.
+                "participation__user__username",
                 "start_time"))
 
     next_flow_session_id = None

--- a/course/templates/course/gradebook-by-opp.html
+++ b/course/templates/course/gradebook-by-opp.html
@@ -104,13 +104,16 @@
       <th class="datacol">{% trans "Overall grade" %}</th>
       <th class="datacol">{% trans "Session state" %}</th>
       <th class="datacol">{% trans "Session grade" %}</th>
+      {% for i in page_numbers %}
+        <th class="datacol">{{ i }}</th>
+      {% endfor %}
     </thead>
     <tbody>
       {% for participation, grade_info in grade_table %}
       <tr>
-        <td class="datacol">
+        <th class="headcol">
           <a href="{% url "relate-view_single_grade" course.identifier participation.id opportunity.id %}"><span class="sensitive">{{ participation.user.username }}</span></a>
-        </td>
+        </th>
         <td class="datacol">
           <span class="sensitive">
             {{ participation.user.last_name }}
@@ -153,6 +156,17 @@
               {% endif %}
           {% endif %}
         </td>
+        {% for visit in grade_info.flow_session.answer_visits %}
+            {% if visit.get_most_recent_grade != None and visit.get_most_recent_grade.value != None %}
+                <td><span class="sensitive">
+                    <a href="{% url "relate-grade_flow_page" course.identifier grade_info.flow_session.id visit.page_data.ordinal %}">
+                        {{ visit.get_most_recent_grade.percentage|floatformat:1 }}%
+                    </a>
+                </span></td>
+            {% else %}
+                <td>-</td>
+            {% endif %}
+        {% endfor %}
       </tr>
       {% endfor %}
     </tbody>
@@ -162,12 +176,14 @@
   {% get_current_js_lang_name as LANG %}
   <script type="text/javascript">
     var tbl = $("table.gradebook-by-opportunity").dataTable({
+        "scrollX": true,
         "scrollCollapse": true,
         "paging": false,
         "ordering": true,
         "columnDefs": [{ type: 'name', targets: 1 }],
         "language": {url: '{% static "datatables-i18n/i18n/" %}{{LANG}}.json'},
     } );
+    new $.fn.dataTable.FixedColumns(tbl);
   </script>
 
 {% endblock %}

--- a/course/templates/course/gradebook-by-opp.html
+++ b/course/templates/course/gradebook-by-opp.html
@@ -102,7 +102,8 @@
       <th class="datacol">{% trans "First name" %}</th>
       <th class="datacol">{% trans "Role" %}</th>
       <th class="datacol">{% trans "Overall grade" %}</th>
-      <th class="datacol">{% trans "Sessions" %}</th>
+      <th class="datacol">{% trans "Session state" %}</th>
+      <th class="datacol">{% trans "Session grade" %}</th>
     </thead>
     <tbody>
       {% for participation, grade_info in grade_table %}
@@ -134,27 +135,22 @@
           <a href="{% url "relate-view_single_grade" course.identifier participation.id opportunity.id %}"
              ><span class="sensitive">{{ grade_info.grade_state_machine.stringify_state }}</span></a>
         </td>
-          <td class="datacol" data-order="{{ grade_info.flow_sessions|length }}">
-          {% if grade_info.flow_sessions %}
-            <ul>
-              {% for flow_session in grade_info.flow_sessions %}
-                <li>
-                  {% include "course/flow-session-state.html" %}
-                  {% if not flow_session.in_progress %}
-                    ({{ flow_session.completion_time }})
-                  {% endif %}
-                  {% if flow_session.access_rules_tag %}
-                    ({% trans "Rules tag" %}: <tt>{{ flow_session.access_rules_tag }}</tt>)
-                  {% endif %}
-                  {% if flow_session.points != None %}
-                    {% blocktrans trimmed with points=flow_session.points|floatformat:1 max_points=flow_session.max_points|floatformat:1 %}
-                    {{ points }}/{{ max_points }}
-                    points
-                    {% endblocktrans %}
-                  {% endif %}
-                </li>
-              {% endfor %}
-            </ul>
+        <td class="datacol" data-order="{{ grade_info.flow_session.in_progress }}">
+          {% if grade_info.flow_session %}
+              {% include "course/flow-session-state.html" with flow_session=grade_info.flow_session %}
+              {% if grade_info.flow_session.access_rules_tag %}
+                ({% trans "Rules tag" %}: <tt>{{ grade_info.flow_session.access_rules_tag }}</tt>)
+              {% endif %}
+          {% endif %}
+        </td>
+        <td class="datacol" data-order="{{ grade_info.flow_session.points }}">
+          {% if grade_info.flow_session %}
+              {% if grade_info.flow_session.points != None %}
+                {% blocktrans trimmed with points=grade_info.flow_session.points|floatformat:1 max_points=grade_info.flow_session.max_points|floatformat:1 %}
+                {{ points }}/{{ max_points }}
+                points
+                {% endblocktrans %}
+              {% endif %}
           {% endif %}
         </td>
       </tr>

--- a/course/templates/course/gradebook-by-opp.html
+++ b/course/templates/course/gradebook-by-opp.html
@@ -54,6 +54,15 @@
           href="{% url "relate-flow_analytics" course.identifier opportunity.flow_id %}">{% trans "View analytics" %}</a>
         <a class="btn btn-default" role="button"
           href="{% url "relate-show_grader_statistics" course.identifier opportunity.flow_id %}">{% trans "View grader statistics" %}</a>
+        {% if not view_page_grades %}
+            <a class="btn btn-default" role="button"
+              href="{% url "relate-view_grades_by_opportunity" course.identifier opportunity.id %}?view_page_grades=1">
+              {% trans "View page grades" %}</a>
+        {% else %}
+            <a class="btn btn-default" role="button"
+              href="{% url "relate-view_grades_by_opportunity" course.identifier opportunity.id %}">
+              {% trans "Hide page grades" %}</a>
+        {% endif %}
         <a class="btn btn-default" href="{% url "relate-download_all_submissions" course.identifier opportunity.flow_id %}"
             role="button">{% trans "Download submissions" %}</a>
       </td>
@@ -101,12 +110,14 @@
       <th class="datacol">{% trans "Last name" %}</th>
       <th class="datacol">{% trans "First name" %}</th>
       <th class="datacol">{% trans "Role" %}</th>
-      <th class="datacol">{% trans "Overall grade" %}</th>
+      {% if view_page_grades %}
+        {% for i in page_numbers %}
+          <th class="datacol">{{ i }}</th>
+        {% endfor %}
+      {% endif %}
       <th class="datacol">{% trans "Session state" %}</th>
       <th class="datacol">{% trans "Session grade" %}</th>
-      {% for i in page_numbers %}
-        <th class="datacol">{{ i }}</th>
-      {% endfor %}
+      <th class="datacol">{% trans "Overall grade" %}</th>
     </thead>
     <tbody>
       {% for participation, grade_info in grade_table %}
@@ -127,6 +138,51 @@
         <td class="datacol">
           {{ participation.role }}
         </td>
+        {% if view_page_grades %}
+        {% for page_idx, grade in grade_info.grades %}
+        <td class="datacol"
+          {% if page_idx == None or grade == None or grade.percentage == None %}
+          data-order="-1"
+          {% else %}
+          data-order="{{ grade.percentage }}"
+          {% endif %}
+          ><span class="sensitive">
+          {% if page_idx == None %}
+              &mdash;
+          {% else %}
+              <a href="{% url "relate-grade_flow_page" course.identifier grade_info.flow_session.id page_idx %}">
+              {% if grade != None and grade.percentage != None %}
+                  {{ grade.percentage|floatformat:1 }}%
+              {% else %}
+                  - &#8709; -
+              {% endif %}
+	      </a>
+          {% endif %}
+          </span>
+        </td>
+        {% endfor %}
+        {% endif %}
+        <td class="datacol" data-order="{{ grade_info.flow_session.in_progress }}">
+          {% if grade_info.flow_session %}
+          {% include "course/flow-session-state.html" with flow_session=grade_info.flow_session %}
+          {% if not flow_session.in_progress %}
+              ({{ grade_info.flow_session.completion_time }})
+          {% endif %}
+          {% if grade_info.flow_session.access_rules_tag %}
+              ({% trans "Rules tag" %}: <tt>{{ grade_info.flow_session.access_rules_tag }}</tt>)
+          {% endif %}
+          {% endif %}
+        </td>
+        <td class="datacol" data-order="{{ grade_info.flow_session.points }}">
+          {% if grade_info.flow_session %}
+              {% if grade_info.flow_session.points != None %}
+                {% blocktrans trimmed with points=grade_info.flow_session.points|floatformat:1 max_points=grade_info.flow_session.max_points|floatformat:1 %}
+                {{ points }}/{{ max_points }}
+                points
+                {% endblocktrans %}
+              {% endif %}
+           {% endif %}
+        </td>
         <td class="datacol"
           {% if grade_info.grade_state_machine.percentage != None %}
             data-order="{{ grade_info.grade_state_machine.percentage }}"
@@ -138,35 +194,6 @@
           <a href="{% url "relate-view_single_grade" course.identifier participation.id opportunity.id %}"
              ><span class="sensitive">{{ grade_info.grade_state_machine.stringify_state }}</span></a>
         </td>
-        <td class="datacol" data-order="{{ grade_info.flow_session.in_progress }}">
-          {% if grade_info.flow_session %}
-              {% include "course/flow-session-state.html" with flow_session=grade_info.flow_session %}
-              {% if grade_info.flow_session.access_rules_tag %}
-                ({% trans "Rules tag" %}: <tt>{{ grade_info.flow_session.access_rules_tag }}</tt>)
-              {% endif %}
-          {% endif %}
-        </td>
-        <td class="datacol" data-order="{{ grade_info.flow_session.points }}">
-          {% if grade_info.flow_session %}
-              {% if grade_info.flow_session.points != None %}
-                {% blocktrans trimmed with points=grade_info.flow_session.points|floatformat:1 max_points=grade_info.flow_session.max_points|floatformat:1 %}
-                {{ points }}/{{ max_points }}
-                points
-                {% endblocktrans %}
-              {% endif %}
-          {% endif %}
-        </td>
-        {% for visit in grade_info.flow_session.answer_visits %}
-            {% if visit.get_most_recent_grade != None and visit.get_most_recent_grade.value != None %}
-                <td><span class="sensitive">
-                    <a href="{% url "relate-grade_flow_page" course.identifier grade_info.flow_session.id visit.page_data.ordinal %}">
-                        {{ visit.get_most_recent_grade.percentage|floatformat:1 }}%
-                    </a>
-                </span></td>
-            {% else %}
-                <td>-</td>
-            {% endif %}
-        {% endfor %}
       </tr>
       {% endfor %}
     </tbody>

--- a/course/templates/course/gradebook-by-opp.html
+++ b/course/templates/course/gradebook-by-opp.html
@@ -98,7 +98,9 @@
   <table class="table table-striped gradebook-by-opportunity">
     <thead>
       <th class="datacol">{% trans "User ID" %}</th>
-      <th class="datacol">{% trans "Name" context "real name of a user" %}</th>
+      <th class="datacol">{% trans "Last name" %}</th>
+      <th class="datacol">{% trans "First name" %}</th>
+      <th class="datacol">{% trans "Role" %}</th>
       <th class="datacol">{% trans "Overall grade" %}</th>
       <th class="datacol">{% trans "Sessions" %}</th>
     </thead>
@@ -109,12 +111,17 @@
           <a href="{% url "relate-view_single_grade" course.identifier participation.id opportunity.id %}"><span class="sensitive">{{ participation.user.username }}</span></a>
         </td>
         <td class="datacol">
-            <span class="sensitive">
-                {{ participation.user.get_full_name }}
-            </span>
-          {% if participation.role != participation_role.student %}
-            ({{ participation.role }})
-          {% endif %}
+          <span class="sensitive">
+            {{ participation.user.last_name }}
+          </span>
+        </td>
+        <td class="datacol">
+          <span class="sensitive">
+            {{ participation.user.first_name }}
+          </span>
+        </td>
+        <td class="datacol">
+          {{ participation.role }}
         </td>
         <td class="datacol"
           {% if grade_info.grade_state_machine.percentage != None %}


### PR DESCRIPTION
Makes the following changes to the per-opportunity gradebook:
* Sorts by user id by default
* Shows all flow sessions
* Adds a "View page grades" button which allows all page grades to be shown in the gradebook