### PR TITLE
Add permission: cannot_see_answer_for_sessions_in_progress

### DIFF
--- a/course/constants.py
+++ b/course/constants.py
@@ -361,6 +361,12 @@ class flow_permission:  # noqa
 
         (Optional) If present, the participant can send interaction emails to
         course staffs for questions for each page with that permission.
+
+    .. attribute:: cannot_see_answer_for_sessions_in_progress
+
+        (Optional) If present, shows the correct answer to the participant if only
+        the sessions are finished, if :attr:`see_answer_before_submission` or
+        :attr:`see_answer_after_submission` present.
     """
     view = "view"
     end_session = "end_session"
@@ -374,6 +380,8 @@ class flow_permission:  # noqa
     see_session_time = "see_session_time"
     lock_down_as_exam_session = "lock_down_as_exam_session"
     send_email_about_flow_page = "send_email_about_flow_page"
+    cannot_see_answer_for_sessions_in_progress = (
+        "cannot_see_answer_for_sessions_in_progress")
 
 FLOW_PERMISSION_CHOICES = (
         (flow_permission.view,
@@ -406,6 +414,9 @@ FLOW_PERMISSION_CHOICES = (
         (flow_permission.send_email_about_flow_page,
          pgettext_lazy("Flow permission",
                        "Send emails about the flow page to course staff")),
+        (flow_permission.cannot_see_answer_for_sessions_in_progress,
+         pgettext_lazy("Flow permission",
+                       "Cannot see answer for sessions in progress")),
         )
 
 # }}}

--- a/course/flow.py
+++ b/course/flow.py
@@ -1551,6 +1551,12 @@ def get_page_behavior(
                 or
                 flow_permission.see_answer_after_submission in permissions)
 
+    if session_in_progress:
+        show_answer = (
+            show_answer
+            and
+            flow_permission.cannot_see_answer_for_sessions_in_progress not in permissions)
+
     may_change_answer = (
             not viewing_prior_version
 


### PR DESCRIPTION
``see_answer_before_submission`` and ``see_answer_after_submission`` seems only control at the page level, not flow level. 

In some situations, I wish not to show correct answer to participants for in-progress sessions, with pages which allow them to see correctness after page submission, and allow them to change answer, so as to encourage them to figure out the correct answer themselves. This cannot be done by current permissions, with ``see_answer_after_submission``, they will be allowed to copy from the correct answer after page submission.