### PR TITLE
Use flow_desc to control display/hide of a gopp for participants

### DIFF
--- a/course/constants.py
+++ b/course/constants.py
@@ -361,6 +361,16 @@ class flow_permission:  # noqa
 
         (Optional) If present, the participant can send interaction emails to
         course staffs for questions for each page with that permission.
+
+    .. attribute:: cannot_see_in_participant_grade_book
+
+        (Optional) If present, participants won't see this flow in their
+        grade book. It can be used to hide grading opportunities.
+
+    .. attribute:: cannot_see_result_in_participant_grade_book
+
+        (Optional) If present, participants won't see the result of this 
+        flow in their grade book and single grade of this flow.
     """
     view = "view"
     end_session = "end_session"
@@ -374,6 +384,10 @@ class flow_permission:  # noqa
     see_session_time = "see_session_time"
     lock_down_as_exam_session = "lock_down_as_exam_session"
     send_email_about_flow_page = "send_email_about_flow_page"
+    cannot_see_in_participant_grade_book =\
+            "cannot_see_in_participant_grade_book"
+    cannot_see_result_in_participant_grade_book =\
+            "cannot_see_result_in_participant_grade_book"
 
 FLOW_PERMISSION_CHOICES = (
         (flow_permission.view,
@@ -406,6 +420,12 @@ FLOW_PERMISSION_CHOICES = (
         (flow_permission.send_email_about_flow_page,
          pgettext_lazy("Flow permission",
                        "Send emails about the flow page to course staff")),
+        (flow_permission.cannot_see_in_participant_grade_book,
+         pgettext_lazy("Flow permission",
+                       "Cannot see in participant grade book")),
+        (flow_permission.cannot_see_result_in_participant_grade_book,
+         pgettext_lazy("Flow permission",
+                       "Cannot see result in participant grade book")),
         )
 
 # }}}

--- a/course/templates/course/gradebook-participant.html
+++ b/course/templates/course/gradebook-participant.html
@@ -54,11 +54,11 @@
       <th>{% trans "Date" %}</th>
     </thead>
     <tbody>
-      {% for grade_info in grade_table %}
+      {% for grade_info, may_view_result in zipped_grade_info %}
       {% with grade_info.grade_state_machine as gsm %}
       <tr>
         <td data-order="{{ grade_info.opportunity.identifier }}">{{ grade_info.opportunity.name }}</td>
-        {% if grade_info.opportunity.result_shown_in_participant_grade_book %}
+        {% if grade_info.opportunity.result_shown_in_participant_grade_book and may_view_result %}
           <td data-order="{{ gsm.stringify_percentage }}">
             <a href="{% url "relate-view_single_grade" course.identifier grade_participation.id grade_info.opportunity.id %}"
              ><span class="sensitive">{{ gsm.stringify_state }}</span></a>


### PR DESCRIPTION
Under current mechanism, a gopp is created if I test the flow in my account. That will let my student see it in their grade book. Sometimes I don't want student to see some gopp that are supposed to start later (like a month later) and kept answering their question "when should I submit that assignment" or "when can I start that session". 

So in this patch, I am using flow_desc to control whether a gopp should be displayed in participant's grade book. I know this patch is somewhat dirty, because the permission added is not for a session, but a gopp.  However, the benefit is that I don't need to manually set whether those flows should be display in participants' gradebook. Or, is there a better way to do that?
