### PR TITLE
Add an ALWAYS_CORRECT tag for MultipleChoice questions

### DIFF
--- a/course/page/choice.py
+++ b/course/page/choice.py
@@ -70,6 +70,7 @@ def markup_to_html_plain(page_context, s):
 class ChoiceQuestionBase(PageBaseWithTitle, PageBaseWithValue):
     CORRECT_TAG = "~CORRECT~"
     DISREGARD_TAG = "~DISREGARD~"
+    ALWAYS_CORRECT_TAG = "~ALWAYS_CORRECT~"
 
     @classmethod
     def process_choice_string(cls, page_context, s):
@@ -77,6 +78,7 @@ class ChoiceQuestionBase(PageBaseWithTitle, PageBaseWithValue):
             s = str(s)
         s = remove_prefix(cls.CORRECT_TAG, s)
         s = remove_prefix(cls.DISREGARD_TAG, s)
+        s = remove_prefix(cls.ALWAYS_CORRECT_TAG, s)
         s = markup_to_html_plain(page_context, s)
         # allow HTML in option
         s = mark_safe(s)
@@ -88,6 +90,7 @@ class ChoiceQuestionBase(PageBaseWithTitle, PageBaseWithValue):
 
         self.correct_choice_count = 0
         self.disregard_choice_count = 0
+        self.always_correct_choice_count = 0
         for choice_idx, choice in enumerate(page_desc.choices):
             try:
                 choice = str(choice)
@@ -105,11 +108,15 @@ class ChoiceQuestionBase(PageBaseWithTitle, PageBaseWithValue):
             if choice.startswith(self.DISREGARD_TAG):
                 self.disregard_choice_count += 1
 
+            if choice.startswith(self.ALWAYS_CORRECT_TAG):
+                self.always_correct_choice_count += 1
+
             if vctx is not None:
                 validate_markup(vctx, location,
                         remove_prefix(self.DISREGARD_TAG,
                             remove_prefix(self.CORRECT_TAG,
-                                choice)))
+                                remove_prefix(self.ALWAYS_CORRECT_TAG,
+                                    choice))))
 
     def required_attrs(self):
         return super(ChoiceQuestionBase, self).required_attrs() + (
@@ -149,6 +156,9 @@ class ChoiceQuestionBase(PageBaseWithTitle, PageBaseWithValue):
 
     def unpermuted_disregard_indices(self):
         return self.unpermuted_indices_with_tag(self.DISREGARD_TAG)
+
+    def unpermuted_always_correct_indices(self):
+        return self.unpermuted_indices_with_tag(self.ALWAYS_CORRECT_TAG)
 
     def make_form(self, page_context, page_data,
             answer_data, page_behavior):
@@ -247,6 +257,14 @@ class ChoiceQuestion(ChoiceQuestionBase):
                         "%(location)s: ",
                         _("ChoiceQuestion does not allow any choices "
                         "marked 'disregard'"))
+                    % {'location': location})
+
+        if self.always_correct_choice_count:
+            raise ValidationError(
+                    string_concat(
+                        "%(location)s: ",
+                        _("ChoiceQuestion does not allow any choices "
+                        "marked 'always_correct'"))
                     % {'location': location})
 
     def allowed_attrs(self):
@@ -358,6 +376,8 @@ class MultipleChoiceQuestion(ChoiceQuestionBase):
         choices are indicated by the prefix ``~CORRECT~``.
         Choices marked with the prefix ``~DISREGARD~`` are
         ignored when determining the correctness of an answer.
+        Choices marked with the prefix ``~ALWAYS_CORRECT~`` are
+        marked as correct whether they are selected or not.
 
     .. attribute:: shuffle
 
@@ -488,10 +508,13 @@ class MultipleChoiceQuestion(ChoiceQuestionBase):
         choice = answer_data["choice"]
 
         disregard_idx_set = set(self.unpermuted_disregard_indices())
+        always_correct_idx_set = set(self.unpermuted_always_correct_indices())
         unpermed_idx_set = (
-                set([permutation[idx] for idx in choice]) - disregard_idx_set)
+                set([permutation[idx] for idx in choice]) - disregard_idx_set
+                - always_correct_idx_set)
         correct_idx_set = (
-                set(self.unpermuted_correct_indices()) - disregard_idx_set)
+                set(self.unpermuted_correct_indices()) - disregard_idx_set
+                - always_correct_idx_set)
         num_choices = len(self.page_desc.choices) - len(disregard_idx_set)
 
         if self.credit_mode == "exact":
@@ -514,7 +537,16 @@ class MultipleChoiceQuestion(ChoiceQuestionBase):
         elif self.credit_mode == "proportional_correct":
 
             correctness = (
-                    len(unpermed_idx_set & correct_idx_set)/len(correct_idx_set))
+                    (
+                        len(unpermed_idx_set & correct_idx_set)
+                        +
+                        len(always_correct_idx_set))
+                    /
+                    (
+                        len(correct_idx_set)
+                        +
+                        len(always_correct_idx_set)))
+
             if not (unpermed_idx_set <= correct_idx_set):
                 correctness = 0
 
@@ -538,9 +570,15 @@ class MultipleChoiceQuestion(ChoiceQuestionBase):
 
     def correct_answer(self, page_context, page_data, answer_data, grade_data):
         corr_idx_list = self.unpermuted_correct_indices()
+        always_correct_idx_list = self.unpermuted_always_correct_indices()
 
-        result = (string_concat(_("The correct answer is"), ": %s.")
-                % self.get_answer_html(page_context, corr_idx_list))
+        result = (string_concat(
+                    string_concat(_("The correct answer is"), ": %s.")
+                        % self.get_answer_html(page_context, corr_idx_list),
+                    string_concat(_("Additional acceptable options are:"),
+                                  ": %s.")
+                        % self.get_answer_html(page_context,
+                                               always_correct_idx_list)))
 
         if hasattr(self.page_desc, "answer_explanation"):
             result += markup_to_html(page_context, self.page_desc.answer_explanation)

--- a/course/page/choice.py
+++ b/course/page/choice.py
@@ -575,7 +575,7 @@ class MultipleChoiceQuestion(ChoiceQuestionBase):
         result = (string_concat(
                     string_concat(_("The correct answer is"), ": %s.")
                         % self.get_answer_html(page_context, corr_idx_list),
-                    string_concat(_("Additional acceptable options are:"),
+                    string_concat(_("Additional acceptable options are"),
                                   ": %s.")
                         % self.get_answer_html(page_context,
                                                always_correct_idx_list)))


### PR DESCRIPTION
I don't have a working RELATE instance to test this with (sorry), so please test it out.

I thought we might want some explanation near line 380 for how the new tag is different from DISREGARD and why it might be used, but I couldn't come up with something short and sweet and didn't want to clutter up the documentation.

I think the string_concat added at the end should do what we want, but I don't know if I wrote it the way you would typically use that function.  I just used the previous message as a model.