### PR TITLE
Extending email settings

### DIFF
--- a/course/auth.py
+++ b/course/auth.py
@@ -435,13 +435,21 @@ def sign_up(request):
                         reverse("relate-home"))
                     })
 
-                from django.core.mail import send_mail
-                send_mail(
+                from django.core.mail import EmailMessage
+                msg = EmailMessage(
                         string_concat("[", _("RELATE"), "] ",
                                      _("Verify your email")),
                         message,
-                        settings.ROBOT_EMAIL_FROM,
-                        recipient_list=[email])
+                        getattr(settings, "NO_REPLY_EMAIL_FROM",
+                                "ROBOT_EMAIL_FROM"),
+                        [email])
+
+                from relate.utils import get_connection
+                msg.connection = (
+                        get_connection("no_reply")
+                        if hasattr(settings, "NO_REPLY_EMAIL_FROM")
+                        else get_connection("robot"))
+                msg.send()
 
                 messages.add_message(request, messages.INFO,
                         _("Email sent. Please check your email and click "
@@ -542,13 +550,21 @@ def reset_password(request, field="email"):
                         "home_uri": request.build_absolute_uri(
                             reverse("relate-home"))
                         })
-                    from django.core.mail import send_mail
-                    send_mail(
+                    from django.core.mail import EmailMessage
+                    msg = EmailMessage(
                             string_concat("[", _("RELATE"), "] ",
                                          _("Password reset")),
                             message,
-                            settings.ROBOT_EMAIL_FROM,
-                            recipient_list=[email])
+                            getattr(settings, "NO_REPLY_EMAIL_FROM",
+                                    "ROBOT_EMAIL_FROM"),
+                            [email])
+
+                    from relate.utils import get_connection
+                    msg.connection = (
+                            get_connection("no_reply")
+                            if hasattr(settings, "NO_REPLY_EMAIL_FROM")
+                            else get_connection("robot"))
+                    msg.send()
 
                     if field == "instid":
                         messages.add_message(request, messages.INFO,
@@ -693,12 +709,20 @@ def sign_in_by_email(request):
                         args=(user.id, user.sign_in_key,))),
                 "home_uri": request.build_absolute_uri(reverse("relate-home"))
                 })
-            from django.core.mail import send_mail
-            send_mail(
+            from django.core.mail import EmailMessage
+            msg = EmailMessage(
                     _("Your %(RELATE)s sign-in link") % {"RELATE": _("RELATE")},
                     message,
-                    settings.ROBOT_EMAIL_FROM,
-                    recipient_list=[email])
+                    getattr(settings, "NO_REPLY_EMAIL_FROM",
+                            "ROBOT_EMAIL_FROM"),
+                    [email])
+
+            from relate.utils import get_connection
+            msg.connection = (
+                get_connection("no_reply")
+                if hasattr(settings, "NO_REPLY_EMAIL_FROM")
+                else get_connection("robot"))
+            msg.send()
 
             messages.add_message(request, messages.INFO,
                     _("Email sent. Please check your email and click the link."))

--- a/course/enrollment.py
+++ b/course/enrollment.py
@@ -244,13 +244,17 @@ def enroll_view(request, course_identifier):
                                 args=(course.identifier, participation.id))))
                     })
 
-                from django.core.mail import send_mail
-                send_mail(
+                from django.core.mail import EmailMessage
+                msg = EmailMessage(
                         string_concat("[%s] ", _("New enrollment request"))
                         % course_identifier,
                         message,
                         settings.ROBOT_EMAIL_FROM,
-                        recipient_list=[course.notify_email])
+                        [course.notify_email])
+
+                from relate.utils import get_connection
+                msg.connection = get_connection("robot")
+                msg.send()
 
             messages.add_message(request, messages.INFO,
                     _("Enrollment request sent. You will receive notifcation "

--- a/course/flow.py
+++ b/course/flow.py
@@ -2317,9 +2317,16 @@ def finish_flow_session_view(pctx, flow_session_id):
                             'identifier': fctx.course.identifier,
                             'flow_id': flow_session.flow_id},
                         message,
-                        fctx.course.from_email,
+                        getattr(settings, "NOTIFICATION_EMAIL_FROM",
+                            "ROBOT_EMAIL_FROM"),
                         fctx.flow_desc.notify_on_submit)
                 msg.bcc = [fctx.course.notify_email]
+
+                from relate.utils import get_connection
+                msg.connection = (
+                    get_connection("notification")
+                    if hasattr(settings, "NOTIFICATION_EMAIL_FROM")
+                    else get_connection("robot"))
                 msg.send()
 
         # }}}

--- a/course/models.py
+++ b/course/models.py
@@ -68,6 +68,9 @@ if False:
 from jsonfield import JSONField
 from yamlfield.fields import YAMLField
 
+ALLOW_NONAUTHORIZED_SENDER = getattr(
+    settings,
+    "RELATE_EMAIL_SMTP_ALLOW_NONAUTHORIZED_SENDER", False)
 
 # {{{ course
 
@@ -227,6 +230,20 @@ class Course(models.Model):
 
     def get_absolute_url(self):
         return reverse("relate-course_page", args=(self.identifier,))
+
+    def get_from_email(self):
+        if ALLOW_NONAUTHORIZED_SENDER:
+            return self.from_email
+        else:
+            return settings.DEFAULT_FROM_EMAIL
+
+    def get_reply_to_email(self):
+        # this functionality need more fields in Course model,
+        # about the preference of the course.
+        if ALLOW_NONAUTHORIZED_SENDER:
+            return self.from_email
+        else:
+            return self.notify_email
 
 # }}}
 

--- a/course/page/base.py
+++ b/course/page/base.py
@@ -946,9 +946,19 @@ class PageBaseWithHumanTextFeedback(PageBase):
                         % {'identifier': page_context.course.identifier,
                             'flow_id': page_context.flow_session.flow_id},
                         message,
-                        page_context.course.from_email,
+                        getattr(settings, "GRADER_FEEDBACK_EMAIL_FROM",
+                                page_context.course.get_from_email()),
                         [page_context.flow_session.participation.user.email])
                 msg.bcc = [page_context.course.notify_email]
+
+                # This will allow user to reply to email to sender, currently,
+                # emails sent (even by TAs) will be reply to instructors.
+                # need more fields in course models
+                msg.reply_to = [page_context.course.get_reply_to_email()]
+
+                if hasattr(settings, "GRADER_FEEDBACK_EMAIL_FROM"):
+                    from relate.utils import get_connection
+                    msg.connection = get_connection("grader_feedback")
                 msg.send()
 
         return grade_data

--- a/course/page/code.py
+++ b/course/page/code.py
@@ -661,8 +661,8 @@ class PythonCodeQuestion(PageBaseWithTitle, PageBaseWithValue):
                         and
                         not is_nuisance_failure(response_dict)):
                     try:
-                        from django.core.mail import send_mail
-                        send_mail("".join(["[%s:%s] ",
+                        from django.core.mail import EmailMessage
+                        msg = EmailMessage("".join(["[%s:%s] ",
                             _("code question execution failed")])
                             % (
                                 page_context.course.identifier,
@@ -671,7 +671,11 @@ class PythonCodeQuestion(PageBaseWithTitle, PageBaseWithValue):
                                 else _("<unknown flow>")),
                             message,
                             settings.ROBOT_EMAIL_FROM,
-                            recipient_list=[page_context.course.notify_email])
+                            [page_context.course.notify_email])
+
+                        from relate.utils import get_connection
+                        msg.connection = get_connection("robot")
+                        msg.send()
 
                     except Exception:
                         from traceback import format_exc

--- a/local_settings.py.example
+++ b/local_settings.py.example
@@ -78,17 +78,93 @@ EMAIL_USE_TLS = False
 ROBOT_EMAIL_FROM = "Example Admin <admin@example.com>"
 RELATE_ADMIN_EMAIL_LOCALE = "en_US"
 
-# Cool down time (seconds) required before another new session of a flow
-# is allowed to be started.
-RELATE_SESSION_RESTART_COOLDOWN_SECONDS = 10
-
 SERVER_EMAIL = ROBOT_EMAIL_FROM
 
 ADMINS = (
     ("Example Admin", "admin@example.com"),
     )
 
+# If your email service do not allow nonauthorized sender, set the following
+# to False and change the configurations above accordingly, noticing that
+# Django will sent all emails using the EMAIL_ above.
+RELATE_EMAIL_SMTP_ALLOW_NONAUTHORIZED_SENDER = True
+
+# Advanced email settings if you want to configure multiple SMTPs for different
+# purpose/type of emails. It is also very useful when
+# "RELATE_EMAIL_SMTP_ALLOW_NONAUTHORIZED_SENDER" is False.
+# If you want to enable this functionality, set the next line to True, and edit
+# the next block with your cofigurations.
+RELATE_ENABLE_MULTIPLE_SMTP = False
+
+if RELATE_ENABLE_MULTIPLE_SMTP:
+    EMAIL_CONNECTIONS = {
+
+        # For automatic email sent by site.
+        "robot": {
+            # You can use email backend your liked.
+            'backend': 'djcelery_email.backends.CeleryEmailBackend',
+            'host': 'smtp.gmail.com',
+            'username': 'blah@blah.com',
+            'password': 'password',
+            'port': 587,
+            'use_tls': True,
+        },
+
+        # For emails that expect no reply for recipients, e.g., registeration,
+        # reset password, etc.
+        "no_reply": {
+            'host': 'smtp.gmail.com',
+            'username': 'blah@blah.com',
+            'password': 'password',
+            'port': 587,
+            'use_tls': True,
+        },
+
+        # For sending notifications like submission of flow sessions.
+        "notification": {
+            'host': 'smtp.gmail.com',
+            'username': 'blah@blah.com',
+            'password': 'password',
+            'port': 587,
+            'use_tls': True,
+        },
+
+        # For sending feedback email to students in grading pages.
+        "grader_feedback": {
+            'host': 'smtp.gmail.com',
+            'username': 'blah@blah.com',
+            'password': 'password',
+            'port': 587,
+            'use_tls': True,
+        }
+
+        # For student to sending email to course staff.
+        # Not implement yet
+        "student_interact": {
+            'host': 'smtp.gmail.com',
+            'username': 'blah@blah.com',
+            'password': 'password',
+            'port': 587,
+            'use_tls': True,
+        }
+    }
+
+    # This will be used as default connection when other keys are not set.
+    EMAIL_CONNECTION_DEFAULT = "robot"
+
+    NO_REPLY_EMAIL_FROM = "Example Noreply <noreply_example@example.com>"
+    NOTIFICATION_EMAIL_FROM = "Example Notification <notification_example@example.com>"
+    GRADER_FEEDBACK_EMAIL_FROM = "Example Feedback <feedback_example@example.com>"
+    STUDENT_INTERACT_EMAIL_FROM = "Example interaction <feedback_example@example.com>"
+
+
 # }}}
+
+
+# Cool down time (seconds) required before another new session of a flow
+# is allowed to be started.
+RELATE_SESSION_RESTART_COOLDOWN_SECONDS = 10
+
 
 # {{{ sign-in methods
 

--- a/relate/utils.py
+++ b/relate/utils.py
@@ -323,4 +323,28 @@ def to_js_lang_name(dj_lang_name):
 # }}}
 
 
+#{{{ Allow multiple email connections
+# https://gist.github.com/niran/840999
+
+def get_connection(label=None, **kwargs):
+    from django.conf import settings
+    if label is None:
+        label = getattr(settings, 'EMAIL_CONNECTION_DEFAULT', None)
+
+    try:
+        connections = getattr(settings, 'EMAIL_CONNECTIONS')
+        options = connections[label]
+    except (KeyError, AttributeError):
+        # Neither EMAIL_CONNECTIONS nor EMAIL_CONNECTION_DEFAULT in settings
+        # fail silently and fall back to django's built-in get_connection
+        options = {}
+
+    options.update(kwargs)
+
+    from django.core import mail
+    return mail.get_connection(**options)
+
+#}}}
+
+
 # vim: foldmethod=marker


### PR DESCRIPTION
1. Allow using email services which don't allow non-authorized sender, fixing #41 and #195
1. Allow multiple smtp, inspired by https://gist.github.com/niran/840999
1. Preparing for #237.