### PR TITLE
Default RELATE_EMAIL_SMTP_ALLOW_NONAUTHORIZED_SENDER to True 

### DIFF
--- a/course/enrollment.py
+++ b/course/enrollment.py
@@ -359,9 +359,7 @@ def send_enrollment_decision(participation, approved, request=None):
                 course.get_from_email(),
                 [participation.user.email])
         msg.bcc = [course.notify_email]
-        if not getattr(
-                settings, "RELATE_EMAIL_SMTP_ALLOW_NONAUTHORIZED_SENDER",
-                False):
+        if not settings.RELATE_EMAIL_SMTP_ALLOW_NONAUTHORIZED_SENDER:
             from relate.utils import get_outbound_mail_connection
             msg.connection = get_outbound_mail_connection("robot")
         msg.send()

--- a/course/models.py
+++ b/course/models.py
@@ -68,10 +68,6 @@ if False:
 from jsonfield import JSONField
 from yamlfield.fields import YAMLField
 
-ALLOW_NONAUTHORIZED_SENDER = getattr(
-    settings,
-    "RELATE_EMAIL_SMTP_ALLOW_NONAUTHORIZED_SENDER", False)
-
 
 # {{{ course
 
@@ -233,7 +229,7 @@ class Course(models.Model):
         return reverse("relate-course_page", args=(self.identifier,))
 
     def get_from_email(self):
-        if ALLOW_NONAUTHORIZED_SENDER:
+        if settings.RELATE_EMAIL_SMTP_ALLOW_NONAUTHORIZED_SENDER:
             return self.from_email
         else:
             return settings.DEFAULT_FROM_EMAIL
@@ -241,7 +237,7 @@ class Course(models.Model):
     def get_reply_to_email(self):
         # this functionality need more fields in Course model,
         # about the preference of the course.
-        if ALLOW_NONAUTHORIZED_SENDER:
+        if settings.RELATE_EMAIL_SMTP_ALLOW_NONAUTHORIZED_SENDER:
             return self.from_email
         else:
             return self.notify_email

--- a/local_settings.example.py
+++ b/local_settings.example.py
@@ -84,10 +84,10 @@ ADMINS = (
     ("Example Admin", "admin@example.com"),
     )
 
-# If your email service do not allow nonauthorized sender, set the following
-# to False and change the configurations above accordingly, noticing that
-# Django will sent all emails using the EMAIL_ above.
-RELATE_EMAIL_SMTP_ALLOW_NONAUTHORIZED_SENDER = True
+# If your email service do not allow nonauthorized sender, uncomment the following
+# statement and change the configurations above accordingly, noticing that all 
+# emails will be sent using the EMAIL_ settings above.
+#RELATE_EMAIL_SMTP_ALLOW_NONAUTHORIZED_SENDER = False
 
 # Advanced email settings if you want to configure multiple SMTPs for different
 # purpose/type of emails. It is also very useful when
@@ -101,7 +101,7 @@ if RELATE_ENABLE_MULTIPLE_SMTP:
 
         # For automatic email sent by site.
         "robot": {
-            # You can use email backend your liked.
+            # You can use your preferred email backend.
             'backend': 'djcelery_email.backends.CeleryEmailBackend',
             'host': 'smtp.gmail.com',
             'username': 'blah@blah.com',
@@ -110,7 +110,7 @@ if RELATE_ENABLE_MULTIPLE_SMTP:
             'use_tls': True,
         },
 
-        # For emails that expect no reply for recipients, e.g., registeration,
+        # For emails that expect no reply for recipients, e.g., registration,
         # reset password, etc.
         "no_reply": {
             'host': 'smtp.gmail.com',
@@ -129,7 +129,7 @@ if RELATE_ENABLE_MULTIPLE_SMTP:
             'use_tls': True,
         },
 
-        # For sending feedback email to students in grading pages.
+        # For sending feedback email to students in grading interface.
         "grader_feedback": {
             'host': 'smtp.gmail.com',
             'username': 'blah@blah.com',
@@ -138,8 +138,7 @@ if RELATE_ENABLE_MULTIPLE_SMTP:
             'use_tls': True,
         },
 
-        # For student to sending email to course staff.
-        # Not implement yet
+        # For student to send email to course staff in flow pages
         "student_interact": {
             'host': 'smtp.gmail.com',
             'username': 'blah@blah.com',

--- a/relate/settings.py
+++ b/relate/settings.py
@@ -18,6 +18,8 @@ import os
 from os.path import join
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 
+RELATE_EMAIL_SMTP_ALLOW_NONAUTHORIZED_SENDER = True
+
 _local_settings_file = join(BASE_DIR, "local_settings.py")
 local_settings = {
         "__file__": _local_settings_file,


### PR DESCRIPTION
Default RELATE_EMAIL_SMTP_ALLOW_NONAUTHORIZED_SENDER to True if not configured in local_settings.py, so as to avoid inconsistency.