### PR TITLE
Consider sympy types as numeric types

### DIFF
--- a/course/page/code_feedback.py
+++ b/course/page/code_feedback.py
@@ -137,7 +137,11 @@ class Feedback:
         import numpy as np
 
         if not isinstance(data, (float, int, np.number)):
-            self.finish(0, "'%s' is not a number" % name)
+            try:
+                if not data.is_number:
+                    raise AttributeError
+            except AttributeError:
+                self.finish(0, "'%s' is not a number" % name)
 
         good = False
 

--- a/course/page/code_feedback.py
+++ b/course/page/code_feedback.py
@@ -138,8 +138,11 @@ class Feedback:
 
         if not isinstance(data, (float, int, np.number)):
             try:
+                # Check whether data is a sympy number because sympy
+                # numbers do not follow the typical interface
+                # See https://github.com/inducer/relate/pull/284
                 if not data.is_number:
-                    raise AttributeError
+                    self.finish(0, "'%s' is not a number" % name)
             except AttributeError:
                 self.finish(0, "'%s' is not a number" % name)
 


### PR DESCRIPTION
Two concerns with this patch:

1) My local version of RELATE is currently not working, so I can't test this.  Please check it carefully before merging.
2) I think the code is ugly.  There should be a simpler way to express the logic, but I can't figure it out right now.  Maybe you can switch a few statements around if it helps the clarity.

What the patch does:
The general idea is that sympy objects have an is_number attribute (note that this is not the same as the is_Number attribute).  We check this and if the attribute does not exist, then we know it is not a sympy object.  Also, we need to check the value of the attribute in case it is a sympy object that is not a number.

On the plus side, this does not require us to explicitly import sympy or check whether the user imported sympy.  Either the data is a sympy object or it is not.