### PR TITLE
Use --no-location to generate i18n .po files. Update zh_CN translation.

### DIFF
--- a/locale/de/LC_MESSAGES/django.po
+++ b/locale/de/LC_MESSAGES/django.po
@@ -8,31 +8,27 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-02-19 13:57-0600\n"
+"POT-Creation-Date: 2017-04-09 23:42+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: \n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: accounts/apps.py:8
 #, fuzzy
 #| msgid "Counts"
 msgid "Accounts"
 msgstr "Anzahlen"
 
-#: accounts/models.py:42
 msgid "username"
 msgstr "Benutzername"
 
-#: accounts/models.py:46
 msgid "Required. 30 characters or fewer. Letters, digits and @/./+/-/_ only."
 msgstr ""
 
-#: accounts/models.py:50
 msgid ""
 "Enter a valid username. This value may contain only letters, numbers and @/./"
 "+/-/_ characters."
@@ -40,297 +36,249 @@ msgstr ""
 "Geben Sie einen gültigen Benutzernamen ein. Dieser Wert darf nur Buchstaben, "
 "Zahlen und die Zeichen @/./+/-/_ enthalten."
 
-#: accounts/models.py:55 course/auth.py:367
 msgid "A user with that username already exists."
 msgstr "Ein Benutzer mit diesem Benutzernamen existiert bereits"
 
-#: accounts/models.py:58
 msgid "first name"
 msgstr "Vorname"
 
-#: accounts/models.py:59
 msgid "last name"
 msgstr "Nachname"
 
-#: accounts/models.py:60 course/auth.py:478
 msgid "email address"
 msgstr ""
 
-#: accounts/models.py:63
 msgid "Name verified"
 msgstr ""
 
-#: accounts/models.py:66
 msgid ""
 "Indicates that this user's name has been verified as being associated with "
 "the individual able to sign in to this account."
 msgstr ""
 
-#: accounts/models.py:72
 msgctxt "User status"
 msgid "active"
 msgstr "Aktiv"
 
-#: accounts/models.py:75
 msgid ""
 "Designates whether this user should be treated as active. Unselect this "
 "instead of deleting accounts."
 msgstr ""
 
-#: accounts/models.py:79
 msgid "date joined"
 msgstr "Beitrittsdatum"
 
-#: accounts/models.py:84
 msgid "staff status"
 msgstr "Team-Status"
 
-#: accounts/models.py:86
 msgid "Designates whether the user can log into this admin site."
 msgstr "Bestimmt, ob der Benutzer sich bei die Admin-Seite anmelden kann"
 
-#: accounts/models.py:90 course/auth.py:436 course/enrollment.py:273
-#: course/models.py:365 course/templates/course/participation-table.html.py:8
-#: relate/templates/reset-passwd-form.html:20
 msgid "Institutional ID"
 msgstr "Institutionelle ID"
 
-#: accounts/models.py:93
 msgid "Institutional ID verified"
 msgstr "Institutionelle ID geprüft"
 
-#: accounts/models.py:96
 msgid ""
 "Indicates that this user's institutional ID has been verified as being "
 "associated with the individual able to log in to this account."
 msgstr ""
 
-#: accounts/models.py:103
 msgid "User status"
 msgstr "Benutzer-Status"
 
-#: accounts/models.py:106
 msgid "The sign in token sent out in email."
 msgstr ""
 
 #. Translators: the sign in token of the user.
-#: accounts/models.py:109
 msgid "Sign in key"
 msgstr "Anmelde-Token"
 
-#: accounts/models.py:112
 msgid "The time stamp of the sign in token."
 msgstr "Zeitstempel des Anmelde-Tokens"
 
 #. Translators: the time when the token is sent out.
-#: accounts/models.py:114
 msgid "Key time"
 msgstr ""
 
-#: accounts/models.py:117
 msgid ""
 "Which key bindings you prefer when editing larger amounts of text or code. "
 "(If you do not understand what this means, leave it as 'Default'.)"
 msgstr ""
 
-#: accounts/models.py:122
 msgid "Default"
 msgstr ""
 
 #. Translators: the text editor used by participants
-#: accounts/models.py:129
 msgid "Editor mode"
 msgstr "Editor-Modus"
 
-#: accounts/models.py:135 accounts/models.py:213
+msgid "A hash of the authentication token to be used for direct git access."
+msgstr ""
+
+msgid "Hash of git authentication token"
+msgstr ""
+
 msgid "user"
 msgstr "Benutzer"
 
-#: accounts/models.py:136
 msgid "users"
 msgstr "Benutzer"
 
-#: accounts/models.py:146
 msgid "(blank)"
 msgstr "(leer)"
 
-#: course/admin.py:237
 msgid "Tags must belong to same course as participation."
 msgstr "Tags müssen zum selben Kurs gehören wie die Teilnahme"
 
-#: course/admin.py:262 course/exam.py:187
-#: course/templates/course/gradebook-by-opp.html:99
-#: course/templates/course/gradebook-participant.html:30
-#: course/templates/course/gradebook.html:18
-#: course/templates/course/participation-table.html:6
+#, fuzzy
+#| msgid "Tags must belong to same course as participation."
+msgid "Role must belong to same course as participation."
+msgstr "Tags müssen zum selben Kurs gehören wie die Teilnahme"
+
+#, fuzzy
+#| msgid "Role"
+msgid "Roles"
+msgstr "Rolle"
+
 msgctxt "real name of a user"
 msgid "Name"
 msgstr ""
 
-#: course/admin.py:373 course/admin.py:499 course/admin.py:584
-#: course/admin.py:695 course/admin.py:770 course/admin.py:852
-#: course/exam.py:99 course/templates/course/gradebook-single.html.py:17
-#: course/views.py:644
 msgid "Participant"
 msgstr "Teilnehmer"
 
-#: course/admin.py:471 course/admin.py:579 course/admin.py:685
-#: course/admin.py:765 course/models.py:205 course/models.py:228
-#: course/models.py:273 course/models.py:311 course/models.py:367
-#: course/models.py:405 course/models.py:440 course/models.py:1032
-#: course/models.py:1399
 msgid "Course"
 msgstr "Kurs"
 
-#: course/admin.py:476 course/flow.py:1812 course/models.py:407
-#: course/models.py:455 course/models.py:858 course/models.py:930
-#: course/models.py:1046 course/models.py:1403
-#: course/templates/course/gradebook-opp-list.html:21
-#: course/templates/course/gradebook-single.html:138 course/views.py:491
-#: course/views.py:573 course/views.py:649
 msgid "Flow ID"
 msgstr "Flow-ID"
 
-#: course/admin.py:481
 msgid "not in use"
 msgstr "nicht verwendet"
 
-#: course/admin.py:490 course/grades.py:1152 course/models.py:575
 msgid "Page ID"
 msgstr "Seiten-ID"
 
-#: course/admin.py:497
 msgid "anonymous"
 msgstr "anonym"
 
-#: course/admin.py:504
+msgid "Owner"
+msgstr ""
+
 msgid "Has answer"
 msgstr "Hat Antwort"
 
-#: course/admin.py:509
 msgid "Flow Session ID"
 msgstr "Flow-Sitzungs-ID"
 
-#: course/admin.py:690
 msgid "Opportunity"
 msgstr "Gelegenheit"
 
-#: course/admin.py:899
 msgid "Revoke Exam Tickets"
 msgstr "Prüfungsticket entwerten"
 
-#. Translators: "TA" is short for Teaching Assistant.
-#: course/analytics.py:61 course/analytics.py:423 course/analytics.py:469
-msgid "must be at least TA to view analytics"
+#, fuzzy
+#| msgid "must be at least TA to view analytics"
+msgid "may not view analytics"
 msgstr "muss mindestens Kurs-Assistent sein um Analytics anzusehen"
 
-#: course/analytics.py:109
 msgctxt "No data"
 msgid "None"
 msgstr "Kein(e)"
 
-#: course/analytics.py:118
 msgctxt "Value of grade"
 msgid "value greater than max"
 msgstr "Wert größer als Maximum"
 
-#: course/analytics.py:126
 msgctxt "Value of grade"
 msgid "value smaller than min"
 msgstr "Wert kleiner als Minimum"
 
-#: course/analytics.py:244 course/analytics.py:392
+msgctxt "Value in histogram"
+msgid "<out of bounds>"
+msgstr ""
+
 msgctxt "Status of session"
 msgid "in progress"
 msgstr "Im Gange"
 
-#: course/analytics.py:386
 msgctxt "Minute (time unit)"
 msgid "min"
 msgstr ""
 
-#: course/analytics.py:433
 #, python-format
 msgid ""
 "Flow '%s' was not found in the repository, but it exists in the database--"
 "maybe it was deleted?"
 msgstr ""
 
-#: course/apps.py:8
 msgid "Course module"
 msgstr "Kurs-Modul"
 
-#: course/auth.py:124
 msgid "Error while impersonating."
 msgstr "Fehler beim sich-ausgeben-als"
 
-#: course/auth.py:149
 msgid "Select user to impersonate."
 msgstr "Benutzer auswählen, als den/die Sie sich ausgeben möchten"
 
-#: course/auth.py:151 course/exam.py:186 course/models.py:450
-#: course/templates/course/grade-import-preview.html:19
 msgid "User"
 msgstr "Benutzer"
 
-#: course/auth.py:153
+#, fuzzy
+#| msgid "Stop impersonating user"
+msgid "Add impersonation header"
+msgstr "Nicht mehr als jemand anders ausgeben"
+
+msgid ""
+"Add impersonation header to every page rendered while impersonating, as a "
+"reminder that impersonation is in progress."
+msgstr ""
+
 msgid "Impersonate"
 msgstr "Sich-ausgeben-als"
 
-#: course/auth.py:160
 msgid "Already impersonating someone."
 msgstr "Sie geben sich bereits als jemand anders aus."
 
-#: course/auth.py:176 relate/templates/base.html.py:75
+msgid "Impersonating that user is not allowed."
+msgstr ""
+
 msgid "Impersonate user"
 msgstr "Sich ausgeben als anderer Benutzer"
 
-#: course/auth.py:186 relate/templates/base-page-top.html.py:66
-#: relate/templates/base.html:73
 msgid "Stop impersonating"
 msgstr "Nicht mehr als anderer Benutzer ausgeben"
 
-#: course/auth.py:192
 msgid "Not currently impersonating anyone."
 msgstr "Sie geben sich gegenwärtig nicht als jemand anders aus."
 
-#: course/auth.py:199
 msgid "No longer impersonating anyone."
 msgstr "Sie geben sich nicht mehr als jemand anders aus."
 
-#: course/auth.py:208
 msgid "Stop impersonating user"
 msgstr "Nicht mehr als jemand anders ausgeben"
 
-#: course/auth.py:286 course/templates/course/course-page.html.py:17
-#: course/templates/course/flow-start.html:199
-#: course/templates/course/login.html:7 relate/templates/403.html.py:14
-#: relate/templates/base.html:111
 msgid "Sign in"
 msgstr "Anmelden"
 
-#: course/auth.py:332
 msgid "Username"
 msgstr "Benutzername"
 
-#: course/auth.py:336
 msgid "Enter a valid username."
 msgstr "Geben Sie einen gültigen Benutzernamen ein."
 
-#: course/auth.py:337
 msgid "This value may contain only letters, numbers and @/./+/-/_ characters."
 msgstr ""
 "Dieser Wert darf nur Buchstaben, Zahlen und die Zeichen @/./+/-/_ enthalten."
 
-#: course/auth.py:353 course/auth.py:430 course/auth.py:442
 msgid "Send email"
 msgstr "Email senden"
 
-#: course/auth.py:359 course/auth.py:454 course/auth.py:562
 msgid "self-registration is not enabled"
 msgstr ""
 
-#: course/auth.py:372
 #, python-format
 msgid ""
 "That email address is already in use. Would you like to <a href='%s'>reset "
@@ -339,60 +287,27 @@ msgstr ""
 "Diese Emailadresse wird bereits verwendet. Möchten Sie statt dessen Ihr <a "
 "href='%s'>Passwort zurücksetzen</a>?"
 
-#: course/auth.py:402 course/auth.py:509 course/auth.py:533 course/auth.py:607
-#: course/auth.py:658 course/templates/course/analytics-flow.html.py:5
-#: course/templates/course/analytics-flows.html:5
-#: course/templates/course/analytics-page.html:5
-#: course/templates/course/broken-code-question-email.txt:6
-#: course/templates/course/calendar.html:8
-#: course/templates/course/course-base.html:8
-#: course/templates/course/flow-completion-grade.html:6
-#: course/templates/course/flow-completion.html:6
-#: course/templates/course/flow-confirm-completion.html:6
-#: course/templates/course/flow-page.html:9
-#: course/templates/course/flow-start.html:6
-#: course/templates/course/grade-flow-page.html:7
-#: course/templates/course/gradebook-by-opp.html:8
-#: course/templates/course/gradebook-opp-list.html:8
-#: course/templates/course/gradebook-participant-list.html:7
-#: course/templates/course/gradebook-participant.html:7
-#: course/templates/course/gradebook-single.html:5
-#: course/templates/course/gradebook.html:5
-#: course/templates/course/grading-statistics.html:5
-#: course/templates/course/home.html:6 course/templates/course/home.html:50
-#: course/templates/course/query-participations.html:7
-#: course/templates/course/sandbox-page.html:17
-#: course/templates/course/sign-in-email.txt:2
-#: relate/templates/admin/base_site.html:5 relate/templates/base.html.py:11
-#: relate/templates/base.html:56 relate/templates/maintenance.html.py:7
 msgid "RELATE"
 msgstr ""
 
-#: course/auth.py:403
 msgid "Verify your email"
 msgstr "Email bestätigen"
 
-#: course/auth.py:409 course/auth.py:522 course/auth.py:664
 msgid "Email sent. Please check your email and click the link."
 msgstr ""
 "Email gesendet. Bitte schauen Sie in Ihre Email und klicken sie auf den Link."
 
-#: course/auth.py:418
 msgid "Sign up"
 msgstr "Registrieren"
 
-#: course/auth.py:424 course/auth.py:617 course/enrollment.py:272
-#: course/models.py:363 relate/templates/reset-passwd-form.html.py:17
 msgid "Email"
 msgstr ""
 
-#: course/auth.py:479
 #, fuzzy
 #| msgid "Institutional ID"
 msgid "institutional ID"
 msgstr "Institutionelle ID"
 
-#: course/auth.py:482
 #, fuzzy, python-format
 #| msgid ""
 #| "That email address doesn't have an associated user account. Are you sure "
@@ -404,98 +319,79 @@ msgstr ""
 "Diese Email hat kein zugeordnetes Benutzerkonto. Sind Sie sicher, dassSie "
 "sich registriert haben?"
 
-#: course/auth.py:490
 msgid "The account with that institution ID doesn't have an associated email."
 msgstr ""
 
-#: course/auth.py:510
 msgid "Password reset"
 msgstr "Passwort zurücksetzen"
 
-#: course/auth.py:517
 #, python-format
 msgid "The email address associated with that account is %s."
 msgstr ""
 
-#: course/auth.py:532 course/auth.py:606
 #, python-format
 msgid "Password reset on %(site_name)s"
 msgstr "Password zurücksetzen auf %(site_name)s"
 
-#: course/auth.py:540
 msgid "Password"
 msgstr "Passwort"
 
-#: course/auth.py:542
 msgid "Password confirmation"
 msgstr "Passwort-Bestätigung"
 
-#: course/auth.py:548 course/auth.py:772 course/versioning.py:475
 msgid "Update"
 msgstr "Aktualisieren"
 
-#: course/auth.py:556
 msgid "The two password fields didn't match."
 msgstr "Die zwei Passwortfelder stimmen nicht überein."
 
-#: course/auth.py:566 course/auth.py:684
 msgid "Invalid sign-in token. Perhaps you've used an old token email?"
 msgstr ""
 "Ungültiges Anmelde-Token. Vielleicht haben Sie eine alte Token-Email "
 "verwendet?"
 
-#: course/auth.py:568 course/auth.py:576 course/auth.py:581 course/auth.py:686
-#: course/auth.py:691
 msgid "invalid sign-in token"
 msgstr "Ungültiges Anmelde-Token"
 
-#: course/auth.py:580 course/auth.py:690
 msgid "Account disabled."
 msgstr "Konto nicht verwendbar"
 
-#: course/auth.py:591 course/auth.py:697
 msgid ""
 "Successfully signed in. Please complete your registration information below."
 msgstr ""
 "Erfolgreich angemeldet. Bitte vervollständigen Sie Ihre Anmeldedaten "
 "unterhalb."
 
-#: course/auth.py:598 course/auth.py:704
 msgid "Successfully signed in."
 msgstr "Erfolgreich angemeldet."
 
-#: course/auth.py:625
 msgid "Send sign-in email"
 msgstr "Anmelde-Email senden"
 
-#: course/auth.py:630 course/auth.py:678
-msgid "email-based sign-in is not being used"
+#, fuzzy
+#| msgid "email-based sign-in is not being used"
+msgid "Email-based sign-in is not being used"
 msgstr "Email-basierte Anmeldung wird nicht verwendet"
 
-#: course/auth.py:658
 #, python-format
 msgid "Your %(RELATE)s sign-in link"
 msgstr "Ihr %(RELATE)s Amelde-Link"
 
-#: course/auth.py:720
 #, fuzzy
 #| msgid "Institutional ID"
 msgid "Institutional ID Confirmation"
 msgstr "Institutionelle ID"
 
-#: course/auth.py:723
 #, fuzzy
 #| msgid "Institutional ID"
 msgid "I have no Institutional ID"
 msgstr "Institutionelle ID"
 
-#: course/auth.py:724
 msgid ""
 "Check the checkbox if you are not a student or you forget your institutional "
 "id."
 msgstr ""
 
-#: course/auth.py:746
 #, python-format
 msgid ""
 "The unique ID your university or school provided, which may be used by some "
@@ -503,794 +399,1011 @@ msgid ""
 "it cannot be changed</b>."
 msgstr ""
 
-#: course/auth.py:753
 msgid "verified"
 msgstr "geprüft"
 
-#: course/auth.py:753
 msgid "submitted"
 msgstr "eingereicht"
 
-#: course/auth.py:811
 msgid "This field is required."
 msgstr "Dieses Feld ist erforderlich."
 
-#: course/auth.py:813
 msgid "Inputs do not match."
 msgstr "Eingaben stimmen nicht überein."
 
-#: course/auth.py:841
 msgid "Profile data saved."
 msgstr "Profildaten gesichert."
 
+#, fuzzy
+#| msgid "Result"
+msgid "Reset"
+msgstr "Ergebnis"
+
+#, python-format
+msgid "A new authentication token has been set: %s."
+msgstr ""
+
+msgid "An authentication token has previously been set."
+msgstr ""
+
+msgid "No authentication token has previously been set."
+msgstr ""
+
+msgid "Manage Git Authentication Token"
+msgstr ""
+
 #. Translators: format of event kind in Event model
-#: course/calendar.py:50 course/calendar.py:192 course/models.py:231
 msgid "Should be lower_case_with_underscores, no spaces allowed."
 msgstr "Sollte kleingeschrieben_mit_unterstrichen sein, ohne Leerzeichen."
 
-#: course/calendar.py:52 course/calendar.py:194
 msgctxt "Kind of event"
 msgid "Kind of event"
 msgstr "Typ des Ereignisses"
 
-#: course/calendar.py:56
 msgctxt "Starting time of event"
 msgid "Starting time"
 msgstr "Anfangszeit"
 
-#: course/calendar.py:58
 msgid "Duration in minutes"
 msgstr "Dauer in Minuten"
 
-#: course/calendar.py:61
+#, fuzzy
+#| msgid "All day"
+msgid "All-day event"
+msgstr "Ganztägig"
+
+#. Translators: for when the due time is "All day", how the webpage
+#. of a event is displayed.
+msgid ""
+"Only affects the rendering in the class calendar, in that a start time is "
+"not shown"
+msgstr ""
+
+msgid "Shown in calendar"
+msgstr ""
+
 msgid "Weekly"
 msgstr "Wöchentlich"
 
-#: course/calendar.py:63
+#, fuzzy
+#| msgid "Weekly"
+msgid "Bi-Weekly"
+msgstr "Wöchentlich"
+
 msgctxt "Interval of recurring events"
 msgid "Interval"
 msgstr "Intervall"
 
-#: course/calendar.py:66 course/calendar.py:197
 msgctxt "Starting ordinal of recurring events"
 msgid "Starting ordinal"
 msgstr "Start-Ordnungszahl"
 
-#: course/calendar.py:68
 msgctxt "Count of recurring events"
 msgid "Count"
 msgstr "Anzahl"
 
-#: course/calendar.py:74
 msgid "Create"
 msgstr "Erstellen"
 
-#: course/calendar.py:102
 #, python-format
 msgid "'%(event_kind)s %(event_ordinal)d' already exists"
 msgstr "%(event_kind)s %(event_ordinal)d' existiert bereits"
 
-#: course/calendar.py:117
 msgctxt "Unkown time interval"
 msgid "unknown interval"
 msgstr "unbekanntes Intervall"
 
-#: course/calendar.py:130 course/calendar.py:213
-msgid "only instructors and TAs may do that"
-msgstr "Nur Instruktoren und Assistenten dürfen das"
+#, fuzzy
+#| msgid "Edit events"
+msgid "may not edit events"
+msgstr "Ereignisse bearbeiten"
 
-#: course/calendar.py:160 course/calendar.py:172
 msgid "No events created."
 msgstr "Keine Ereignisse erstellt."
 
-#: course/calendar.py:178
 msgid "Events created."
 msgstr "Ereignisse erstellt."
 
-#: course/calendar.py:186 course/templates/course/course-base.html.py:114
 msgid "Create recurring events"
 msgstr "Wiederkehrende Ereignisse erstellen"
 
-#: course/calendar.py:203
 msgid "Renumber"
 msgstr "Neu numerieren"
 
-#: course/calendar.py:245
 msgid "Events renumbered."
 msgstr "Ereignisse neu numeriert"
 
-#: course/calendar.py:248
 msgid "No events found."
 msgstr "Keine Ereignisse gefunden."
 
-#: course/calendar.py:255 course/templates/course/course-base.html.py:115
 msgid "Renumber events"
 msgstr "Ereignisse neu numerieren"
 
-#: course/constants.py:44
+#, fuzzy
+#| msgid "View calendar"
+msgid "may not view calendar"
+msgstr "Kalender ansehen"
+
 msgctxt "User status"
 msgid "Unconfirmed"
 msgstr "Unbestätigt"
 
-#: course/constants.py:45
 msgctxt "User status"
 msgid "Active"
 msgstr "Aktiv"
 
-#: course/constants.py:63
-msgctxt "Participation role"
-msgid "Instructor"
-msgstr "Instruktor"
-
-#: course/constants.py:65
-msgctxt "Participation role"
-msgid "Teaching Assistant"
-msgstr "Assistent"
-
-#: course/constants.py:67
-msgctxt "Participation role"
-msgid "Student"
-msgstr "Student/Schüler"
-
-#: course/constants.py:69
-msgctxt "Participation role"
-msgid "Observer"
-msgstr "Beobachter"
-
-#: course/constants.py:71
-msgctxt "Participation role"
-msgid "Auditor"
-msgstr "Auditor"
-
-#: course/constants.py:85
 msgctxt "Participation status"
 msgid "Requested"
 msgstr "Beantragt"
 
-#: course/constants.py:87
 msgctxt "Participation status"
 msgid "Active"
 msgstr "Aktiv"
 
-#: course/constants.py:89
 msgctxt "Participation status"
 msgid "Dropped"
 msgstr "Abgemeldet"
 
-#: course/constants.py:91
 msgctxt "Participation status"
 msgid "Denied"
 msgstr "Abgelehnt"
 
-#: course/constants.py:125
+#, fuzzy
+#| msgid "Edit course"
+msgctxt "Participation permission"
+msgid "Edit course"
+msgstr "Kurs bearbeiten"
+
+#, fuzzy
+#| msgctxt "Grade aggregation strategy"
+#| msgid "Use the min grade"
+msgctxt "Participation permission"
+msgid "Use admin interface"
+msgstr "Die niedrigste erzielte Note verwenden"
+
+#, fuzzy
+#| msgid "Impersonate"
+msgctxt "Participation permission"
+msgid "Impersonate role"
+msgstr "Sich-ausgeben-als"
+
+#, fuzzy
+#| msgid "Set fake time"
+msgctxt "Participation permission"
+msgid "Set fake time"
+msgstr "Eine andere Zeit vorgeben"
+
+#, fuzzy
+#| msgid "Pretend to be in facilities"
+msgctxt "Participation permission"
+msgid "Pretend to be in facility"
+msgstr "Vorgeben in Einrichtungen zu sein"
+
+#, fuzzy
+#| msgid "Update Course Revision"
+msgctxt "Participation permission"
+msgid "Edit course permissions"
+msgstr "Kurs-Version aktualisieren"
+
+#, fuzzy
+#| msgid "Back to course page"
+msgctxt "Participation permission"
+msgid "View hidden course page"
+msgstr "Zurück zur Kursseite"
+
+#, fuzzy
+#| msgid "View calendar"
+msgctxt "Participation permission"
+msgid "View calendar"
+msgstr "Kalender ansehen"
+
+#, fuzzy
+#| msgid "Instant message"
+msgctxt "Participation permission"
+msgid "Send instant message"
+msgstr "Sofortnachricht"
+
+#, fuzzy
+#| msgid "Access rules tag"
+msgctxt "Participation permission"
+msgid "Access files for"
+msgstr "Zugangs-Regel-Tag"
+
+#, fuzzy
+#| msgid "Grading statistics"
+msgctxt "Participation permission"
+msgid "Included in grade statistics"
+msgstr "Benotungsstatistik"
+
+#, fuzzy
+#| msgid "Edit exams"
+msgctxt "Participation permission"
+msgid "Edit exam"
+msgstr "Prüfungen bearbeiten"
+
+#, fuzzy
+#| msgid "Issue exam tickets"
+msgctxt "Participation permission"
+msgid "Issue exam ticket"
+msgstr "Prüfungstickets ausgeben"
+
+#, fuzzy
+#| msgid "Batch-issue exam tickets"
+msgctxt "Participation permission"
+msgid "Batch issue exam ticket"
+msgstr "Prüfungstickets en masse ausgeben"
+
+msgctxt "Participation permission"
+msgid "View flow sessions from role "
+msgstr ""
+
+#, fuzzy
+#| msgid "View grades"
+msgctxt "Participation permission"
+msgid "View gradebook"
+msgstr "Noten ansehen"
+
+#, fuzzy
+#| msgid "Grading opportunity"
+msgctxt "Participation permission"
+msgid "Edit grading opportunity"
+msgstr "Benotungsmöglichkeit"
+
+#, fuzzy
+#| msgid "Session regraded."
+msgctxt "Participation permission"
+msgid "Assign grade"
+msgstr "Sitzung neu benotet."
+
+#, fuzzy
+#| msgid "View grades"
+msgctxt "Participation permission"
+msgid "View grader stats"
+msgstr "Noten ansehen"
+
+#, fuzzy
+#| msgid "Import Grades"
+msgctxt "Participation permission"
+msgid "Batch-import grades"
+msgstr "Noten importieren"
+
+#, fuzzy
+#| msgid "Import Grades"
+msgctxt "Participation permission"
+msgid "Batch-export grades"
+msgstr "Noten importieren"
+
+#, fuzzy
+#| msgid "Past submissions"
+msgctxt "Participation permission"
+msgid "Batch-download submissions"
+msgstr "Vergangene Sitzungen"
+
+msgctxt "Participation permission"
+msgid "Impose flow session deadline"
+msgstr ""
+
+msgctxt "Participation permission"
+msgid "Batch-impose flow session deadline"
+msgstr ""
+
+#, fuzzy
+#| msgctxt "Flow permission"
+#| msgid "End session"
+msgctxt "Participation permission"
+msgid "End flow session"
+msgstr "Sitzung beenden"
+
+#, fuzzy
+#| msgid "Flow sessions"
+msgctxt "Participation permission"
+msgid "Batch-end flow sessions"
+msgstr "Flow-Sitzungen"
+
+#, fuzzy
+#| msgid "Regrade flows"
+msgctxt "Participation permission"
+msgid "Regrade flow session"
+msgstr "Flows neu benoten"
+
+#, fuzzy
+#| msgid "Flow sessions"
+msgctxt "Participation permission"
+msgid "Batch-regrade flow sessions"
+msgstr "Flow-Sitzungen"
+
+#, fuzzy
+#| msgid "Recalculate grade"
+msgctxt "Participation permission"
+msgid "Recalculate flow session grade"
+msgstr "Note neu berechnen"
+
+msgctxt "Participation permission"
+msgid "Batch-recalculate flow sesssion grades"
+msgstr ""
+
+#, fuzzy
+#| msgid "Reopen session"
+msgctxt "Participation permission"
+msgid "Reopen flow session"
+msgstr "Sitzung wieder öffnen"
+
+#, fuzzy
+#| msgid "Grant exception"
+msgctxt "Participation permission"
+msgid "Grant exception"
+msgstr "Ausnahme gewähren"
+
+msgctxt "Participation permission"
+msgid "View analytics"
+msgstr ""
+
+#, fuzzy
+#| msgid "Preview ended."
+msgctxt "Participation permission"
+msgid "Preview content"
+msgstr "Vorschau beendet."
+
+#, fuzzy
+#| msgid "date joined"
+msgctxt "Participation permission"
+msgid "Update content"
+msgstr "Beitrittsdatum"
+
+#, fuzzy
+#| msgid "Markup sandbox"
+msgctxt "Participation permission"
+msgid "Use markup sandbox"
+msgstr "Markup-Sandkasten"
+
+#, fuzzy
+#| msgid "Page sandbox"
+msgctxt "Participation permission"
+msgid "Use page sandbox"
+msgstr "Seiten-Sandkasten"
+
+#, fuzzy
+#| msgid "Test flow"
+msgctxt "Participation permission"
+msgid "Test flow"
+msgstr "Flow testen"
+
+#, fuzzy
+#| msgid "Edit events"
+msgctxt "Participation permission"
+msgid "Edit events"
+msgstr "Ereignisse bearbeiten"
+
+#, fuzzy
+#| msgctxt "menu item"
+#| msgid "Query participations"
+msgctxt "Participation permission"
+msgid "Query participation"
+msgstr "Teilnahmen durchsuchen"
+
+#, fuzzy
+#| msgid "Participation"
+msgctxt "Participation permission"
+msgid "Edit participation"
+msgstr "Teilnahme"
+
+#, fuzzy
+#| msgctxt "menu item"
+#| msgid "Query participations"
+msgctxt "Participation permission"
+msgid "Preapprove participation"
+msgstr "Teilnahmen durchsuchen"
+
+#, fuzzy
+#| msgid "Manage instant flow requests"
+msgctxt "Participation permission"
+msgid "Manage instant flow requests"
+msgstr "Sofort-Flow-Anforderungen verwalten"
+
 msgctxt "Flow expiration mode"
 msgid "Submit session for grading"
 msgstr "Sitzung zur Benotung einreichen"
 
-#: course/constants.py:128
 msgctxt "Flow expiration mode"
 msgid "Do not submit session for grading"
 msgstr "Sitzung nicht zur Benotung einreichen"
 
-#: course/constants.py:140
 msgid "unknown expiration mode"
 msgstr "Unbekannter Ablaufmodus"
 
-#: course/constants.py:221
 msgctxt "Flow permission"
 msgid "View the flow"
 msgstr "Flow ansehen"
 
-#: course/constants.py:223
 msgctxt "Flow permission"
 msgid "Submit answers"
 msgstr "Antworten einreichen"
 
-#: course/constants.py:225
 msgctxt "Flow permission"
 msgid "End session"
 msgstr "Sitzung beenden"
 
-#: course/constants.py:227
 msgctxt "Flow permission"
 msgid "Change already-graded answer"
 msgstr "Benotete Antwort ändern"
 
-#: course/constants.py:230
 msgctxt "Flow permission"
 msgid "See whether an answer is correct"
 msgstr "Sehen, ob eine Antwort korrekt ist"
 
-#: course/constants.py:233
 msgctxt "Flow permission"
 msgid "See the correct answer before answering"
 msgstr "Die korrekte Antwort vor der Einreichung sehen"
 
-#: course/constants.py:236
 msgctxt "Flow permission"
 msgid "See the correct answer after answering"
 msgstr "Die korrekte Antwort nach der Einreichung sehen"
 
-#: course/constants.py:239
 msgctxt "Flow permission"
 msgid "Cannot see flow result"
 msgstr "Darf Flow-Ergebnis nicht sehen"
 
-#: course/constants.py:242
 msgctxt "Flow permission"
 msgid "Set the session to 'roll over' expiration mode"
 msgstr ""
 
-#: course/constants.py:244
 msgctxt "Flow permission"
 msgid "See session time"
 msgstr "Sitzungs-Zeit sehen"
 
-#: course/constants.py:246
 msgctxt "Flow permission"
 msgid "Lock down as exam session"
 msgstr "Als Prüfungs-Sitzung einschränken"
 
-#: course/constants.py:258
+#, fuzzy
+#| msgid "Only visible to course staff"
+msgctxt "Flow permission"
+msgid "Send emails about the flow page to course staff"
+msgstr "Nur für Kurs-Mitarbeiter sichtbar"
+
 msgctxt "Flow rule kind choices"
 msgid "Session Start"
 msgstr "Sitzungs-Start"
 
-#: course/constants.py:260
 msgctxt "Flow rule kind choices"
 msgid "Session Access"
 msgstr "Sitzungs-Zugriff"
 
-#: course/constants.py:262
 msgctxt "Flow rule kind choices"
 msgid "Grading"
 msgstr "Benotung"
 
-#: course/constants.py:300
 msgctxt "Grade aggregation strategy"
 msgid "Use the max grade"
 msgstr "Die höchste erzielte Note verwenden"
 
-#: course/constants.py:302
 msgctxt "Grade aggregation strategy"
 msgid "Use the avg grade"
 msgstr "Die durchschnittlich erzielte Note verwenden"
 
-#: course/constants.py:304
 msgctxt "Grade aggregation strategy"
 msgid "Use the min grade"
 msgstr "Die niedrigste erzielte Note verwenden"
 
-#: course/constants.py:306
 msgctxt "Grade aggregation strategy"
 msgid "Use the earliest grade"
 msgstr "Die zuerst erzielte Note verwenden"
 
-#: course/constants.py:308
 msgctxt "Grade aggregation strategy"
 msgid "Use the latest grade"
 msgstr "Die zuletzt erzielte Note verwenden"
 
-#: course/constants.py:325
 msgctxt "Grade state change"
 msgid "Grading started"
 msgstr ""
 
-#: course/constants.py:327
 msgctxt "Grade state change"
 msgid "Graded"
 msgstr "Benotet"
 
-#: course/constants.py:329
 msgctxt "Grade state change"
 msgid "Retrieved"
 msgstr "Geholt"
 
-#: course/constants.py:331
 msgctxt "Grade state change"
 msgid "Unavailable"
 msgstr "Nicht verfügbar"
 
-#: course/constants.py:333
 msgctxt "Grade state change"
 msgid "Extension"
 msgstr "Verlängerung"
 
-#: course/constants.py:335
 msgctxt "Grade state change"
 msgid "Report sent"
 msgstr "Bericht gesendet"
 
-#: course/constants.py:337
 msgctxt "Grade state change"
 msgid "Do-over"
 msgstr "Erneuter Versuch"
 
-#: course/constants.py:339
 msgctxt "Grade state change"
 msgid "Exempt"
 msgstr "Ausgenommen"
 
-#: course/constants.py:351
 msgctxt "Exam ticket state"
 msgid "Valid"
 msgstr "Gültig"
 
-#: course/constants.py:353
 msgctxt "Exam ticket state"
 msgid "Used"
 msgstr "Benutzt"
 
-#: course/constants.py:355
 msgctxt "Exam ticket state"
 msgid "Revoked"
 msgstr "Widerrufen"
 
-#: course/content.py:117
+#, fuzzy, python-format
+#| msgid "resource '%s' not found"
+msgid "commit sha '%s' not found"
+msgstr "Ressource '%s' nicht gefunden"
+
+#, fuzzy, python-format
+#| msgid "resource '%s' not found"
+msgid "resource '%s' is a file, not a directory"
+msgstr "Ressource '%s' nicht gefunden"
+
+msgid "repo root is a directory, not a file"
+msgstr ""
+
+#, fuzzy, python-format
+#| msgid "resource '%s' not found"
+msgid "resource '%s' is a directory, not a file"
+msgstr "Ressource '%s' nicht gefunden"
+
 #, python-format
 msgid "resource '%s' not found"
 msgstr "Ressource '%s' nicht gefunden"
 
-#: course/content.py:488
 msgid "I have no idea what a processing instruction is."
 msgstr ""
 
-#: course/content.py:822
 #, python-format
 msgid "invalid period: %s"
 msgstr "Ungültiges Zeitintervall: %s"
 
-#: course/content.py:911 course/content.py:936
 #, python-format
 msgid "unrecognized date/time specification: '%s' (interpreted as 'now')"
 msgstr ""
 
-#: course/content.py:1088
+#, python-format
+msgid "event '%s' has no end time, using start time instead"
+msgstr ""
+
 #, python-format
 msgid "page '%(group_id)s/%(page_id)s' in flow '%(flow_id)s'"
 msgstr ""
 
-#: course/content.py:1145
 #, python-format
 msgid "repo page class must conist of two dotted components (invalid: '%s')"
 msgstr ""
 
-#: course/enrollment.py:73
 msgid "Already enrolled. Cannot re-renroll."
 msgstr "Bereits geingeschrieben. Kann nicht erneut einschreiben."
 
-#: course/enrollment.py:78
 msgid "Course is not accepting enrollments."
 msgstr "Kurs akzeptiert keine Einschreibungen"
 
-#: course/enrollment.py:85
 msgid "Can only enroll using POST request"
 msgstr ""
 
-#: course/enrollment.py:92
 msgid ""
 "Your email address is not yet confirmed. Confirm your email to continue."
-msgstr "Ihre Email ist noch nicht bestätigt. Bestätigen Sie Ihre Email, um fortzufahren."
+msgstr ""
+"Ihre Email ist noch nicht bestätigt. Bestätigen Sie Ihre Email, um "
+"fortzufahren."
 
-#: course/enrollment.py:119
 #, python-format
 msgid "Enrollment not allowed. Please use your '%s' email to enroll."
-msgstr "Einschreibung nicht erlaubt. Bitte benutzen Sie Ihre Email '%s' um sich einzuschreiben."
+msgstr ""
+"Einschreibung nicht erlaubt. Bitte benutzen Sie Ihre Email '%s' um sich "
+"einzuschreiben."
 
-#: course/enrollment.py:146
 msgid "New enrollment request"
 msgstr "Neue Einschreibe-Anforderung"
 
-#: course/enrollment.py:153
 msgid ""
 "Enrollment request sent. You will receive notifcation by email once your "
 "request has been acted upon."
 msgstr ""
 
-#: course/enrollment.py:160
 msgid "Successfully enrolled."
 msgstr "Erfolgreich eingeschrieben"
 
+msgid "A participation already exists. Enrollment attempt aborted."
+msgstr ""
+
 #. Translators: how many enroll requests have ben processed.
-#: course/enrollment.py:213
 #, python-format
 msgid "%d requests processed."
 msgstr "%d Anforderungen bearbeitet."
 
-#: course/enrollment.py:240
 msgid "Your enrollment request"
 msgstr "Ihr Einschreibe-Ersuchen"
 
-#: course/enrollment.py:252
 msgctxt "Admin"
 msgid "Approve enrollment"
 msgstr "Einschreibung genhemigen"
 
-#: course/enrollment.py:258
 msgid "Deny enrollment"
 msgstr "Einschreibung verweigern"
 
-#: course/enrollment.py:269 course/models.py:370
-#: course/templates/course/participation-table.html:7
-msgid "Role"
-msgstr "Rolle"
-
-#: course/enrollment.py:276
 #, fuzzy
 #| msgid "Preapprove"
 msgid "Preapproval type"
 msgstr "Vorab-Bestätigungs-Typ"
 
-#: course/enrollment.py:278
 msgid ""
-"Enter fully qualified data according to \"Preapprovaltype\" you selected, "
-"one per line."
+"Enter fully qualified data according to the \"Preapproval type\" you "
+"selected, one per line."
 msgstr ""
 
-#: course/enrollment.py:280
 msgid "Preapproval data"
 msgstr "Vorab-Bestätigungs-Daten"
 
-#: course/enrollment.py:286
 msgid "Preapprove"
 msgstr "Vorab bestätigen"
 
-#: course/enrollment.py:294 course/enrollment.py:643
-msgid "only instructors may do that"
-msgstr ""
+#, fuzzy
+#| msgctxt "menu item"
+#| msgid "Query participations"
+msgid "may not preapprove participation"
+msgstr "Teilnahmen durchsuchen"
 
-#: course/enrollment.py:397
 #, python-format
 msgid ""
-"%(n_created)d preapprovals created, %(n_exist)d already existed, "
-"%(n_requested_approved)d pending requests approved."
+"%(n_created)d preapprovals created, %(n_exist)d already existed, %"
+"(n_requested_approved)d pending requests approved."
 msgstr ""
 
-#: course/enrollment.py:412
 msgid "Create Participation Preapprovals"
 msgstr "Teilnahme-Vorab-Bestätigungen Erstellen"
 
-#: course/enrollment.py:601
-msgid ""
-"Enter queries, one per line. Allowed: <code>and</code>, <code>or</code>, "
-"<code>not</code>, <code>id:1234</code>, <code>email:a@b.com</code>, "
-"<code>email-contains:abc</code>, <code>username:abc</code>, <code>username-"
-"contains:abc</code>, <code>tagged:abc</code>, <code>role:instructor|"
-"teaching_assistant|student|observer|auditor</code>, <code>status:requested|"
-"active|dropped|denied</code>."
+msgid "Enter queries, one per line."
 msgstr ""
 
-#: course/enrollment.py:616
+msgid "Allowed"
+msgstr ""
+
 msgid "Queries"
 msgstr "Anfragen"
 
-#: course/enrollment.py:619
 msgid "Apply tag"
 msgstr "Tag anwenden"
 
-#: course/enrollment.py:620
 msgid "Remove tag"
 msgstr "Tag entfernen"
 
-#: course/enrollment.py:621
 msgid "Drop"
 msgstr "Abmelden"
 
-#: course/enrollment.py:623
 msgid "Operation"
 msgstr "Vorgang"
 
-#: course/enrollment.py:625
 msgid "Tag"
 msgstr "Tag"
 
-#: course/enrollment.py:626
 msgid "Tag to apply or remove"
 msgstr "Tag zum Hinzufügen oder Entfernen"
 
-#: course/enrollment.py:633 course/exam.py:181
 msgid "List"
 msgstr "Liste"
 
-#: course/enrollment.py:635
 msgid "Apply operation"
 msgstr "Operation anwenden"
 
-#: course/enrollment.py:668
+#, fuzzy
+#| msgctxt "menu item"
+#| msgid "Query participations"
+msgid "may not query participations"
+msgstr "Teilnahmen durchsuchen"
+
 #, python-format
 msgid "Error in line %(lineno)d: %(error_type)s: %(error)s"
 msgstr ""
 
-#: course/exam.py:97
+msgid ""
+"Permissions for this participant in addition to those granted by their role"
+msgstr ""
+
+#, fuzzy
+#| msgid "Preapprove"
+msgid "Approve"
+msgstr "Vorab bestätigen"
+
+msgid "Deny"
+msgstr ""
+
+#, fuzzy
+#| msgid "Answer saved."
+msgid "Changes saved."
+msgstr "Antwort gespeichert."
+
+#, fuzzy
+#| msgid "Successfully enrolled."
+msgid "Successfully denied."
+msgstr "Erfolgreich eingeschrieben"
+
+#, fuzzy
+#| msgid "Successfully enrolled."
+msgid "Successfully dropped."
+msgstr "Erfolgreich eingeschrieben"
+
+#, fuzzy
+#| msgid "Participation"
+msgid "Edit Participation"
+msgstr "Teilnahme"
+
 msgid "Select participant for whom ticket is to be issued."
 msgstr ""
 
-#: course/exam.py:106 course/exam.py:272 course/models.py:1415
-#: course/models.py:1431
 msgid "Exam"
 msgstr "Prüfung"
 
-#: course/exam.py:109
+#, fuzzy
+#| msgid "Start date"
+msgid "Start validity"
+msgstr "Anfangsdatum"
+
+#, fuzzy
+#| msgid "Event validity check"
+msgid "End validity"
+msgstr "Ereignis-Gültigkeitsprüfung"
+
+msgid "Restrict to facility"
+msgstr ""
+
+msgid "If not blank, the exam ticket may only be used in the given facility"
+msgstr ""
+
 msgid "Revoke prior exam tickets for this user"
 msgstr "Vorige Prüfungs-Tickets für diesen Benutzer widerrufen"
 
-#: course/exam.py:116
 msgid "Issue ticket"
 msgstr "Ticket herausgeben"
 
-#: course/exam.py:135
 msgid "User is not enrolled in course."
 msgstr ""
 
-#: course/exam.py:159
 #, python-format
 msgid ""
-"Ticket issued for <b>%(participation)s</b>. The ticket code is <b>"
-"%(ticket_code)s</b>."
+"Ticket issued for <b>%(participation)s</b>. The ticket code is <b>%"
+"(ticket_code)s</b>."
 msgstr ""
 
-#: course/exam.py:171
 msgid "Issue Exam Ticket"
 msgstr ""
 
-#: course/exam.py:188 course/exam.py:233
 msgctxt "ticket code required to login exam"
 msgid "Code"
 msgstr ""
 
-#: course/exam.py:211
 msgid "Instructions for {{ ticket.exam.description }}"
 msgstr ""
 
-#: course/exam.py:215
 msgid ""
 "These are personalized instructions for {{ ticket.participation.user."
 "get_full_name }}."
 msgstr ""
 
-#: course/exam.py:218
 msgid ""
 "If this is not you, please let the proctor know so that you can get the "
 "correct set of instructions."
 msgstr ""
 
-#: course/exam.py:221
 msgid ""
 "Please sit down at your workstation and open a browser at this location:"
 msgstr ""
 
-#: course/exam.py:224
 msgid "Exam URL"
 msgstr "Prüfungs-URL"
 
-#: course/exam.py:226
 msgid ""
 "You should see boxes prompting for your user name and a one-time check-in "
 "code."
 msgstr ""
 
-#: course/exam.py:229
 msgid "Enter the following information"
 msgstr ""
 
-#: course/exam.py:231 course/exam.py:442
 msgid "User name"
 msgstr "Benutzername"
 
-#: course/exam.py:235
 msgid "You have one hour to complete the exam."
 msgstr "Sie haben eine Stunde, um die Prüfung zu bearbeiten."
 
-#: course/exam.py:237
 msgid "Good luck!"
 msgstr "Viel Glück!"
 
-#: course/exam.py:253
 msgid ""
 "Enter <a href=\"http://documen.tician.de/relate/content.html#relate-markup"
 "\">RELATE markup</a> containing Django template statements to render your "
 "exam tickets. <tt>tickets</tt> contains a list of data structures containing "
-"ticket information. For each entry <tt>tkt</tt>  in this list, use "
-"<tt>{{ tkt.participation.user.user_name }}</tt>, <tt>{{ tkt.code }}</tt>, "
-"<tt>{{ tkt.exam.description }}</tt>, and <tt>{{ checkin_uri }}</tt> as "
+"ticket information. For each entry <tt>tkt</tt>  in this list, use <tt>"
+"{{ tkt.participation.user.user_name }}</tt>, <tt>{{ tkt.code }}</tt>, <tt>"
+"{{ tkt.exam.description }}</tt>, and <tt>{{ checkin_uri }}</tt> as "
 "placeholders. See the example for how to use this."
 msgstr ""
 
-#: course/exam.py:274
 msgid "Ticket Format"
 msgstr "Ticket-Format"
 
-#: course/exam.py:280
 msgid "Revoke prior exam tickets"
 msgstr ""
 
-#: course/exam.py:287
 msgid "Issue tickets"
 msgstr "Tickets herausgeben"
 
-#: course/exam.py:296
-msgid "must be instructor or TA to batch-issue tickets"
-msgstr ""
+#, fuzzy
+#| msgid "Batch-issue exam tickets"
+msgid "may not batch-issue tickets"
+msgstr "Prüfungstickets en masse ausgeben"
 
-#: course/exam.py:349 course/exam.py:357
 msgid "Template rendering failed"
 msgstr ""
 
-#: course/exam.py:363
 #, python-format
 msgid "%d tickets issued."
 msgstr ""
 
-#: course/exam.py:371
 msgid "Batch-Issue Exam Tickets"
 msgstr ""
 
-#: course/exam.py:393
 msgid "User name or ticket code not recognized."
 msgstr "Benutzername oder Ticket-Code nicht korrekt."
 
-#: course/exam.py:399
 msgid "Ticket is not in usable state. (Has it been revoked?)"
 msgstr ""
 
-#: course/exam.py:409
 msgid "Ticket has exceeded its validity period."
 msgstr "Ticket hat seine Gültigkeitsperiode überschritten."
 
-#: course/exam.py:412
+#, fuzzy
+#| msgid "Exam has not started yet."
+msgid "Exam is not active."
+msgstr "Prüfung hat noch nicht begonnen."
+
 msgid "Exam has not started yet."
 msgstr "Prüfung hat noch nicht begonnen."
 
-#: course/exam.py:417
 msgid "Exam has ended."
 msgstr "Prüfung hat geendet."
 
-#: course/exam.py:419
+#, python-format
+msgid "Exam ticket requires presence in facility '%s'."
+msgstr ""
+
+#, fuzzy
+#| msgid "Ticket is valid."
+msgid "Exam ticket is not yet valid."
+msgstr "Ticket ist gültig."
+
+#, fuzzy
+#| msgid "Exam has ended."
+msgid "Exam ticket has expired."
+msgstr "Prüfung hat geendet."
+
 msgid "Ticket is valid."
 msgstr "Ticket ist gültig."
 
-#: course/exam.py:445
 msgid "This is typically your full email address."
 msgstr "Dies ist typischerweise Ihre volle Email-Adresse."
 
-#: course/exam.py:446
 msgid "Code"
 msgstr "Code"
 
-#: course/exam.py:448
 msgid ""
 "This is not your password, but a code that was given to you by a staff "
 "member. If you do not have one, please follow the link above to log in."
 msgstr ""
 
-#: course/exam.py:456
 msgid "Check in"
 msgstr "Anmelden"
 
-#: course/exam.py:512 course/templates/course/exam-check-in.html.py:7
 msgid "Check in for Exam"
 msgstr "Für Prüfung Anmelden"
 
-#: course/exam.py:587
 msgid ""
 "Access to flows in an exams-only facility is only granted if the flow is "
 "locked down. To do so, add 'lock_down_as_exam_session' to your flow's access "
 "permissions."
 msgstr ""
 
-#: course/exam.py:610
 msgid "Error while processing exam lockdown: flow session not found."
 msgstr ""
 
-#: course/exam.py:666
 msgid ""
 "Your RELATE session is currently locked down to this exam flow. Navigating "
-"to other parts of RELATE is not currently allowed. To abandon this exam, log "
+"to other parts of RELATE is not currently allowed. To exit this exam, log "
 "out."
 msgstr ""
 
-#: course/flow.py:86
 msgid "cannot grade ungraded answer"
 msgstr ""
 
-#: course/flow.py:533
 msgid "Can't end a session that's already ended"
 msgstr ""
 
-#: course/flow.py:581
 msgid "Can't expire a session that's not in progress"
 msgstr ""
 
-#: course/flow.py:583
 msgid "Can't expire an anonymous flow session"
 msgstr ""
 
-#: course/flow.py:626
 #, python-format
 msgid "invalid expiration mode '%(mode)s' on flow session ID %(session_id)d"
 msgstr ""
 
 #. Translators: grade flow: calculating grade.
-#: course/flow.py:661
 #, python-format
 msgid "Counted at %(percent).1f%% of %(point).1f points"
 msgstr ""
 
-#: course/flow.py:728
 msgid "Cannot reopen a session that's already in progress"
 msgstr ""
 
-#: course/flow.py:731
 msgid "Cannot reopen anonymous sessions"
 msgstr ""
 
-#: course/flow.py:739
 #, python-format
 msgid ""
-"Session reopened at %(now)s, previous completion time was "
-"'%(complete_time)s'."
+"Session reopened at %(now)s, previous completion time was '%(complete_time)"
+"s'."
 msgstr ""
 
-#: course/flow.py:810
 #, python-format
 msgid "Session regraded at %(time)s."
 msgstr ""
 
-#: course/flow.py:828
 msgid "cannot recalculate grade on in-progress session"
 msgstr ""
 
-#: course/flow.py:833
 #, python-format
 msgid "Session grade recomputed at %(time)s."
 msgstr ""
 
-#: course/flow.py:975
 msgid "new session not allowed"
 msgstr ""
 
-#: course/flow.py:1048 course/flow.py:1052
 msgid "may not view other people's sessions"
 msgstr ""
 
-#: course/flow.py:1114
 msgid "Save answer"
 msgstr "Antwort speichern"
 
-#: course/flow.py:1121
 #, fuzzy
 #| msgid "Submit answer for grading"
 msgid "Submit answer for feedback"
 msgstr "Antwort zur Benotung einreichen"
 
-#: course/flow.py:1126
 msgid "Submit final answer"
 msgstr "Endgültige Antwort einreichen"
 
-#: course/flow.py:1135
 msgid "Save answer and move on"
 msgstr "Antwort speichern und weiter"
 
-#: course/flow.py:1143
 msgid "Save answer and finish"
 msgstr "Antwort speichern und abschließen"
 
-#: course/flow.py:1170
 msgid ""
 "No in-progress session record found for this flow. Redirected to flow start "
 "page."
 msgstr ""
 
-#: course/flow.py:1215
 msgid "not allowed to view flow"
 msgstr ""
 
-#: course/flow.py:1273
 #, python-format
-msgid "Viewing prior submission dated %(date)s."
+msgid "Viewing prior submission dated %(date)s. "
 msgstr ""
 
-#: course/flow.py:1327
+msgid "Go back"
+msgstr "Zurück"
+
 msgid ""
 "The page data stored in the database was found to be invalid for the page as "
 "given in the course content. Likely the course content was changed in an "
@@ -1298,468 +1411,496 @@ msgid ""
 "changing the question ID. The precise error encountered was the following: "
 msgstr ""
 
-#: course/flow.py:1372
 msgid ""
 "Changes to this session are being prevented because this session yields a "
 "permanent grade, but you have not completed your enrollment process in this "
 "course."
 msgstr ""
 
-#: course/flow.py:1457
 msgid "could not find which button was pressed"
 msgstr ""
 
-#: course/flow.py:1473
 msgid "Answer submission not allowed."
 msgstr ""
 
-#: course/flow.py:1482
 msgid "Already have final answer."
 msgstr ""
 
-#: course/flow.py:1504
 msgid "Answer saved."
 msgstr "Antwort gespeichert."
 
-#: course/flow.py:1590
 msgid "Failed to submit answer."
 msgstr "Antwort konnte nicht eingereicht werden."
 
-#: course/flow.py:1604
+#, fuzzy, python-format
+#| msgid "Signed in as %(username)s"
+msgid "Interaction request from %(username)s"
+msgstr "Als %(username)s angemeldet"
+
+msgid "Email sent, and notice that you will also receive a copy of the email."
+msgstr ""
+
+#, fuzzy
+#| msgid "Send sign-in email"
+msgid "Send interaction email"
+msgstr "Anmelde-Email senden"
+
+#, python-format
+msgid "Your questions about page %s . "
+msgstr ""
+
+msgid ""
+"Notice that <strong>only</strong> questions for that page will be answered."
+msgstr ""
+
+msgid "Message"
+msgstr ""
+
+#, fuzzy
+#| msgid "Send email"
+msgid "Send Email"
+msgstr "Email senden"
+
+msgid "At least 20 characters are required for submission."
+msgstr ""
+
 msgid "only POST allowed"
 msgstr ""
 
-#: course/flow.py:1610
 msgid "may only change your own flow sessions"
 msgstr ""
 
-#: course/flow.py:1613
+#, fuzzy
+#| msgid "invalid operation"
+msgid "invalid bookmark state"
+msgstr "Ungültige Operation"
+
 msgid "may only change in-progress flow sessions"
 msgstr ""
 
-#: course/flow.py:1618
 msgid "invalid expiration mode"
 msgstr ""
 
-#: course/flow.py:1689
 msgid "odd POST parameters"
 msgstr ""
 
-#: course/flow.py:1693
 msgid "Cannot end a session that's already ended"
 msgstr ""
 
-#: course/flow.py:1697
 msgid "not permitted to end session"
 msgstr ""
 
-#: course/flow.py:1737
 #, python-format
 msgid "Submission by %(participation)s"
 msgstr ""
 
-#: course/flow.py:1815
 msgid ""
 "If non-empty, limit the regrading to sessions started under this access "
 "rules tag."
 msgstr ""
 
-#: course/flow.py:1817 course/models.py:478
 msgid "Access rules tag"
 msgstr "Zugangs-Regel-Tag"
 
-#: course/flow.py:1821
 msgid "Regrade in-progress and not-in-progress sessions"
 msgstr ""
 
-#: course/flow.py:1823
 msgid "Regrade in-progress sessions only"
 msgstr ""
 
-#: course/flow.py:1825
 msgid "Regrade not-in-progress sessions only"
 msgstr ""
 
-#: course/flow.py:1827
 msgid "Regraded session in progress"
 msgstr ""
 
-#: course/flow.py:1830 course/templates/course/gradebook-single.html.py:271
 msgid "Regrade"
 msgstr "Neu benoten"
 
-#: course/flow.py:1836
-msgid "must be instructor to regrade flows"
-msgstr ""
+#, fuzzy
+#| msgid "Regrade flows"
+msgid "may not batch-regrade flows"
+msgstr "Flows neu benoten"
 
-#: course/flow.py:1866
 msgid ""
 "This regrading process is only intended for flows that donot show up in the "
 "grade book. If you would like to regradefor-credit flows, use the "
 "corresponding functionality in the grade book."
 msgstr ""
 
-#: course/flow.py:1871
 msgid "Regrade not-for-credit Flow Sessions"
 msgstr ""
 
-#: course/grades.py:61
+#, fuzzy
+#| msgid "Grade changes"
+msgid "Re-allow changes"
+msgstr "Noten-Änderungen"
+
+#, fuzzy
+#| msgctxt "Cancel all instant flow(s)"
+#| msgid "Cancel all"
+msgid "Cancel"
+msgstr "Alle abbrechen"
+
+#, fuzzy
+#| msgid "flow page has no ID"
+msgid "Flow page changes reallowed. "
+msgstr "Flow-Seite hat keine ID"
+
+msgid "Re-allow Changes to Flow Page"
+msgstr ""
+
 msgid "must be enrolled to view grades"
 msgstr ""
 
-#: course/grades.py:74 course/grades.py:722
 msgid "may not view other people's grades"
 msgstr ""
 
-#: course/grades.py:153 course/grades.py:176 course/grades.py:273
-#: course/grades.py:388 course/grading.py:63
-msgid "must be instructor or TA to view grades"
+msgid "may not view grade book"
 msgstr ""
 
-#: course/grades.py:297
-msgid "must be instructor or TA to export grades"
+msgid "may not batch-export grades"
 msgstr ""
 
-#: course/grades.py:351
 msgid "Session tag"
 msgstr "Sitzungs-Tag"
 
-#: course/grades.py:355
 msgid ""
 "Only act on in-progress sessions that are past their access rule's due date "
 "(applies to 'expire')"
 msgstr ""
 
 #. Translators: see help text above.
-#: course/grades.py:358
 msgid "Past due only"
 msgstr ""
 
-#: course/grades.py:361
 msgid "Impose deadline (Expire sessions)"
 msgstr ""
 
-#: course/grades.py:365
 msgid "Regrade ended sessions"
 msgstr ""
 
-#: course/grades.py:367
 msgid "Recalculate grades of ended sessions"
 msgstr ""
 
-#: course/grades.py:393
 msgid "opportunity from wrong course"
 msgstr ""
 
-#: course/grades.py:419 course/views.py:524 course/views.py:551
-#: course/views.py:599
+msgid "may not impose deadline"
+msgstr ""
+
+msgid "may not batch-end flows"
+msgstr ""
+
+#, fuzzy
+#| msgid "Recalculate grade"
+msgid "may not batch-recalculate grades"
+msgstr "Note neu berechnen"
+
 msgid "invalid operation"
 msgstr "Ungültige Operation"
 
-#: course/grades.py:574 course/views.py:899
 msgid "Set access rules tag"
 msgstr "Zugriffsregel-Tag setzen"
 
-#: course/grades.py:578 course/models.py:888 course/models.py:942
-#: course/models.py:1124 course/views.py:943
+msgid "Re-allow changes to already-submitted questions"
+msgstr ""
+
 msgid "Comment"
 msgstr "Kommentar"
 
-#: course/grades.py:582 course/templates/course/gradebook-single.html.py:285
 msgid "Reopen"
 msgstr "Wieder öffnen"
 
-#: course/grades.py:611
+#, fuzzy
+#| msgid "Reopen session"
+msgid "may not reopen session"
+msgstr "Sitzung wieder öffnen"
+
 msgid "Cannot reopen a session that's already in progress."
 msgstr ""
 
-#: course/grades.py:625
 #, python-format
 msgid ""
-"Session reopened at %(now)s by %(user)s, previous completion time was "
-"'%(completion_time)s': %(comment)s."
+"Session reopened at %(now)s by %(user)s, previous completion time was '%"
+"(completion_time)s': %(comment)s."
 msgstr ""
 
-#: course/grades.py:649
 msgid "Reopen session"
 msgstr "Sitzung wieder öffnen"
 
-#: course/grades.py:706
 msgid "participation does not match course"
 msgstr ""
 
-#: course/grades.py:715
 msgid "This grade is not shown in the grade book."
 msgstr "Diese Note wird nicht im Notenbuch gezeigt."
 
-#: course/grades.py:718
 msgid "This grade is not shown in the student grade book."
 msgstr "Diese Note wird nicht im Teilnehmer-Notenbuch gezeigt."
 
-#: course/grades.py:725
 msgid "grade has not been released"
 msgstr ""
 
-#: course/grades.py:745
 msgid "unknown action"
 msgstr ""
 
-#: course/grades.py:761
-msgid "Session expired."
-msgstr "Sitzung abgelaufen."
+#, fuzzy
+#| msgid "Session ended."
+msgid "Session deadline imposed."
+msgstr "Sitzung beendet."
 
-#: course/grades.py:768
 msgid "Session ended."
 msgstr "Sitzung beendet."
 
-#: course/grades.py:774
 msgid "Session regraded."
 msgstr "Sitzung neu benotet."
 
-#: course/grades.py:780
 msgid "Session grade recalculated."
 msgstr "Sitzungs-Note neu berechnet."
 
-#: course/grades.py:783
 msgid "invalid session operation"
 msgstr ""
 
-#: course/grades.py:789 course/grades.py:1099 course/versioning.py:545
 msgctxt "Starting of Error message"
 msgid "Error"
 msgstr "Fehler"
 
-#: course/grades.py:885
 #, python-format
 msgid ""
 "Click to <a href='%s' target='_blank'>create</a> a new grading opportunity. "
 "Reload this form when done."
 msgstr ""
 
-#: course/grades.py:889
 msgctxt "Field name in Import grades form"
 msgid "Grading opportunity"
 msgstr ""
 
-#: course/grades.py:894 course/models.py:1115
 msgid "Attempt ID"
 msgstr ""
 
-#: course/grades.py:896
 msgid "File"
 msgstr ""
 
-#: course/grades.py:900
 msgid "CSV with Header"
 msgstr ""
 
-#: course/grades.py:903
 msgid "Format"
 msgstr ""
 
+msgid "Email or NetID"
+msgstr ""
+
+#, fuzzy
+#| msgid "User status"
+msgid "User attribute"
+msgstr "Benutzer-Status"
+
 #. Translators: the following strings are for the format
 #. informatioin for a CSV file to be imported.
-#: course/grades.py:908
 msgid ""
-"1-based column index for the Email or NetID used to locate student record"
+"1-based column index for the user attribute selected above to locate student "
+"record"
 msgstr ""
 
-#: course/grades.py:911
-msgid "User ID column"
+msgid "User attribute column"
 msgstr ""
 
-#: course/grades.py:913
 msgid "1-based column index for the (numerical) grade"
 msgstr ""
 
-#: course/grades.py:915
 msgid "Points column"
 msgstr "Spaltennr. mit Punktzahl"
 
-#: course/grades.py:917
 msgid "1-based column index for further (textual) feedback"
 msgstr ""
 
-#: course/grades.py:919
 msgid "Feedback column"
 msgstr "Spaltennr mit Punktzahl"
 
 #. Translators: "Max point" refers to full credit in points.
-#: course/grades.py:923 course/models.py:734 course/models.py:1121
 msgid "Max points"
 msgstr "Maximal-Punktzahl"
 
-#: course/grades.py:925 course/sandbox.py:70
-#: course/templates/course/grade-import-preview.html:15
-#: course/versioning.py:481
 msgid "Preview"
 msgstr "Vorschau"
 
-#: course/grades.py:926
 msgid "Import"
 msgstr "Importieren"
 
+#. Translators: use institutional_id_string to find user
+#. (participant).
+#, python-format
+msgid "no participant found with institutional ID '%(inst_id_string)s'"
+msgstr ""
+
+#, python-format
+msgid ""
+"more than one participant found with institutional ID '%(inst_id_string)s'"
+msgstr ""
+
 #. Translators: use id_string to find user (participant).
-#: course/grades.py:961
 #, python-format
 msgid "no participant found for '%(id_string)s'"
 msgstr ""
 
-#: course/grades.py:965
 #, python-format
 msgid "more than one participant found for '%(id_string)s'"
 msgstr ""
 
-#: course/grades.py:1107
+#, python-format
+msgid "Unknown user attribute '%(attr_type)s'"
+msgstr ""
+
+#, fuzzy
+#| msgid "point"
+#| msgid_plural "points"
+msgid "points"
+msgstr "Punkt"
+
+#, fuzzy
+#| msgid "Max points"
+msgid "max_points"
+msgstr "Maximal-Punktzahl"
+
+#, fuzzy
+#| msgid "Comment"
+msgid "comment"
+msgstr "Kommentar"
+
+#, fuzzy
+#| msgid "Update"
+msgid "updated"
+msgstr "Aktualisieren"
+
+msgid "may not batch-import grades"
+msgstr ""
+
 #, python-format
 msgid "%(total)d grades found, %(unchaged)d unchanged."
 msgstr "%(total)d Noten gefunden, %(unchaged)d unverändert."
 
-#: course/grades.py:1121
 #, python-format
 msgid "%d grades imported."
 msgstr "%d Noten importiert."
 
-#: course/grades.py:1134
 msgid "Import Grade Data"
 msgstr "Notendaten importieren"
 
-#: course/grades.py:1155
 msgid "Least recent attempt"
 msgstr ""
 
-#: course/grades.py:1156
 msgid "Most recent attempt"
 msgstr ""
 
-#: course/grades.py:1157
 msgid "All attempts"
 msgstr "Alle Versuche"
 
-#: course/grades.py:1159
 msgid "Attempts to include."
 msgstr ""
 
-#: course/grades.py:1161
 msgid "Every submission to the page counts as an attempt."
 msgstr ""
 
-#: course/grades.py:1165
 msgid "Only download sessions tagged with this rules tag."
 msgstr ""
 
-#: course/grades.py:1166
 msgid "Restrict to rules tag"
 msgstr ""
 
-#: course/grades.py:1170
 msgid "Only download submissions from non-in-progress sessions"
 msgstr ""
 
-#: course/grades.py:1172
 #, fuzzy
 #| msgid "in progress"
 msgid "Non-in-progress only"
 msgstr "im Gange"
 
-#: course/grades.py:1174
+msgid "Include provided feedback as text file in zip"
+msgstr ""
+
+msgid "Include feedback"
+msgstr ""
+
 msgid "Additional File"
 msgstr ""
 
-#: course/grades.py:1176
 msgid ""
 "If given, the uploaded file will be included in the zip archive. If the "
 "produced archive is to be used for plagiarism detection, then this may be "
 "used to include the reference solution."
 msgstr ""
 
-#: course/grades.py:1184
 msgid "Download"
 msgstr ""
 
-#: course/grades.py:1194
 #, fuzzy
-#| msgid "must be at least TA to view analytics"
-msgid "must be at least TA to download submissions"
-msgstr "muss mindestens Kurs-Assistent sein um Analytics anzusehen"
+#| msgid "Past submissions"
+msgid "may not batch-download submissions"
+msgstr "Vergangene Sitzungen"
 
-#: course/grades.py:1207 course/grades.py:1211
 msgid "ALL"
 msgstr ""
 
-#: course/grades.py:1320
 msgid "Download All Submissions in Zip file"
 msgstr ""
 
-#: course/grading.py:69
+#, fuzzy
+#| msgid "Grading opportunity"
+msgid "Edit Grading Opportunity"
+msgstr "Benotungsmöglichkeit"
+
 msgid "Flow session not part of specified course"
 msgstr ""
 
-#: course/grading.py:72
 msgid "Cannot grade anonymous session"
 msgstr ""
 
-#: course/grading.py:213 course/templates/course/flow-page.html.py:54
+msgid "may not assign grades"
+msgstr ""
+
 msgid "Submit"
 msgstr ""
 
-#: course/grading.py:290
-msgid "must be instructor or TA to view grading stats"
+msgid "may not view grader stats"
 msgstr ""
 
-#: course/im.py:53
 msgctxt "Instant message"
 msgid "Message"
 msgstr ""
 
 #. Translators: literals in this file are about
 #. the instant messaging function.
-#: course/im.py:65
 msgctxt "Send instant messages"
 msgid "Send"
 msgstr ""
 
-#: course/im.py:141
 msgid "unable to connect"
 msgstr ""
 
-#: course/im.py:159
-msgid "only enrolled folks may do that"
-msgstr ""
-
-#: course/im.py:166
 msgid "Instant messaging is not enabled for this course."
 msgstr ""
 
-#: course/im.py:172
 msgid "Recipient is <span class='label label-success'>Online</span>."
 msgstr ""
 
-#: course/im.py:175
 msgid "Recipient is <span class='label label-danger'>Offline</span>."
 msgstr ""
 
-#: course/im.py:189
 msgid "no recipient XMPP ID"
 msgstr ""
 
-#: course/im.py:192
 msgid "no XMPP password"
 msgstr ""
 
-#: course/im.py:204
 msgid "An error occurred while sending the message. Sorry."
 msgstr ""
 
-#: course/im.py:208
 msgid "Message sent."
 msgstr ""
 
-#: course/im.py:217 course/templates/course/course-base.html.py:35
 msgid "Send instant message"
 msgstr ""
 
-#: course/models.py:62
 msgid ""
 "A course identifier. Alphanumeric with dashes, no spaces. This is visible in "
 "URLs and determines the location on your file system where the course's git "
@@ -1767,91 +1908,71 @@ msgid ""
 "been created without also moving the course's git on the server."
 msgstr ""
 
-#: course/models.py:67
 msgid "Course identifier"
 msgstr ""
 
-#: course/models.py:73
 msgid "Identifier may only contain letters, numbers, and hypens ('-')."
 msgstr ""
 
-#: course/models.py:80
 msgid "Course name"
 msgstr "Kurs-Modul"
 
-#: course/models.py:81
 msgid "A human-readable name for the course. (e.g. 'Numerical Methods')"
 msgstr ""
 
-#: course/models.py:86
 msgid "Course number"
 msgstr "Kurs-Nummer"
 
-#: course/models.py:87
 msgid "A human-readable course number/ID for the course (e.g. 'CS123')"
 msgstr ""
 
-#: course/models.py:92
 msgid "Time Period"
 msgstr "Zeit-Intervall"
 
-#: course/models.py:93
 msgid ""
 "A human-readable description of the time period for the course (e.g. 'Fall "
 "2014')"
 msgstr ""
 
-#: course/models.py:97
 msgid "Start date"
 msgstr "Anfangsdatum"
 
-#: course/models.py:100
 msgid "End date"
 msgstr "Enddatum"
 
-#: course/models.py:105
 msgid "Is the course only accessible to course staff?"
 msgstr "Ist der Kurs nur für Teammitglieder zugänglich?"
 
-#: course/models.py:106
 msgid "Only visible to course staff"
 msgstr "Nur für Kurs-Mitarbeiter sichtbar"
 
-#: course/models.py:109
 msgid "Should the course be listed on the main page?"
 msgstr "Soll der Kurs auf der Hauptseite gelistet werden?"
 
-#: course/models.py:110
 msgid "Listed on main page"
 msgstr "Auf der Hauptseite gelistet"
 
-#: course/models.py:113
 msgid "Accepts enrollment"
 msgstr "Akzeptiert Anmeldungen"
 
-#: course/models.py:116
 msgid ""
 "A Git URL from which to pull course updates. If you're just starting out, "
 "enter <tt>git://github.com/inducer/relate-sample</tt> to get some sample "
 "content."
 msgstr ""
 
-#: course/models.py:120
 msgid "git source"
 msgstr "git-Quelle"
 
-#: course/models.py:122
 msgid ""
 "An SSH private key to use for Git authentication. Not needed for the sample "
 "URL above.You may use <a href='/generate-ssh-key'>this tool</a> to generate "
 "a key pair."
 msgstr ""
 
-#: course/models.py:126
 msgid "SSH private key"
 msgstr "Geheimer SSH-Schlüssel"
 
-#: course/models.py:129
 msgid ""
 "Subdirectory <em>within</em> the git repository to use as course root "
 "directory. Not required, and usually blank. Use only if your course content "
@@ -1859,257 +1980,249 @@ msgid ""
 "slash."
 msgstr ""
 
-#: course/models.py:134
 msgid "Course root in repository"
 msgstr "Kurs-Wurzel im Repository"
 
-#: course/models.py:138
 msgid ""
 "Name of a YAML file in the git repository that contains the root course "
 "descriptor."
 msgstr ""
 
-#: course/models.py:140
 msgid "Course file"
 msgstr ""
 
-#: course/models.py:143
 msgid ""
 "Name of a YAML file in the git repository that contains calendar information."
 msgstr "Name einer YAML-Datei, die die Kalender-Information enthält."
 
-#: course/models.py:145 course/validation.py:1141
 msgid "Events file"
 msgstr ""
 
-#: course/models.py:149
 msgid "If set, each enrolling student must be individually approved."
 msgstr ""
 
-#: course/models.py:151
 msgid "Enrollment approval required"
 msgstr ""
 
-#: course/models.py:154
 msgid ""
-"If set, students cannot get particiaption preapproval using institutional ID "
-"if institutional ID they provided are not verified."
+"If set, students cannot get participation preapproval using institutional ID "
+"if the institutional ID they provided is not verified."
 msgstr ""
 
-#: course/models.py:158
 #, fuzzy
 #| msgid "Institutional ID verified"
-msgid "None preapproval by institutional ID if not verified?"
+msgid "Prevent preapproval by institutional ID if not verified?"
 msgstr "Institutionelle ID geprüft"
 
-#: course/models.py:162
 msgid ""
 "Enrollee's email addresses must end in the specified suffix, such as "
 "'@illinois.edu'."
 msgstr ""
 
-#: course/models.py:164
 msgid "Enrollment required email suffix"
 msgstr ""
 
 #. Translators: replace "RELATE" with the brand name of your
 #. website if necessary.
-#: course/models.py:169
 msgid ""
 "This email address will be used in the 'From' line of automated emails sent "
 "by RELATE."
 msgstr ""
 
-#: course/models.py:171
 msgid "From email"
 msgstr ""
 
-#: course/models.py:174
 msgid "This email address will receive notifications about the course."
 msgstr ""
 
-#: course/models.py:176
 msgid "Notify email"
 msgstr ""
 
-#: course/models.py:181
 msgid ""
 "(Required only if the instant message feature is desired.) The Jabber/XMPP "
 "ID (JID) the course will use to sign in to an XMPP server."
 msgstr ""
 
-#: course/models.py:184
 msgid "Course xmpp ID"
 msgstr ""
 
-#: course/models.py:186
 msgid ""
 "(Required only if the instant message feature is desired.) The password to "
 "go with the JID above."
 msgstr ""
 
-#: course/models.py:188
 msgid "Course xmpp password"
 msgstr ""
 
-#: course/models.py:191
 msgid ""
 "(Required only if the instant message feature is desired.) The JID to which "
 "instant messages will be sent."
 msgstr ""
 
-#: course/models.py:193
 msgid "Recipient xmpp ID"
 msgstr ""
 
-#: course/models.py:199 course/models.py:453
 msgid "Active git commit SHA"
 msgstr ""
 
-#: course/models.py:206
 msgid "Courses"
 msgstr "Kurse"
 
-#: course/models.py:233
 msgid "Kind of event"
 msgstr ""
 
 #. Translators: ordinal of event of the same kind
-#: course/models.py:236
 msgid "Ordinal of event"
 msgstr ""
 
-#: course/models.py:238 course/models.py:409 course/models.py:457
-#: course/templates/course/flow-start.html:23
 msgid "Start time"
 msgstr "Anfangszeit"
 
-#: course/models.py:240 course/models.py:411
 msgid "End time"
 msgstr "Endzeit"
 
-#. Translators: for when the due time is "All day", how the webpage
-#. of a event is displayed.
-#: course/models.py:244
-msgid ""
-"Only affects the rendering in the class calendar, in that a start time is "
-"not shown"
-msgstr ""
-
-#: course/models.py:246
 msgid "All day"
 msgstr "Ganztägig"
 
-#: course/models.py:249
-msgid "Shown in calendar"
-msgstr ""
-
-#: course/models.py:252
 msgid "Event"
 msgstr "Ereignis"
 
-#: course/models.py:253
 msgid "Events"
 msgstr "Ereignisse"
 
 #. Translators: name format of ParticipationTag
-#: course/models.py:276
 msgid "Format is lower-case-with-hyphens. Do not use spaces."
 msgstr ""
 
-#: course/models.py:278
 msgid "Name of participation tag"
 msgstr ""
 
-#: course/models.py:280
 msgid "Shown to pariticpant"
 msgstr "Wird Teilnehmern angezeigt"
 
-#: course/models.py:291
 msgid "Name contains invalid characters."
 msgstr "Name enthält ungültige Zeichen."
 
-#: course/models.py:300
 msgid "Participation tag"
 msgstr "Teilnahmen-Tag"
 
-#: course/models.py:301
 msgid "Participation tags"
 msgstr "Teilnahmen-Tags"
 
-#: course/models.py:308 course/templates/course/gradebook-by-opp.html.py:98
-#: course/templates/course/gradebook-participant.html:26
-#: course/templates/course/gradebook.html:17
-#: course/templates/course/participation-table.html:5
-msgid "User ID"
-msgstr ""
-
-#: course/models.py:314
-msgid "Enroll time"
-msgstr "Registrierungszeit"
-
-#: course/models.py:317
 msgid ""
-"Instructors may update course content. Teaching assistants may access and "
-"change grade data. Observers may access analytics. Each role includes "
-"privileges from subsequent roles."
+"A symbolic name for this role, used in course code. "
+"lower_case_with_underscores, no spaces. May be any string. The name "
+"'unenrolled' is special and refers to anyone not enrolled in the course."
 msgstr ""
 
-#: course/models.py:321
+msgid "Role identifier"
+msgstr ""
+
+msgid "A human-readable description of this role."
+msgstr ""
+
+#, fuzzy
+#| msgid "Course name"
+msgid "Role name"
+msgstr "Kurs-Modul"
+
+#, fuzzy
+#| msgid "List of Participants"
+msgid "Is default role for new participants"
+msgstr "Teilnehmerliste"
+
+msgid "Is default role for unenrolled users"
+msgstr ""
+
+#, fuzzy, python-format
+#| msgid "%(user)s in %(course)s as %(role)s"
+msgid "%(identifier)s in %(course)s"
+msgstr "%(user)s in %(course)s als %(role)s"
+
 msgid "Participation role"
 msgstr "Teilnahme-Rolle"
 
-#: course/models.py:324
+#, fuzzy
+#| msgid "Participation role"
+msgid "Participation roles"
+msgstr "Teilnahme-Rolle"
+
+msgid "Permission"
+msgstr ""
+
+msgid "Argument"
+msgstr ""
+
+msgid "Role"
+msgstr "Rolle"
+
+#, fuzzy
+#| msgid "Participation role"
+msgid "Participation role permission"
+msgstr "Teilnahme-Rolle"
+
+#, fuzzy
+#| msgid "Participation role"
+msgid "Participation role permissions"
+msgstr "Teilnahme-Rolle"
+
+msgid "User ID"
+msgstr ""
+
+msgid "Enroll time"
+msgstr "Registrierungszeit"
+
+msgid "Role (unused)"
+msgstr ""
+
 msgid "Participation status"
 msgstr "Teilnahme-Status"
 
-#: course/models.py:329
 msgid "Multiplier for time available on time-limited flows"
 msgstr ""
 
-#: course/models.py:331
 msgid "Time factor"
 msgstr "Zeit-Faktor"
 
-#: course/models.py:335
 msgid "Preview git commit SHA"
 msgstr ""
 
-#: course/models.py:338 course/templates/course/gradebook-participant.html:38
-#: course/templates/course/participation-table.html:9
 msgid "Tags"
+msgstr ""
+
+msgid "Notes"
 msgstr ""
 
 #. Translators: displayed format of Participation: some user in some
 #. course as some role
-#: course/models.py:343
 #, python-format
 msgid "%(user)s in %(course)s as %(role)s"
 msgstr "%(user)s in %(course)s als %(role)s"
 
-#: course/models.py:351 course/models.py:444 course/models.py:856
-#: course/models.py:932 course/models.py:1102 course/models.py:1375
-#: course/models.py:1434 course/templates/course/course-base.html.py:125
 msgid "Participation"
 msgstr "Teilnahme"
 
-#: course/models.py:352
 msgid "Participations"
 msgstr "Teilnahmen"
 
-#: course/models.py:373 course/models.py:874 course/models.py:937
-#: course/models.py:1130 course/models.py:1437
+#, fuzzy
+#| msgid "Participation role"
+msgid "Participation permission"
+msgstr "Teilnahme-Rolle"
+
+#, fuzzy
+#| msgid "Participation preapprovals"
+msgid "Participation permissionss"
+msgstr "Teilnahmen-Vorab-Bestätigungen"
+
 msgid "Creator"
 msgstr "Ersteller"
 
-#: course/models.py:375 course/models.py:876 course/models.py:939
-#: course/models.py:1057 course/models.py:1439
 msgid "Creation time"
 msgstr "Erstellungszeitpunkt"
 
 #. Translators: somebody's email in some course in Participation
 #. Preapproval
-#: course/models.py:381
 #, fuzzy, python-format
 #| msgid "%(user)s in %(course)s as %(role)s"
 msgid "Email %(email)s in %(course)s"
@@ -2117,625 +2230,586 @@ msgstr "%(user)s in %(course)s als %(role)s"
 
 #. Translators: somebody's Institutional ID in some course in
 #. Participation Preapproval
-#: course/models.py:386
 #, python-format
 msgid "Institutional ID %(inst_id)s in %(course)s"
 msgstr ""
 
-#: course/models.py:393
 msgid "Participation preapproval"
 msgstr "Teilnahmen-Vorab-Bestätigung"
 
-#: course/models.py:394
 msgid "Participation preapprovals"
 msgstr "Teilnahmen-Vorab-Bestätigungen"
 
-#: course/models.py:413
+#, fuzzy
+#| msgctxt "Participation role"
+#| msgid "Instructor"
+msgid "Instructor"
+msgstr "Instruktor"
+
+#, fuzzy
+#| msgctxt "Participation role"
+#| msgid "Teaching Assistant"
+msgid "Teaching Assistant"
+msgstr "Assistent"
+
+#, fuzzy
+#| msgctxt "Participation role"
+#| msgid "Student"
+msgid "Student"
+msgstr "Student/Schüler"
+
+#, fuzzy
+#| msgid "Deny enrollment"
+msgid "Unenrolled"
+msgstr "Einschreibung verweigern"
+
 msgid "Cancelled"
 msgstr ""
 
-#: course/models.py:416
 msgid "Instant flow request"
 msgstr "Sofort-Flow-Anforderung"
 
-#: course/models.py:417 course/templates/course/course-base.html.py:130
 msgid "Instant flow requests"
 msgstr "Sofort-Flow-Anforderungen"
 
-#: course/models.py:420
 #, python-format
 msgid "Instant flow request for %(flow_id)s in %(course)s at %(start_time)s"
 msgstr ""
 
-#: course/models.py:459
 msgid "Completion time"
 msgstr "Abschlusszeit"
 
-#: course/models.py:461
 msgid "Page count"
 msgstr "Seitenzahl"
 
-#: course/models.py:469
 #, fuzzy
 #| msgid "Update Course Revision"
 msgid "Page data at course revision"
 msgstr "Kurs-Version aktualisieren"
 
-#: course/models.py:471
 #, fuzzy
 #| msgid "Prevent updating to a git revision prior to the current one"
 msgid "Page set-up data is up-to date for this revision of the course material"
 msgstr "Aktualisierung auf eine vorherige git-Version verhindern"
 
-#: course/models.py:475
 msgid "In progress"
 msgstr "Im Gange"
 
-#: course/models.py:482 course/templates/course/gradebook-single.html.py:166
 msgid "Expiration mode"
 msgstr "Ablauf-Modus"
 
-#: course/models.py:491 course/models.py:1119
-#: course/templates/course/gradebook-single.html:226
 msgid "Points"
 msgstr "Punkte"
 
-#: course/models.py:494
 msgid "Max point"
 msgstr ""
 
-#: course/models.py:496
 msgid "Result comment"
 msgstr "Resultats-Kommentar"
 
-#: course/models.py:499 course/models.py:562 course/models.py:625
-#: course/models.py:1136 course/templates/course/grade-flow-page.html.py:58
 msgid "Flow session"
 msgstr "Flow-Sitzung"
 
-#: course/models.py:500 course/templates/course/gradebook-single.html.py:131
 msgid "Flow sessions"
 msgstr "Flow-Sitzungen"
 
-#: course/models.py:505
 #, python-format
 msgid "anonymous session %(session_id)d on '%(flow_id)s'"
 msgstr ""
 
-#: course/models.py:509
 #, python-format
 msgid "%(user)s's session %(session_id)d on '%(flow_id)s'"
 msgstr ""
 
-#: course/models.py:564
 msgid "Ordinal"
 msgstr ""
 
-#: course/models.py:569
 msgid "Page type as indicated in course content"
 msgstr ""
 
-#: course/models.py:573
 msgid "Group ID"
 msgstr "Gruppen-ID"
 
-#: course/models.py:580
 msgid "Data"
 msgstr ""
 
-#: course/models.py:582
 #, fuzzy
 #| msgid "Page count"
 msgid "Page Title"
 msgstr "Seitenzahl"
 
-#: course/models.py:585
 msgid ""
 "A user-facing 'marking' feature to allow participants to easily return to "
 "pages that still need their attention."
 msgstr ""
 
-#: course/models.py:587
 msgid "Bookmarked"
 msgstr ""
 
-#: course/models.py:590 course/models.py:591
 msgid "Flow page data"
 msgstr "Flow-Seiten-Daten"
 
-#: course/models.py:595
 #, python-format
 msgid ""
-"Data for page '%(group_id)s/%(page_id)s' (ordinal %(ordinal)s) in "
-"%(flow_session)s"
+"Data for page '%(group_id)s/%(page_id)s' (ordinal %(ordinal)s) in %"
+"(flow_session)s"
 msgstr ""
 
-#: course/models.py:628 course/models.py:787
 msgid "Page data"
 msgstr ""
 
-#: course/models.py:630
 msgid "Visit time"
 msgstr ""
 
-#: course/models.py:632
 msgid "Remote address"
 msgstr ""
 
-#: course/models.py:635
+#, fuzzy
+#| msgid "Impersonate"
+msgid "Impersonated by"
+msgstr "Sich-ausgeben-als"
+
 msgid ""
 "Synthetic flow page visits are generated for unvisited pages once a flow is "
 "finished. This is needed since grade information is attached to a visit, and "
 "it needs a place to go."
 msgstr ""
 
-#: course/models.py:639
 msgid "Is synthetic"
 msgstr "Ist synthetisch"
 
 #. Translators: "Answer" is a Noun.
-#: course/models.py:645 course/page/code.py:62 course/page/text.py:98
 msgid "Answer"
 msgstr "Antwort"
 
 #. Translators: determine whether the answer is a final,
 #. submitted answer fit for grading.
-#: course/models.py:658
 msgid "Is submitted answer"
 msgstr "Ist eingereichte Antwort"
 
 #. Translators: flow page visit
-#: course/models.py:663
 #, python-format
 msgid "'%(group_id)s/%(page_id)s' in '%(session)s' on %(time)s"
 msgstr ""
 
 #. Translators: flow page visit: if an answer is
 #. provided by user then append the string.
-#: course/models.py:673
 msgid " (with answer)"
 msgstr " (mit Antwort)"
 
-#: course/models.py:681
 msgid "Flow page visit"
 msgstr "Flow-Seiten-Besuch"
 
-#: course/models.py:682
 msgid "Flow page visits"
 msgstr "Flow-Seiten-Besuche"
 
-#: course/models.py:709
 msgid "Visit"
 msgstr ""
 
-#: course/models.py:713 course/templates/course/gradebook-single.html.py:228
 msgid "Grader"
 msgstr "Benotet von"
 
-#: course/models.py:715 course/models.py:1132
 msgid "Grade time"
 msgstr ""
 
-#: course/models.py:719
 msgid "Graded at git commit SHA"
 msgstr ""
 
-#: course/models.py:724
 msgid "Grade data"
 msgstr ""
 
 #. Translators: max point in grade
-#: course/models.py:732
 msgid "Point value of this question when receiving full credit."
 msgstr ""
 
 #. Translators: correctness in grade
-#: course/models.py:737
 msgid ""
 "Real number between zero and one (inclusively) indicating the degree of "
 "correctness of the answer."
 msgstr ""
 
-#: course/models.py:739
 msgid "Correctness"
 msgstr ""
 
 #. Translators: "Feedback" stands for the feedback of answers.
-#: course/models.py:750 course/templates/course/grade-import-preview.html.py:21
 msgid "Feedback"
 msgstr ""
 
-#: course/models.py:765
 msgid "Flow page visit grade"
 msgstr ""
 
-#: course/models.py:766
 msgid "Flow page visit grades"
 msgstr ""
 
 #. Translators: return the information of the grade of a user
 #. by percentage.
-#: course/models.py:776
 #, python-format
 msgid "grade of %(visit)s: %(percentage)s"
 msgstr ""
 
-#: course/models.py:789 course/templates/course/grade-import-preview.html.py:20
-#: course/templates/course/gradebook-participant.html:53
-#: course/templates/course/gradebook-single.html:72
 msgid "Grade"
 msgstr "Note"
 
-#: course/models.py:794
 msgid "Bulk feedback"
 msgstr ""
 
-#: course/models.py:830
 msgid "stipulations must be a dictionary"
 msgstr ""
 
-#: course/models.py:835
 msgid "unrecognized keys in stipulations"
 msgstr ""
 
-#: course/models.py:841
 msgid "credit_percent must be a float"
 msgstr ""
 
-#: course/models.py:847
 msgid "'allowed_session_count' must be a non-negative integer"
 msgstr ""
 
-#: course/models.py:860 course/models.py:934
 msgid "Expiration"
 msgstr ""
 
 #. Translators: help text for stipulations in FlowAccessException
 #. (deprecated)
-#: course/models.py:865
 msgid ""
 "A dictionary of the same things that can be added to a flow access rule, "
 "such as allowed_session_count or credit_percent. If not specified here, "
 "values will default to the stipulations in the course content."
 msgstr ""
 
-#: course/models.py:871
 msgid "Stipulations"
 msgstr ""
 
 #. Translators: deprecated
-#: course/models.py:881
 msgid ""
 "Check if a flow started under this exception rule set should stay under this "
 "rule set until it is expired."
 msgstr ""
 
 #. Translators: deprecated
-#: course/models.py:885
 msgid "Is sticky"
 msgstr ""
 
 #. Translators: flow access exception in admin (deprecated)
-#: course/models.py:893
 #, python-format
 msgid "Access exception for '%(user)s' to '%(flow_id)s' in '%(course)s'"
 msgstr ""
 
-#: course/models.py:910
 msgid "Exception"
 msgstr ""
 
-#: course/models.py:913
-msgid "Permission"
-msgstr ""
-
 #. Translators: FlowAccessExceptionEntry (deprecated)
-#: course/models.py:917
 msgid "Flow access exception entries"
 msgstr ""
 
-#: course/models.py:946
 msgid "Kind"
 msgstr ""
 
-#: course/models.py:948
 msgid "Rule"
 msgstr ""
 
-#: course/models.py:951
 msgctxt "Is the flow rule exception activated?"
 msgid "Active"
 msgstr ""
 
 #. Translators: For FlowRuleException
-#: course/models.py:956
 #, python-format
 msgid "%(kind)s exception for '%(user)s' to '%(flow_id)s'in '%(course)s'"
 msgstr ""
 
-#: course/models.py:972
 msgid "grading rules may not expire"
 msgstr ""
 
-#: course/models.py:1015
 msgid "invalid rule kind: "
 msgstr ""
 
-#: course/models.py:1019
 msgid "invalid existing_session_rules: "
 msgstr ""
 
-#: course/models.py:1022
 msgid "Flow rule exception"
 msgstr "Flow-Regel-Ausnahme"
 
-#: course/models.py:1023
 msgid "Flow rule exceptions"
 msgstr "Flow-Regel-Ausnahmen"
 
 #. Translators: format of identifier for GradingOpportunity
-#: course/models.py:1036
 msgid "A symbolic name for this grade. lower_case_with_underscores, no spaces."
 msgstr ""
 
-#: course/models.py:1038
 msgid "Grading opportunity ID"
 msgstr ""
 
 #. Translators: name for GradingOpportunity
-#: course/models.py:1041
 msgid "A human-readable identifier for the grade."
 msgstr ""
 
-#: course/models.py:1042
 msgid "Grading opportunity name"
 msgstr ""
 
-#: course/models.py:1044
 msgid "Flow identifier that this grading opportunity is linked to, if any"
 msgstr ""
 
 #. Translators: strategy on how the grading of mutiple sessioins
 #. are aggregated.
-#: course/models.py:1052 course/templates/course/gradebook-by-opp.html.py:31
-#: course/templates/course/gradebook-opp-list.html:22
-#: course/templates/course/gradebook-single.html:119
 msgid "Aggregation strategy"
 msgstr ""
 
-#: course/models.py:1055 course/models.py:1127
-#: course/templates/course/gradebook-opp-list.html:23 course/views.py:932
 msgid "Due time"
 msgstr ""
 
-#: course/models.py:1060
 msgid "Shown in grade book"
 msgstr ""
 
-#: course/models.py:1062
 msgid "Shown in student grade book"
 msgstr ""
 
-#: course/models.py:1064
+#, fuzzy
+#| msgid "This grade is not shown in the student grade book."
+msgid "Result shown in student grade book"
+msgstr "Diese Note wird nicht im Teilnehmer-Notenbuch gezeigt."
+
 msgid "Scores for individual pages are shown in the participants' grade book"
 msgstr ""
 
-#: course/models.py:1068 course/models.py:1099
+msgid "Hide superseded grade history before"
+msgstr ""
+
+msgid ""
+"Grade changes dated before this date that are superseded by later grade "
+"changes will not be shown to participants. This can help avoid discussions "
+"about pre-release grading adjustments. May be blank. In that case, the "
+"entire grade history is shown."
+msgstr ""
+
 msgid "Grading opportunity"
 msgstr "Benotungsmöglichkeit"
 
-#: course/models.py:1069
 msgid "Grading opportunities"
 msgstr "Benotungsmöglichkeiten"
 
 #. Translators: For GradingOpportunity
-#: course/models.py:1076
 #, python-format
 msgid "%(opportunity_name)s (%(opportunity_id)s) in %(course)s"
 msgstr ""
 
 #. Translators: something like 'status'.
-#: course/models.py:1107 course/templates/course/flow-start.html.py:24
-#: course/templates/course/gradebook-single.html:139
-#: course/templates/course/task-monitor.html:17
 msgid "State"
 msgstr "Zustand"
 
 #. Translators: help text of "attempt_id" in GradeChange class
-#: course/models.py:1112
 msgid ""
 "Grade changes are grouped by their 'attempt ID' where later grades with the "
 "same attempt ID supersede earlier ones."
 msgstr ""
 
-#: course/models.py:1139
 msgid "Grade change"
 msgstr "Noten-Änderung"
 
-#: course/models.py:1140
 msgid "Grade changes"
 msgstr "Noten-Änderungen"
 
 #. Translators: information for GradeChange
-#: course/models.py:1145
 #, python-format
 msgid "%(participation)s %(state)s on %(opportunityname)s"
 msgstr ""
 
-#: course/models.py:1157
 msgid "Participation and opportunity must live in the same course"
 msgstr ""
 
-#: course/models.py:1209
 msgid "cannot accept grade once opportunity has been marked 'unavailable'"
 msgstr ""
 
-#: course/models.py:1213
 msgid "cannot accept grade once opportunity has been marked 'exempt'"
 msgstr ""
 
-#: course/models.py:1256
 #, python-format
 msgid "invalid grade change state '%s'"
 msgstr ""
 
-#: course/models.py:1298
 #, python-format
 msgid "invalid grade aggregation strategy '%s'"
 msgstr ""
 
 #. Translators: display the name of a flow
-#: course/models.py:1348
 #, python-format
 msgid "Flow: %(flow_desc_title)s"
 msgstr ""
 
-#: course/models.py:1377
 msgid "Text"
 msgstr ""
 
-#: course/models.py:1379 course/templates/course/gradebook-single.html.py:69
-#: course/views.py:332
 msgid "Time"
 msgstr ""
 
-#: course/models.py:1382
 msgid "Instant message"
 msgstr "Sofortnachricht"
 
-#: course/models.py:1383
 msgid "Instant messages"
 msgstr "Sofortnachrichten"
 
-#: course/models.py:1401
 msgid "Description"
 msgstr "Beschreibung"
 
-#: course/models.py:1406
-msgid "Currently active"
+#, fuzzy
+#| msgctxt "User status"
+#| msgid "Active"
+msgid "Active"
+msgstr "Aktiv"
+
+msgid "Currently active, i.e. may be used to log in via an exam ticket"
 msgstr ""
 
-#: course/models.py:1409
+#, fuzzy
+#| msgid "List"
+msgid "Listed"
+msgstr "Liste"
+
+msgid "Shown in the list of current exams"
+msgstr ""
+
 msgid "No exams before"
 msgstr ""
 
-#: course/models.py:1412
 msgid "No exams after"
 msgstr ""
 
-#: course/models.py:1416 course/templates/course/course-base.html.py:80
-#: relate/templates/base.html:84
 msgid "Exams"
 msgstr "Prüfungen"
 
-#: course/models.py:1420
 #, python-format
 msgid "Exam  %(description)s in %(course)s"
 msgstr ""
 
-#: course/models.py:1441
+#, fuzzy
+#| msgid "User name"
+msgid "Usage time"
+msgstr "Benutzername"
+
 msgid "Date and time of first usage of ticket"
 msgstr ""
 
-#: course/models.py:1446
 msgid "Exam ticket state"
 msgstr ""
 
-#: course/models.py:1451
+#, fuzzy
+#| msgid "invalid period: %s"
+msgid "End valid period"
+msgstr "Ungültiges Zeitintervall: %s"
+
+msgid ""
+"If not blank, date and time at which this exam ticket starts being valid/"
+"usable"
+msgstr ""
+
+msgid ""
+"If not blank, date and time at which this exam ticket stops being valid/"
+"usable"
+msgstr ""
+
+msgid "If not blank, this exam ticket may only be used in the given facility"
+msgstr ""
+
 msgid "Exam ticket"
 msgstr "Prüfungsticket"
 
-#: course/models.py:1452
 msgid "Exam tickets"
 msgstr "Prüfungstickets"
 
-#: course/models.py:1455
 msgid "Can issue exam tickets to student"
 msgstr ""
 
-#: course/models.py:1459
 #, python-format
 msgid "Exam  ticket for %(participation)s in %(exam)s"
 msgstr ""
 
-#: course/models.py:1472
 msgid "Participation and exam must live in the same course"
 msgstr ""
 
-#: course/page/base.py:107
-msgid "Your answer is not correct."
-msgstr ""
-
-#: course/page/base.py:109
-msgid "Your answer is correct."
-msgstr ""
-
-#: course/page/base.py:113
-msgid "Your answer is mostly correct."
-msgstr ""
-
-#: course/page/base.py:117
 msgid "No information on correctness of answer."
 msgstr ""
 
-#: course/page/base.py:121
-msgid "Your answer is somewhat correct."
+msgid "Your answer is not correct."
 msgstr ""
 
-#: course/page/base.py:150
+msgid "Your answer is correct."
+msgstr ""
+
+msgid "Your answer is correct and earned bonus points."
+msgstr ""
+
+msgid "Your answer is mostly correct."
+msgstr ""
+
+msgid "Your answer is somewhat correct. "
+msgstr ""
+
 msgid "Invalid correctness value"
 msgstr ""
 
-#: course/page/base.py:544
+msgid "Not passing page_desc to PageBase.__init__ is deprecated"
+msgstr ""
+
+#, python-format
+msgid "%s is using the make_page_data compatiblity hook, which is deprecated."
+msgstr ""
+
+#, python-format
+msgid "%s is using the post_form compatiblity hook, which is deprecated."
+msgstr ""
+
+#, python-format
+msgid ""
+"%s is using the update_grade_data_from_grading_form compatiblity hook, which "
+"is deprecated."
+msgstr ""
+
 #, python-format
 msgid ""
 "PageBaseWithTitle subclass '%s' does not implement markdown_body_for_title()"
 msgstr ""
 
-#: course/page/base.py:555
 msgid "no title found in body or title attribute"
 msgstr ""
 
-#: course/page/base.py:599
+msgid "Attribute 'value' should be removed when 'is_optional_page' is True."
+msgstr ""
+
 msgid "Grade assigned, in percent"
 msgstr ""
 
-#: course/page/base.py:604
 msgid "Grade percent"
 msgstr ""
 
-#: course/page/base.py:610
 #, python-format
 msgid ""
 "Grade assigned, as points out of %.1f. Fill out either this or 'grade "
 "percent'."
 msgstr ""
 
-#: course/page/base.py:617
 msgid "Grade points"
 msgstr "Notenpunkte"
 
-#: course/page/base.py:623
 msgid ""
 "Feedback to be shown to student, using <a href='http://documen.tician.de/"
 "relate/content.html#relate-markup'>RELATE-flavored Markdown</a>"
 msgstr ""
 
-#: course/page/base.py:627
 msgid "Feedback text"
 msgstr ""
 
-#: course/page/base.py:630
 msgid ""
 "Checking this box and submitting the form will notify the participant with a "
 "generic message containing the feedback text"
 msgstr ""
 
-#: course/page/base.py:633
 msgid "Notify"
 msgstr "Benachrichtigen"
 
-#: course/page/base.py:636
+msgid "Allow recipient to reply to this email?"
+msgstr ""
+
+msgid "May reply email to me"
+msgstr ""
+
 msgid ""
 "Whether the grade and feedback are to be shown to student. (If you would "
 "like to release all grades at once, do not use this. Instead, use the 'shown "
@@ -2743,99 +2817,121 @@ msgid ""
 "admin.)"
 msgstr ""
 
-#: course/page/base.py:641
 msgid "Released"
 msgstr ""
 
-#: course/page/base.py:644
 msgid "Internal notes, not shown to student"
 msgstr ""
 
-#: course/page/base.py:646
-msgid "Notes"
+msgid ""
+"Checking this box and submitting the form will notify the instructor with a "
+"generic message containing the notes"
 msgstr ""
 
-#: course/page/base.py:659 course/page/base.py:673
+#, fuzzy
+#| msgctxt "Participation role"
+#| msgid "Instructor"
+msgid "Notify instructor"
+msgstr "Instruktor"
+
 msgid "Grade (percent) and Grade (points) disagree"
 msgstr ""
 
-#: course/page/base.py:750
 msgid "New notification"
 msgstr ""
 
-#: course/page/base.py:781 course/page/choice.py:240 course/page/choice.py:373
-#: course/page/code.py:557 course/page/code.py:905 course/page/inline.py:837
-#: course/page/text.py:911
+#, python-format
+msgid "Grading notes from %(ta)s"
+msgstr ""
+
 msgid "No answer provided."
 msgstr ""
 
-#: course/page/base.py:803
 msgid "The following feedback was provided"
 msgstr ""
 
 #. Translators: "choice" in Choice Answer Form in a single-choice question.
-#: course/page/choice.py:47
 msgid "Choice"
 msgstr "Auswahl"
 
 #. Translators: "Choice" in Choice Answer Form in a multiple
 #. choice question in which multiple answers can be chosen.
-#: course/page/choice.py:58
-msgid "Choices"
-msgstr "Auswahl"
+msgid "Select all that apply:"
+msgstr ""
 
-#: course/page/choice.py:133 course/page/choice.py:493
-#: course/page/inline.py:421
 #, python-format
 msgid "choice %(idx)d: unable to convert to string"
 msgstr ""
 
-#: course/page/choice.py:148
-#, python-format
-msgid "one or more correct answer(s) expected, %(n_correct)d found"
-msgstr ""
-
-#: course/page/choice.py:208
 msgid ""
 "existing choice permutation not suitable for number of choices in question"
 msgstr ""
 
-#: course/page/choice.py:254 course/page/inline.py:809 course/page/text.py:932
+#, python-format
+msgid "one or more correct answer(s) expected, %(n_correct)d found"
+msgstr ""
+
+msgid "ChoiceQuestion does not allow any choices marked 'disregard'"
+msgstr ""
+
+msgid "ChoiceQuestion does not allow any choices marked 'always_correct'"
+msgstr ""
+
 msgid "A correct answer is"
 msgstr ""
 
-#: course/page/choice.py:338
 msgid ""
-"'allow_partial_credit' and 'allow_partial_credit_subset_only' are not "
-"allowed to co-exist when both attribute are 'True'"
+"'allow_partial_credit' or 'allow_partial_credit_subset_only' may not be "
+"specifiedat the same time as 'credit_mode'"
 msgstr ""
 
-#: course/page/choice.py:424
+msgid ""
+"'allow_partial_credit' and 'allow_partial_credit_subset_only' are not "
+"allowed to coexist when both attribute are 'True'"
+msgstr ""
+
+#, python-format
+msgid "unrecognized credit_mode '%(credit_mode)s'"
+msgstr ""
+
+msgid ""
+"'credit_mode' will be required on multi-select choice questions in a future "
+"version. set 'credit_mode: {}' to match current behavior."
+msgstr ""
+
 msgid "The correct answer is"
 msgstr ""
 
-#: course/page/code.py:644
+msgid "Additional acceptable options are"
+msgstr ""
+
+msgid ""
+"code question does not explicitly allow multiple submission. Either add "
+"access_rules/add_permssions/change_answer or add 'single_submission: True' "
+"to confirm that you intend for only a single submission to be allowed. While "
+"you're at it, consider adding access_rules/add_permssions/see_correctness."
+msgstr ""
+
 msgid "code question execution failed"
 msgstr ""
 
-#: course/page/code.py:656
+msgid "<unknown flow>"
+msgstr ""
+
 msgid ""
 "Both the grading code and the attempt to notify course staff about the issue "
 "failed. Please contact the course or site staff and inform them of this "
 "issue, mentioning this entire error message:"
 msgstr ""
 
-#: course/page/code.py:664
 msgid ""
 "Sending an email to the course staff about the following failure failed with "
 "the following error message:"
 msgstr ""
 
-#: course/page/code.py:670
 msgid "The original failure message follows:"
 msgstr ""
 
-#: course/page/code.py:698
 msgid ""
 "The grading code failed. Sorry about that. The staff has been informed, and "
 "if this problem is due to an issue with the grading code, it will be fixed "
@@ -2843,168 +2939,164 @@ msgid ""
 "help you figure out what went wrong."
 msgstr ""
 
-#: course/page/code.py:710
 #, python-format
 msgid ""
 "Your code took too long to execute. The problem specifies that your code may "
 "take at most %s seconds to run. It took longer than that and was aborted."
 msgstr ""
 
-#: course/page/code.py:722
 msgid "Your code failed to compile. An error message is below."
 msgstr ""
 
-#: course/page/code.py:730
 msgid "Your code failed with an exception. A traceback is below."
 msgstr ""
 
-#: course/page/code.py:741
 msgid "Here is some feedback on your code"
 msgstr ""
 
-#: course/page/code.py:750
 msgid "This is the exception traceback"
 msgstr ""
 
-#: course/page/code.py:763
 #, python-format
 msgid "Your code ran on %s."
 msgstr ""
 
-#: course/page/code.py:769
 msgid "Your code printed the following output"
 msgstr ""
 
-#: course/page/code.py:776
 msgid "Your code printed the following error messages"
 msgstr ""
 
-#: course/page/code.py:782
 msgid "Your code produced the following plots"
 msgstr ""
 
-#: course/page/code.py:791
 msgid "Figure"
 msgstr ""
 
-#: course/page/code.py:813
 msgid "The following code is a valid answer"
 msgstr ""
 
-#: course/page/code.py:887
+msgid ""
+"'human_feedback_value' and 'human_feedback_percentage' are not allowed to "
+"coexist"
+msgstr ""
+
+msgid ""
+"expecting either 'human_feedback_value' or 'human_feedback_percentage', "
+"found neither."
+msgstr ""
+
+msgid ""
+"Used deprecated 'human_feedback_value' attribute--use "
+"'human_feedback_percentage' instead."
+msgstr ""
+
+msgid ""
+"'human_feedback_value' attribute is not allowed if value of question is 0, "
+"use 'human_feedback_percentage' instead"
+msgstr ""
+
 msgid "human_feedback_value greater than overall value of question"
 msgstr ""
 
-#: course/page/inline.py:134
+msgid "the value of human_feedback_percentage must be between 0 and 100"
+msgstr ""
+
 #, python-format
 msgid "unknown embedded question type '%(type)s'"
 msgstr ""
 
-#: course/page/inline.py:148
 msgid "must be struct"
 msgstr ""
 
-#: course/page/inline.py:239
 #, python-format
 msgid "unrecogonized width attribute string: '%(width_attr)s'"
 msgstr ""
 
-#: course/page/inline.py:250
 #, python-format
 msgid ""
-"unsupported length unit '%(length_unit)s', expected length unit can be "
-"%(allowed_length_unit)s"
+"unsupported length unit '%(length_unit)s', expected length unit can be %"
+"(allowed_length_unit)s"
 msgstr ""
 
-#: course/page/inline.py:293 course/page/text.py:881
 msgid "at least one answer must be provided"
 msgstr ""
 
 #. Translators: refers to optional
 #. correct answer for checking
 #. correctness sumbitted by students.
-#: course/page/inline.py:316
 msgid "answer"
 msgstr ""
 
-#: course/page/inline.py:326 course/page/text.py:896
 msgid "no matcher is able to provide a plain-text correct answer"
 msgstr ""
 
-#: course/page/inline.py:438
 #, python-format
 msgid ""
-"one or more correct answer(s) expected  for question '%(question_name)s', "
-"%(n_correct)d found"
+"one or more correct answer(s) expected  for question '%(question_name)s', %"
+"(n_correct)d found"
 msgstr ""
 
-#: course/page/inline.py:628
+msgid "InlineMultiQuestion requires at least one answer field to be defined."
+msgstr ""
+
 #, python-format
 msgid "invalid answers name %s. "
 msgstr ""
 
-#: course/page/inline.py:629 course/page/inline.py:647
 msgid ""
 "A valid name should start with letters. Alphanumeric with underscores. Do "
 "not use spaces."
 msgstr ""
 
-#: course/page/inline.py:646
 #, python-format
 msgid "invalid embedded question name %s. "
 msgstr ""
 
-#: course/page/inline.py:664
 #, python-format
 msgid "embedded question name %s not unique."
 msgstr ""
 
-#: course/page/inline.py:675
 #, python-format
 msgid "correct answer(s) not provided for question %s."
 msgstr ""
 
-#: course/page/inline.py:683
 #, python-format
 msgid "redundant answers %s provided for non-existing question(s)."
 msgstr ""
 
-#: course/page/inline.py:710
 #, python-format
 msgid "have unpaired '%s'."
 msgstr ""
 
-#: course/page/text.py:153
 #, python-format
 msgid "page must be of type '%s'"
 msgstr ""
 
-#: course/page/text.py:176
 msgid "unknown validator type"
 msgstr ""
 
-#: course/page/text.py:186 course/page/text.py:595
 msgid "must be struct or string"
 msgstr ""
 
-#: course/page/text.py:285
 #, python-format
 msgid "regex '%(pattern)s' did not compile"
 msgstr ""
 
-#: course/page/text.py:341
 msgid "unable to check symbolic expression"
 msgstr ""
 
-#: course/page/text.py:445 course/page/text.py:456 course/page/text.py:474
 msgid "does not provide a valid float literal"
 msgstr ""
 
-#: course/page/text.py:463
 msgid "not allowed when 'value' is zero"
 msgstr ""
 
-#: course/page/text.py:484
+msgid ""
+"Float match for 'value' zero should have atol--otherwise it will match any "
+"number"
+msgstr ""
+
 msgid ""
 "Float match should have either rtol or atol--otherwise it will match any "
 "number"
@@ -3013,419 +3105,307 @@ msgstr ""
 #. Translators: a "matcher" is used to determine
 #. if the answer to text question (blank filling
 #. question) is correct.
-#: course/page/text.py:542
 #, python-format
 msgid "%(matcherclassname)s only accepts '%(matchertype)s' patterns"
 msgstr ""
 
-#: course/page/text.py:554
 #, python-format
 msgid "unknown match type '%(matchertype)s'"
 msgstr ""
 
-#: course/page/text.py:573
 msgid "does not specify match type"
 msgstr ""
 
-#: course/page/text.py:581
 msgid "uses deprecated 'matcher:answer' style"
 msgstr ""
 
-#: course/page/text.py:602
 msgid "matcher must supply 'type'"
 msgstr ""
 
-#: course/page/text.py:653
 msgid "unrecognized widget type"
 msgstr ""
 
-#: course/page/upload.py:44
 msgid "Uploaded file"
 msgstr "Hochgeladene Datei"
 
-#: course/page/upload.py:58
 #, python-format
 msgid ""
-"Please keep file size under %(allowedsize)s. Current filesize is "
-"%(uploadedsize)s."
+"Please keep file size under %(allowedsize)s. Current filesize is %"
+"(uploadedsize)s."
 msgstr ""
 
-#: course/page/upload.py:65
 msgid "Uploaded file is not a PDF."
 msgstr ""
 
-#: course/page/upload.py:151
 msgid "unrecognized mime types"
 msgstr ""
 
-#: course/page/upload.py:161
 msgid "upload question does not have assigned point value"
 msgstr ""
 
-#: course/sandbox.py:63
 msgid "Press Alt/Cmd+(Shift+)P to preview."
 msgstr ""
 
-#: course/sandbox.py:66
 msgid "Content"
 msgstr "Inhalt"
 
-#: course/sandbox.py:84 course/sandbox.py:138
-msgid "must be instructor or TA to access sandbox"
-msgstr ""
+msgid "Clear"
+msgstr "Löschen"
 
-#: course/sandbox.py:90
 msgid ""
 "Enter <a href=\"http://documen.tician.de/relate/content.html#relate-markup"
 "\">RELATE markup</a>."
 msgstr ""
 
-#: course/sandbox.py:112
 msgid "Markup failed to render"
 msgstr ""
 
-#: course/sandbox.py:160
+msgid "Clear Response Data"
+msgstr ""
+
 msgid "Enter YAML markup for a flow page."
 msgstr ""
 
-#: course/sandbox.py:190 course/sandbox.py:219
 msgid "Page failed to load/validate"
 msgstr ""
 
-#: course/sandbox.py:299
+msgid "Page failed to load/validate (change page ID to clear faults)"
+msgstr ""
+
 msgid "Submit answer"
 msgstr "Antwort einreichen"
 
-#: course/tasks.py:68
 #, python-format
 msgid "%d sessions expired."
 msgstr "%d Sitzungen abgelaufen."
 
-#: course/tasks.py:102
 #, python-format
 msgid "%d sessions ended."
 msgstr "%d Sitzungen beendet."
 
-#: course/tasks.py:134
 #, python-format
 msgid "Grades recalculated for %d sessions."
 msgstr ""
 
-#: course/tasks.py:169
 #, python-format
 msgid "%d sessions regraded."
 msgstr "%d Sitzungen neu benotet."
 
-#: course/templates/course/analytics-flow.html:5
-#: course/templates/course/analytics-flows.html:5
-#: course/templates/course/analytics-page.html:5
-#: course/templates/course/analytics-page.html:9
 msgid "Analytics"
 msgstr ""
 
-#: course/templates/course/analytics-flow.html:9
 #, python-format
 msgid " Analytics: <tt>%(flow_identifier)s</tt> "
 msgstr ""
 
-#: course/templates/course/analytics-flow.html:11
 msgid "Grade Distribution"
 msgstr "Notenverteilung"
 
 #. Translators: the following are the options when showing attempts of particiants in
 #. grade analytics.
 #.
-#: course/templates/course/analytics-flow.html:19
-#: course/templates/course/analytics-page.html:23
 msgid "Showing results for <i>only the first attempt</i> by each participant."
 msgstr ""
 
-#: course/templates/course/analytics-flow.html:23
-#: course/templates/course/analytics-page.html:27
 msgid "Show all attempts"
 msgstr ""
 
-#: course/templates/course/analytics-flow.html:26
-#: course/templates/course/analytics-page.html:30
 msgid "Showing results for <i>all attempts</i> by each participant."
 msgstr ""
 
-#: course/templates/course/analytics-flow.html:28
-#: course/templates/course/analytics-page.html:32
 msgid "Show only the first attempt"
 msgstr ""
 
-#: course/templates/course/analytics-flow.html:33
 #, python-format
 msgid "%(weight)s grade"
 msgid_plural "%(weight)s grades"
 msgstr[0] ""
 msgstr[1] ""
 
-#: course/templates/course/analytics-flow.html:39
 #, python-format
 msgid "(from %(participant_count)s distinct participant)"
 msgid_plural "(from %(participant_count)s distinct participants)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: course/templates/course/analytics-flow.html:49
 msgid "Page-by-Page Statistics"
 msgstr ""
 
-#: course/templates/course/analytics-flow.html:61
 #, python-format
 msgid "(%(answer_count)s non-empty response,"
 msgid_plural "(%(answer_count)s non-empty responses,"
 msgstr[0] ""
 msgstr[1] ""
 
-#: course/templates/course/analytics-flow.html:66
 #, python-format
 msgid "%(total_count)s response total)"
 msgid_plural "%(total_count)s responses total)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: course/templates/course/analytics-flow.html:93
 msgid "Time Distribution"
 msgstr ""
 
-#: course/templates/course/analytics-flows.html:9
 msgid "Analytics: List of Flows with Sessions"
 msgstr ""
 
-#: course/templates/course/analytics-flows.html:21
 msgid " No flow sessions have been recorded."
 msgstr ""
 
-#: course/templates/course/analytics-page.html:15
 msgid "Answer Distribution"
 msgstr ""
 
-#: course/templates/course/analytics-page.html:42
 #, python-format
 msgid "(%(astats_count)s response)"
 msgid_plural "(%(astats_count)s responses)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: course/templates/course/broken-code-question-email.txt:1
 #, python-format
 msgid ""
 "Hi there,\n"
+"This message was sent from %(site)s at %(time)s.\n"
 "Bad news! A code question with ID '%(page_id)s' in '%(course_identifier)s' "
 "has just failed while a user was trying to get his or her code graded.\n"
 "Details of the problem are below:\n"
 "%(error_message)s\n"
 msgstr ""
 
-#: course/templates/course/calendar.html:8
-#: course/templates/course/calendar.html:21
-#: course/templates/course/course-base.html:110
+msgid "You can navigate to the following url to check the problem:"
+msgstr ""
+
 msgid "Calendar"
 msgstr "Kalender"
 
-#: course/templates/course/calendar.html:42
 msgid ""
 "<b>Note:</b> Some calendar entries are clickable and link to entries below."
 msgstr ""
 
 #. Translators: The following are names for menu items in course page
-#: course/templates/course/course-base.html:32
 msgctxt "menu item"
 msgid "Student"
 msgstr ""
 
-#: course/templates/course/course-base.html:37
 msgid "View grades"
 msgstr "Noten ansehen"
 
-#: course/templates/course/course-base.html:38
 msgid "View calendar"
 msgstr "Kalender ansehen"
 
-#: course/templates/course/course-base.html:39
 msgid "Back to course page"
 msgstr "Zurück zur Kursseite"
 
-#: course/templates/course/course-base.html:46
 msgctxt "menu item"
 msgid "Grading"
 msgstr "Benotung"
 
-#: course/templates/course/course-base.html:48
 msgid "Analytics Overview"
 msgstr "Analytics-Überblick"
 
-#: course/templates/course/course-base.html:52
-#: course/templates/course/gradebook-participant.html:18
-msgid "Grades"
-msgstr "Noten"
+#, fuzzy
+#| msgid "Grade book"
+msgid "Grade Book"
+msgstr "Notenbuch"
 
-#: course/templates/course/course-base.html:53
-#: course/templates/course/gradebook-participant-list.html:7
-#: course/templates/course/gradebook-participant-list.html:15
 msgid "List of Participants"
 msgstr "Teilnehmerliste"
 
-#: course/templates/course/course-base.html:55
-#, fuzzy
-#| msgid "Participations"
-msgid "Edit Participations (admin)"
-msgstr "Teilnahmen"
-
-#: course/templates/course/course-base.html:57
-#: course/templates/course/gradebook-opp-list.html:8
-#: course/templates/course/gradebook-opp-list.html:16
 msgid "List of Grading Opportunities"
 msgstr "Liste der Benotungsmöglichkeiten"
 
-#: course/templates/course/course-base.html:59
-msgid "Edit Grading Opportunities (admin)"
-msgstr "Benotungsmöglichkeiten bearbeiten (Admin)"
-
-#: course/templates/course/course-base.html:61
-#: course/templates/course/gradebook-by-opp.html:8
-#: course/templates/course/gradebook-by-opp.html:17
-#: course/templates/course/gradebook-single.html:5
-#: course/templates/course/gradebook.html:5
-#: course/templates/course/gradebook.html:13
 msgid "Grade book"
 msgstr "Notenbuch"
 
-#: course/templates/course/course-base.html:62
 msgid "Grade book (CSV export)"
 msgstr "Notenbuch (CSV-Export)"
 
-#: course/templates/course/course-base.html:65
 msgid "Import Grades"
 msgstr "Noten importieren"
 
-#: course/templates/course/course-base.html:67
 msgid "Regrade flows"
 msgstr "Flows neu benoten"
 
-#: course/templates/course/course-base.html:71
 msgid "Exceptions"
 msgstr "Ausnahmen"
 
-#: course/templates/course/course-base.html:72
-#: course/templates/course/gradebook-single.html:294
-#: course/templates/course/gradebook-single.html:309
 msgid "Grant exception"
 msgstr "Ausnahme gewähren"
 
-#: course/templates/course/course-base.html:74
 msgid "Show exceptions"
 msgstr "Ausnahmen zeigen"
 
-#: course/templates/course/course-base.html:82
 msgid "Edit exams"
 msgstr "Prüfungen bearbeiten"
 
-#: course/templates/course/course-base.html:84
 msgid "Batch-issue exam tickets"
 msgstr "Prüfungstickets en masse ausgeben"
 
-#: course/templates/course/course-base.html:93
 msgctxt "menu item"
 msgid "Content"
 msgstr "Inhalte"
 
-#: course/templates/course/course-base.html:96
 msgid "Retrieve/preview new course revisions"
 msgstr "Abholen/Vorschau von neuen Kurs-Inhalten"
 
-#: course/templates/course/course-base.html:99
 msgid "Edit course"
 msgstr "Kurs bearbeiten"
 
-#: course/templates/course/course-base.html:102
 msgid "Content creation"
 msgstr "Inhaltserstellung"
 
-#: course/templates/course/course-base.html:103
 msgid "Page sandbox"
 msgstr "Seiten-Sandkasten"
 
-#: course/templates/course/course-base.html:104
 msgid "Markup sandbox"
 msgstr "Markup-Sandkasten"
 
-#: course/templates/course/course-base.html:107
 msgid "Test flow"
 msgstr "Flow testen"
 
-#: course/templates/course/course-base.html:112
 msgid "Edit events"
 msgstr "Ereignisse bearbeiten"
 
-#: course/templates/course/course-base.html:123
 msgctxt "menu item"
 msgid "Instructor"
 msgstr "Instruktor"
 
-#: course/templates/course/course-base.html:126
 msgctxt "menu item"
 msgid "Preapprove enrollments"
 msgstr "Teilnahmen vorab bestätigen"
 
-#: course/templates/course/course-base.html:127
 msgctxt "menu item"
 msgid "Query participations"
 msgstr "Teilnahmen durchsuchen"
 
-#: course/templates/course/course-base.html:131
 msgid "Manage instant flow requests"
 msgstr "Sofort-Flow-Anforderungen verwalten"
 
-#: course/templates/course/course-base.html:142
-msgid "You are currently seeing a preview of revision"
-msgstr "Sie sehen eine Vorschau von Revision"
-
-#: course/templates/course/course-base.html:145
-msgid "View revisions"
-msgstr "Versionen ansehen"
-
-#: course/templates/course/course-base.html:155
 msgid "There is an interactive activity going on right now."
 msgstr "Es ist eine interaktive Aktivität im Gange."
 
-#: course/templates/course/course-base.html:159
-#: course/templates/course/course-base.html:166
 msgid "Go to activity"
 msgstr "Zur Aktivität"
 
-#: course/templates/course/course-base.html:162
 msgid "There are some interactive activities going on right now."
 msgstr "Es sind interaktive Aktivitäten im Gange"
 
-#: course/templates/course/course-page.html:8
 msgid "This course is only visible to course staff at the moment."
 msgstr "Dieser Kurs ist im Moment nur für Kurs-Mitarbeiter sichtbar."
 
-#: course/templates/course/course-page.html:10
 msgctxt "change the visibility of a course"
 msgid "Change"
 msgstr "Ändern"
 
-#: course/templates/course/course-page.html:15
 msgid "You're not currently signed in."
 msgstr ""
 
-#: course/templates/course/course-page.html:26
 msgid "Enroll"
 msgstr ""
 
-#: course/templates/course/enrollment-decision-email.txt:1
-#: course/templates/course/grade-notify.txt:1
-#: course/templates/course/sign-in-email.txt:1
 #, python-format
 msgid "Dear %(username)s,"
 msgstr ""
 
-#: course/templates/course/enrollment-decision-email.txt:3
 #, python-format
 msgid ""
 "Welcome! Your request to join the course '%(course_identifier)s' has been "
@@ -3435,11 +3415,10 @@ msgid ""
 "Welcome, and we hope you have a productive class!"
 msgstr ""
 
-#: course/templates/course/enrollment-decision-email.txt:8
 #, python-format
 msgid ""
-"We're sorry to let you know that your request to join the course "
-"'%(course_identifier)s' has been denied. Please get in touch with the course "
+"We're sorry to let you know that your request to join the course '%"
+"(course_identifier)s' has been denied. Please get in touch with the course "
 "staff (for example by replying to this email) to state your case.\n"
 "One common reason for this may be that you may have used your personal email "
 "(such as a GMail or Yahoo account) rather than your official university "
@@ -3447,15 +3426,9 @@ msgid ""
 "try again."
 msgstr ""
 
-#: course/templates/course/enrollment-decision-email.txt:12
-#: course/templates/course/enrollment-request-email.txt:8
-#: course/templates/course/grade-notify.txt:13
-#: course/templates/course/sign-in-email.txt:11
-#: course/templates/course/submit-notify.txt:8
 msgid "- RELATE staff "
 msgstr ""
 
-#: course/templates/course/enrollment-request-email.txt:1
 #, python-format
 msgid ""
 "Dear course staff of %(course_identifier)s,\n"
@@ -3468,7 +3441,6 @@ msgid ""
 "actions.\n"
 msgstr ""
 
-#: course/templates/course/exam-check-in.html:12
 #, python-format
 msgid ""
 "If you have a not been issued an exam ticket by your instructor, please <a "
@@ -3476,313 +3448,331 @@ msgid ""
 "instead."
 msgstr ""
 
-#: course/templates/course/feedback-code-with-human.html:4
-#: course/templates/course/gradebook-by-opp.html:100
-#: course/templates/course/gradebook-single.html:113
 msgid "Overall grade"
 msgstr "Gesamtnote"
 
-#: course/templates/course/feedback-code-with-human.html:7
 #, python-format
 msgid "The overall grade is %(percentage)s%%."
 msgstr ""
 
-#: course/templates/course/feedback-code-with-human.html:16
 msgid "Autograder feedback"
 msgstr ""
 
-#: course/templates/course/feedback-code-with-human.html:20
 #, python-format
 msgid "The autograder assigned %(feedback_points)s/%(points)s points."
 msgstr ""
 
-#: course/templates/course/feedback-code-with-human.html:33
 msgid "Human feedback"
 msgstr ""
 
-#: course/templates/course/feedback-code-with-human.html:37
 #, python-format
 msgid "The human grader assigned %(feedback_points)s/%(human_points)s points."
 msgstr ""
 
-#: course/templates/course/file-upload-form.html:8
 msgid "Review uploaded file"
 msgstr "Hochgeladene Datei ansehen"
 
-#: course/templates/course/file-upload-form.html:10
 msgid "Embed viewer"
 msgstr "Betrachter einbetten"
 
-#: course/templates/course/file-upload-form.html:21
 #, python-format
 msgid ""
 " Your browser reported itself unable to render <tt>%(mime_type)s</tt> "
 "inline. "
 msgstr ""
 
-#: course/templates/course/flow-completion-grade.html:12
-#: course/templates/course/flow-start.html:82
 msgid "Results"
 msgstr "Ergebnis"
 
 #. Translators: the following 5 blocks of literals make a sentence. PartI
-#: course/templates/course/flow-completion-grade.html:16
 msgid "You have"
 msgstr "Sie haben"
 
 #. Translators: PartII
-#: course/templates/course/flow-completion-grade.html:19
 msgid "(so far)"
 msgstr "(bis jetzt)"
 
 #. Translators: PartIII
-#: course/templates/course/flow-completion-grade.html:22
 #, python-format
 msgid "achieved <b>%(provisional_points)s</b> out of %(max_points)s points."
 msgstr "<b>%(provisional_points)s</b> von %(max_points)s Punkten erreicht."
 
 #. Translators: PartIV
-#: course/templates/course/flow-completion-grade.html:29
 msgid "(Some questions are not graded yet, so your grade will likely change.)"
 msgstr ""
 "(Einige Fragen sind noch nicht benotet, daher wird sich Ihre Note "
 "wahrscheinlich noch ändern.)"
 
 #. Translators: PartV
-#: course/templates/course/flow-completion-grade.html:35
 #, python-format
 msgid "(That's <b>%(points_percent)s%%</b>.)"
 msgstr "(Das sind <b>%(points_percent)s%%</b>.)"
 
-#: course/templates/course/flow-completion-grade.html:55
-#, python-format
+#, fuzzy, python-format
+#| msgid ""
+#| "You have answered %(fully_correct_count)s questions correctly, %"
+#| "(partially_correct_count)s questions partially correctly, and %"
+#| "(incorrect_count)s questions incorrectly."
 msgid ""
-"You have answered %(fully_correct_count)s questions correctly, "
-"%(partially_correct_count)s questions partially correctly, and "
-"%(incorrect_count)s questions incorrectly."
+"You have answered %(fully_correct_count)s grading questions correctly, %"
+"(partially_correct_count)s questions partially correctly, and %"
+"(incorrect_count)s questions incorrectly."
 msgstr ""
-"Sie haben answered %(fully_correct_count)s Fragen korrekt bentwortet, "
-"%(partially_correct_count)s Fragen teilweise korrekt, und "
-"%(incorrect_count)s Fragen inkorrekt."
+"Sie haben answered %(fully_correct_count)s Fragen korrekt bentwortet, %"
+"(partially_correct_count)s Fragen teilweise korrekt, und %(incorrect_count)s "
+"Fragen inkorrekt."
 
-#: course/templates/course/flow-completion-grade.html:62
 #, python-format
 msgid "The grade for %(unknown_count)s questions is not yet known."
 msgstr "Die Note für %(unknown_count)s Fragen ist noch nicht verfügbar."
 
-#: course/templates/course/flow-completion-grade.html:86
-#: course/templates/course/flow-completion.html:15
+#, fuzzy, python-format
+#| msgid ""
+#| "You have answered %(fully_correct_count)s questions correctly, %"
+#| "(partially_correct_count)s questions partially correctly, and %"
+#| "(incorrect_count)s questions incorrectly."
+msgid ""
+"There are %(total_count)s optional questions (not for grading). You have "
+"answered %(fully_correct_count)s correctly, %(partially_correct_count)s "
+"partially correctly, and %(incorrect_count)s incorrectly."
+msgstr ""
+"Sie haben answered %(fully_correct_count)s Fragen korrekt bentwortet, %"
+"(partially_correct_count)s Fragen teilweise korrekt, und %(incorrect_count)s "
+"Fragen inkorrekt."
+
+#, fuzzy, python-format
+#| msgid "The grade for %(unknown_count)s questions is not yet known."
+msgid ""
+"The correctness for %(unknown_count)s optional questions is not yet known."
+msgstr "Die Note für %(unknown_count)s Fragen ist noch nicht verfügbar."
+
 msgid "Back to start page"
 msgstr "Zurück zur Startseite"
 
-#: course/templates/course/flow-confirm-completion.html:10
 msgid "End Session"
 msgstr "Sitzung beenden"
 
-#: course/templates/course/flow-confirm-completion.html:15
-msgid "You have left questions unanswered."
+#, fuzzy
+#| msgid "You have left questions unanswered."
+msgid "You have left the following question(s) unanswered:"
 msgstr "Sie haben Fragen unbeantwortet gelassen."
 
-#: course/templates/course/flow-confirm-completion.html:21
-#, python-format
-msgid "There were %(total_count)s questions."
+#, fuzzy, python-format
+#| msgid "There were %(total_count)s questions."
+msgid "There were %(required_count)s grading questions."
 msgstr "Es gab %(total_count)s Fragen."
 
-#: course/templates/course/flow-confirm-completion.html:25
 msgid "You have provided an answer for all of them."
 msgstr "Sie haben alle beantwortet."
 
-#: course/templates/course/flow-confirm-completion.html:29
 #, python-format
 msgid ""
 "You have answered %(answered_count)s and left %(unanswered_count)s "
 "unanswered."
 msgstr ""
 
-#: course/templates/course/flow-confirm-completion.html:36
 msgid "If you choose to end your session, the following things will happen:"
 msgstr ""
 
-#: course/templates/course/flow-confirm-completion.html:38
 msgid "You will be prevented from making further changes to your answers."
 msgstr ""
 
-#: course/templates/course/flow-confirm-completion.html:39
 msgid ""
 "All your currently saved answers, if not graded already, will be graded."
 msgstr ""
 
-#: course/templates/course/flow-confirm-completion.html:40
 msgid ""
 "If possible, a final grade will be computed from all saved, graded answers."
 msgstr ""
 
-#: course/templates/course/flow-confirm-completion.html:49
-msgid "Go back"
-msgstr "Zurück"
-
-#: course/templates/course/flow-confirm-completion.html:51
 msgid "Confirm: Submit answers and end session"
 msgstr "Bestätigen: Antworten einreichen und Sitzung beenden"
 
-#: course/templates/course/flow-page.html:28
-#: course/templates/course/flow-page.html:32
+msgid "Are you sure you will submit this session with questions unanswered?"
+msgstr ""
+
+#. Translators: student should confirm to start another session.
+msgid "I am sure"
+msgstr "Ich bin sicher"
+
+#, python-format
+msgid ""
+"Hi there,\n"
+"I have some question with the flow page with ID \"%(page_id)s\" in flow \"%"
+"(flow_session_id)s\" of  \"%(course_identifier)s\". Details of the question "
+"follows:\n"
+"-------------------------------------------------------------------\n"
+"%(question_text)s\n"
+"-------------------------------------------------------------------\n"
+"Click here to review the question in the flow page:\n"
+"%(review_uri)s\n"
+"\n"
+msgstr ""
+
+#, fuzzy
+#| msgctxt "Flow expiration mode"
+#| msgid "Submit session for grading"
+msgid "Viewing session for partipant"
+msgstr "Sitzung zur Benotung einreichen"
+
+#, fuzzy
+#| msgid "A participant"
+msgid "(unspecified participant)"
+msgstr "Ein Teilnehmer"
+
+#, fuzzy
+#| msgctxt "Previous page/item in a flow"
+#| msgid "Previous"
 msgctxt "Previous page/item in a flow"
-msgid "Previous"
+msgid "Previous page"
 msgstr "Voherige"
 
-#: course/templates/course/flow-page.html:37
-#: course/templates/course/flow-page.html:41
+#, fuzzy
+#| msgctxt "Next page/item in a flow"
+#| msgid "Next"
 msgctxt "Next page/item in a flow"
-msgid "Next"
+msgid "Next page"
 msgstr "Nächste"
 
-#: course/templates/course/flow-page.html:52
-msgid "Go to end"
-msgstr "Zum Ende gehen"
-
-#: course/templates/course/flow-page.html:56
-#: course/templates/course/flow-page.html:60
-msgid "Finish"
-msgstr "Beenden"
-
-#: course/templates/course/flow-page.html:58
 #, fuzzy
-#| msgid "Submit answer"
-msgid "Submit assignment"
-msgstr "Antwort einreichen"
+#| msgid "Back to start page"
+msgid "Boomark this page"
+msgstr "Zurück zur Startseite"
 
-#: course/templates/course/flow-page.html:74
-msgid "Past submissions"
-msgstr "Vergangene Sitzungen"
+#, fuzzy
+#| msgid "Only visible to course staff"
+msgid "Send an email about this page to course staff"
+msgstr "Nur für Kurs-Mitarbeiter sichtbar"
 
-#: course/templates/course/flow-page.html:90
+#, fuzzy
+#| msgid "Page number"
+msgid "Page Menu"
+msgstr "Seite Nr."
+
+#, fuzzy
+#| msgid "Flow start page"
+msgid "Return to flow start page"
+msgstr "Flow-Startseite"
+
+msgid "View in grading interface"
+msgstr ""
+
+msgid "Re-allow changes to page"
+msgstr ""
+
+msgid "Submission history for this page"
+msgstr ""
+
 msgid "(current)"
 msgstr ""
 
-#: course/templates/course/flow-page.html:93
 msgid "(submitted)"
 msgstr ""
 
+msgid "Go to end"
+msgstr "Zum Ende gehen"
+
+#, python-format
+msgid "Submit %(flow_title)s"
+msgstr ""
+
+msgid "Finish"
+msgstr "Beenden"
+
+msgid "Result"
+msgstr "Ergebnis"
+
 #. Translators: the string is followed by "what will happen" at deadline.
-#: course/templates/course/flow-page.html:112
 msgid "At deadline:"
 msgstr "Wenn fällig:"
 
-#: course/templates/course/flow-page.html:177
 msgid "Session duration:"
 msgstr "Sitzungs-Dauer"
 
-#: course/templates/course/flow-page.html:179
 msgid "minutes"
 msgstr "Minuten"
 
-#: course/templates/course/flow-page.html:182
 msgid "Time factor:"
 msgstr "Zeitfaktor:"
 
-#: course/templates/course/flow-page.html:197
 #, python-format
 msgid "%(max_points)s point"
 msgid_plural "%(max_points)s points"
 msgstr[0] "%(max_points)s Punkt"
 msgstr[1] "%(max_points)s Punkte"
 
-#: course/templates/course/flow-page.html:221
+msgid "Optional question"
+msgstr ""
+
 msgid "(You may still change your answer after you submit it.)"
 msgstr ""
 "(Sie können Ihre Antwort noch ändern, nachdem Sie sie eingereicht haben.)"
 
-#: course/templates/course/flow-page.html:300
 msgid "You have unsaved changes on this page."
 msgstr "Sie haben ungespeicherte Änderungen auf dieser Seite."
 
-#: course/templates/course/flow-page.html:371
 msgid "Saved."
 msgstr "Gespeichert."
 
-#: course/templates/course/flow-session-state.html:3
-msgid "in progress"
-msgstr "im Gange"
+msgid "Error--not saved."
+msgstr ""
 
-#: course/templates/course/flow-session-state.html:5
+#, fuzzy
+#| msgid "finished"
+msgid "unfinished"
+msgstr "fertig"
+
 msgid "finished"
 msgstr "fertig"
 
-#: course/templates/course/flow-start.html:19
 msgid "Past sessions"
 msgstr "Vergangene Sitzungen"
 
-#: course/templates/course/flow-start.html:25
-#: course/templates/course/gradebook-single.html:159
 msgid "Grading rules"
 msgstr "Benotungsregeln"
 
-#: course/templates/course/flow-start.html:26
-#: course/templates/course/gradebook-by-opp.html:28
-#: course/templates/course/gradebook-single.html:29
-#: course/templates/course/gradebook-single.html:140
 msgid "Due"
 msgstr "Fällig"
 
-#: course/templates/course/flow-start.html:27
-#: course/templates/course/gradebook-single.html:141
-msgid "Result"
-msgstr "Ergebnis"
-
-#: course/templates/course/flow-start.html:28
-#: course/templates/course/gradebook-single.html:146
 msgid "Actions"
 msgstr "(Aktionen)"
 
-#: course/templates/course/flow-start.html:43
 msgid "(no description)"
 msgstr "(keine Beschreibung)"
 
-#: course/templates/course/flow-start.html:54
 #, python-format
 msgid "<b>%(points)s</b> out of %(max_points)s (<b>%(percentage)s%%</b>)"
 msgstr "<b>%(points)s</b> von %(max_points)s (<b>%(percentage)s%%</b>)"
 
-#: course/templates/course/flow-start.html:62
-#: course/templates/course/gradebook-single.html:207
 msgid "(none)"
 msgstr "(kein)"
 
-#: course/templates/course/flow-start.html:65
 msgid "(not shown)"
 msgstr ""
 
-#: course/templates/course/flow-start.html:73
 msgid "Resume"
 msgstr "Fortsetzen"
 
-#: course/templates/course/flow-start.html:75
 msgid "Review"
 msgstr "Ansehen"
 
-#: course/templates/course/flow-start.html:95
 msgid "If you start a new session, the following rules will apply:"
 msgstr ""
 "Wenn Sie eine neue Sitzung beginnen, werden die folgenden Regeln gelten:"
 
-#: course/templates/course/flow-start.html:99
 #, python-format
 msgid "Your session will be a '<b>%(description)s</b>'."
 msgstr "Ihre Sitzung wird eine '<b>%(description)s</b>' sein."
 
-#: course/templates/course/flow-start.html:106
 #, python-format
 msgid "Your session will be due on <b>%(due)s</b>."
 msgstr "Ihre Sitzung wird am <b>%(due)s</b> fällig sein."
 
-#: course/templates/course/flow-start.html:112
 #, python-format
 msgid "You will receive <b>%(credit_percent)s%% credit</b> for your work."
 msgstr ""
 "Sie werden Ihre Arbeit <b>zu %(credit_percent)s%%</b> angerechnet bekommen."
 
-#: course/templates/course/flow-start.html:119
 #, python-format
 msgid ""
 "This is not your first session. If you start another one, for your overall "
@@ -3793,32 +3783,22 @@ msgstr ""
 "für Ihre Gesamtnote  '<b>%(grade_aggregation_strategy_descr)s</b>' über all "
 "Ihre Sitzungen."
 
-#: course/templates/course/flow-start.html:134
-#: course/templates/course/flow-start.html:166
 msgid "Start"
 msgstr "Los"
 
-#: course/templates/course/flow-start.html:138
 msgid "I understand that starting a new session could lower my overall grade."
 msgstr ""
 "Ich verstehe, dass ich meine Gesamtnote verringern kann, wenn ich eine neue "
 "Sitzung starte."
 
-#. Translators: student should confirm to start another session.
-#: course/templates/course/flow-start.html:143
-msgid "I am sure"
-msgstr "Ich bin sicher"
-
-#: course/templates/course/flow-start.html:188
 msgid ""
-"You do not have any existing sessions and are not allowed to start a new one."
+"You do not have any existing/viewable sessions and are not allowed to start "
+"a new one."
 msgstr ""
 
-#: course/templates/course/flow-start.html:195
 msgid "Check the following:"
 msgstr ""
 
-#: course/templates/course/flow-start.html:201
 #, python-format
 msgid ""
 "You're not currently signed in. Access to the resource is restricted, and "
@@ -3827,143 +3807,136 @@ msgid ""
 "href=\"%(relate-home)s\"> home page </a> and retry your last action."
 msgstr ""
 
-#: course/templates/course/flow-start.html:212
 msgid "Has the deadline for this assignment passed?"
 msgstr ""
 
-#: course/templates/course/flow-start.html:215 relate/templates/403.html:27
 msgid ""
 "Complete your enrollment in your course. If you're not enrolled, a large "
 "\"Enroll now\" button will show up at the top of your course page. Click "
 "that, follow the indicated steps, and then retry your last action."
 msgstr ""
 
-#: course/templates/course/flow-start.html:223 relate/templates/403.html:34
 #, python-format
 msgid ""
 "If none of the above steps help, please navigate back to your course from "
-"the <a href=\"%(relate-home)s\"> home page </a> and contact your course "
-"staff."
+"the <a href=\"%(relate-home)s\">home page</a> and contact your course staff."
 msgstr ""
 
-#: course/templates/course/grade-flow-page.html:7
-#: course/templates/course/grade-flow-page.html:46
 msgid "Grading"
 msgstr "Benotung"
 
-#: course/templates/course/grade-flow-page.html:53
-#: course/templates/course/gradebook-by-opp.html:21
-#: course/templates/course/gradebook-participant.html:22
-#: course/templates/course/gradebook-single.html:13
+#, fuzzy
+#| msgid "Past submissions"
+msgid "Past submissions/grades"
+msgstr "Vergangene Sitzungen"
+
+#, fuzzy
+#| msgid "Past submissions"
+msgid "Submission:"
+msgstr "Vergangene Sitzungen"
+
+#, fuzzy
+#| msgid "Grade"
+msgid "Grade:"
+msgstr "Note"
+
+#, fuzzy
+#| msgid "(no grade)"
+msgid "no grade"
+msgstr "(keine Note)"
+
 msgid "Property"
 msgstr "Eigenschaft"
 
-#: course/templates/course/grade-flow-page.html:53
-#: course/templates/course/gradebook-by-opp.html:21
-#: course/templates/course/gradebook-participant.html:22
-#: course/templates/course/gradebook-single.html:13
 msgid "Value"
 msgstr "Wert"
 
 #. Translators: the grade information "for" a participant with fullname + (username)
-#: course/templates/course/grade-flow-page.html:63
 #, python-format
 msgid "for %(full_name)s (%(username)s)"
 msgstr ""
 
-#: course/templates/course/grade-flow-page.html:73
 msgid "Points awarded"
 msgstr ""
 
-#: course/templates/course/grade-flow-page.html:80
 msgid "(unknown)"
 msgstr ""
 
 #. Translators: the unit name in grading
-#: course/templates/course/grade-flow-page.html:85
 msgid "point"
 msgid_plural "points"
 msgstr[0] "Punkt"
 msgstr[1] "Punkte"
 
-#: course/templates/course/grade-flow-page.html:92
-#: course/templates/course/grade-flow-page.html:112
 msgid "(n/a)"
 msgstr "-/-"
 
-#: course/templates/course/grade-flow-page.html:97
 msgid "Graded"
 msgstr "Benotet"
 
-#: course/templates/course/grade-flow-page.html:101
-#: course/templates/course/grading-statistics.html:19
 msgid "(autograded)"
 msgstr "(automatisch)"
 
 #. Translators: the grade is awarded "by" some humman grader.
-#: course/templates/course/grade-flow-page.html:104
 #, python-format
 msgid "by %(grader_name)s"
 msgstr "von %(grader_name)s"
 
-#: course/templates/course/grade-flow-page.html:109
 #, fuzzy
 #| msgid "Date"
 msgctxt "at (what time)"
 msgid "at"
 msgstr "Datum"
 
-#: course/templates/course/grade-flow-page.html:130 course/views.py:737
 msgid "Session"
 msgstr "Sitzung"
 
-#: course/templates/course/grade-flow-page.html:135
 msgid "Start:"
 msgstr "Start:"
 
-#: course/templates/course/grade-flow-page.html:153
 msgid "Page number"
 msgstr "Seite Nr."
 
-#: course/templates/course/grade-flow-page.html:158
 msgid "View in flow"
 msgstr ""
 
-#: course/templates/course/grade-flow-page.html:176
 #, fuzzy
 #| msgid "Answer"
 msgid "Correct Answer"
 msgstr "Antwort"
 
-#: course/templates/course/grade-flow-page.html:250
 msgid "Enter new feedback item:"
 msgstr ""
 
-#: course/templates/course/grade-flow-page.html:298
 msgid "Add phrase"
 msgstr "Phrase hinzufügen"
 
-#: course/templates/course/grade-flow-page.html:300
-#: course/templates/course/grade-flow-page.html:325
-#: course/templates/course/grade-flow-page.html:361
-msgid "Clear"
-msgstr "Löschen"
-
-#: course/templates/course/grade-flow-page.html:407
 msgid "Submit and next page"
 msgstr "Abschicken und nächste Seite"
 
-#: course/templates/course/grade-flow-page.html:412
 msgid "Submit and next session"
 msgstr "Abschicken und nächste Sitzung"
 
-#: course/templates/course/grade-notify.txt:2
+#, python-format
+msgid ""
+"Hi there,\n"
+"I am sending you the internal grading notes regarding %(username)s's work on "
+"the page with title '%(page_title)s' in '%(flow_id)s' of '%"
+"(course_identifier)s'. The full text of the notes follows.\n"
+"-------------------------------------------------------------------\n"
+"%(notes_text)s\n"
+"-------------------------------------------------------------------\n"
+"Click here to review the page in the flow page:\n"
+"%(review_uri)s\n"
+"\n"
+msgstr ""
+
 #, python-format
 msgid ""
 "\n"
-"You have a new notification regarding your work on the page with title\n"
-"'%(page_title)s' in '%(flow_id)s' of '%(course_identifier)s'. The\n"
-"full text of the feedback follows.\n"
+"You have a new notification regarding your work on the page with title '%"
+"(page_title)s' in '%(flow_id)s' of '%(course_identifier)s'. The full text of "
+"the feedback follows.\n"
 "-------------------------------------------------------------------\n"
 "%(feedback_text)s\n"
 "-------------------------------------------------------------------\n"
@@ -3972,51 +3945,62 @@ msgid ""
 "\n"
 msgstr ""
 
-#: course/templates/course/gradebook-by-opp.html:25
-#: course/templates/course/gradebook-single.html:25
+#, fuzzy
+#| msgid "Courses"
+msgid "course staff"
+msgstr "Kurse"
+
 msgid "Grading Opportunity ID"
 msgstr "ID der Benotungsmöglichkeit"
 
-#: course/templates/course/gradebook-by-opp.html:35
-#: course/templates/course/gradebook-single.html:34
 msgid "Flow"
 msgstr ""
 
-#: course/templates/course/gradebook-by-opp.html:37
 msgid "(Start page)"
 msgstr "(Startseite)"
 
-#: course/templates/course/gradebook-by-opp.html:39
-msgid "Grading statistics"
-msgstr "Benotungsstatistik"
-
 #. Translators: "Counts" on the quantities of total session and finished sessions
-#: course/templates/course/gradebook-by-opp.html:44
 msgid "Counts"
 msgstr "Anzahlen"
 
-#: course/templates/course/gradebook-by-opp.html:46
 #, python-format
 msgid "%(total_sessions)s total sessions (%(finished_sessions)s finished)"
 msgstr ""
 
-#: course/templates/course/gradebook-by-opp.html:53
 #, fuzzy
 #| msgid "Operation"
 msgid "Operations"
 msgstr "Vorgang"
 
-#: course/templates/course/gradebook-by-opp.html:56
+msgid "View analytics"
+msgstr ""
+
+#, fuzzy
+#| msgid "Grading statistics"
+msgid "View grader statistics"
+msgstr "Benotungsstatistik"
+
+#, fuzzy
+#| msgid "View grades"
+msgid "View page grades"
+msgstr "Noten ansehen"
+
+#, fuzzy
+#| msgid "Average grade"
+msgid "Hide page grades"
+msgstr "Durchschnittsnote"
+
 #, fuzzy
 #| msgid "Past submissions"
 msgid "Download submissions"
 msgstr "Vergangene Sitzungen"
 
-#: course/templates/course/gradebook-by-opp.html:64
+msgid "Edit"
+msgstr ""
+
 msgid "Modify many sessions at once"
 msgstr ""
 
-#: course/templates/course/gradebook-by-opp.html:68
 msgid ""
 "<p> \"Impose deadline (Expire sessions)\" will find all sessions for this "
 "flow that match the selected session tag and, depending on the session's "
@@ -4033,288 +4017,269 @@ msgid ""
 "grading rules. </p>"
 msgstr ""
 
-#: course/templates/course/gradebook-by-opp.html:101
-msgid "Sessions"
-msgstr ""
+#, fuzzy
+#| msgctxt "Flow rule kind choices"
+#| msgid "Session Start"
+msgid "Session state"
+msgstr "Sitzungs-Start"
 
-#: course/templates/course/gradebook-by-opp.html:138
+#, fuzzy
+#| msgid "Session regraded."
+msgid "Session grade"
+msgstr "Sitzung neu benotet."
+
 msgid "Rules tag"
 msgstr ""
 
-#: course/templates/course/gradebook-by-opp.html:141
 #, python-format
 msgid "%(points)s/%(max_points)s points"
 msgstr ""
 
-#: course/templates/course/gradebook-opp-list.html:20
-#: course/templates/course/gradebook-participant.html:52
+#, fuzzy
+#| msgid "Grading opportunity"
+msgid "Add grading opportunity"
+msgstr "Benotungsmöglichkeit"
+
 msgid "Name of grading opportunity"
 msgstr "Name der Benotungsmöglichkeit"
 
-#: course/templates/course/gradebook-opp-list.html:24
 #, fuzzy
 #| msgid "Shown to pariticpant"
 msgid "Shown to participants"
 msgstr "Wird Teilnehmern angezeigt"
 
-#: course/templates/course/gradebook-participant.html:7
-#: course/templates/course/gradebook-participant.html:16
+#, fuzzy
+#| msgid "A participant"
+msgid "Add participant"
+msgstr "Ein Teilnehmer"
+
 msgid "My Grades"
 msgstr "Meine Noten"
 
-#: course/templates/course/gradebook-participant.html:54
+msgid "Grades"
+msgstr "Noten"
+
 msgid "Date"
 msgstr "Datum"
 
-#: course/templates/course/gradebook-single.html:9
+#, fuzzy
+#| msgid "(no grade)"
+msgid "(not released)"
+msgstr "(keine Note)"
+
 msgid "Understand a grade"
 msgstr "Noten-Details"
 
-#: course/templates/course/gradebook-single.html:40
 msgid "Flow start page"
 msgstr "Flow-Startseite"
 
 #. Translators: averaged grade of a flow of all participants
-#: course/templates/course/gradebook-single.html:46
 msgid "Average grade"
 msgstr "Durchschnittsnote"
 
 #. Translators: average grade of a flow, format "10% (out of 5 grades)"
-#: course/templates/course/gradebook-single.html:50
 #, python-format
 msgid "%(avg_grade_percentage)s%% (out of %(avg_grade_population)s grades)"
 msgstr ""
 
-#: course/templates/course/gradebook-single.html:55
 msgid "(no data)"
 msgstr "(keine Daten)"
 
-#: course/templates/course/gradebook-single.html:63
 msgid "Grade history"
 msgstr "Notengeschichte"
 
-#: course/templates/course/gradebook-single.html:65
 msgid " (no grade data available)"
 msgstr ""
 
 #. Translators: "what" stand for the state of a grade, e.g. "graded"
-#: course/templates/course/gradebook-single.html:71
 msgid "What"
 msgstr "Was"
 
-#: course/templates/course/gradebook-single.html:73
 msgid "Further Information"
 msgstr ""
 
-#: course/templates/course/gradebook-single.html:88
 #, python-format
 msgid "%(points)s/%(max_points)s points (%(percentage)s%%)"
 msgstr ""
 
-#: course/templates/course/gradebook-single.html:94
-#: course/templates/course/gradebook-single.html:253
 msgid "(no grade)"
 msgstr "(keine Note)"
 
-#: course/templates/course/gradebook-single.html:105
 #, python-format
 msgid "(from flow session %(gchange_flow_session_id)s)"
 msgstr ""
 
-#: course/templates/course/gradebook-single.html:143
 msgid "Pages"
 msgstr ""
 
 #. Translators: means "Started at", which followed by a time string
-#: course/templates/course/gradebook-single.html:171
 msgid "Started"
 msgstr "Begonnen"
 
 #. Translators: means "Completed at", which followed by a time string
-#: course/templates/course/gradebook-single.html:176
 msgid "Completed"
 msgstr "Beendet"
 
 #. Translators: means "Last activity at", which followed by a time string
-#: course/templates/course/gradebook-single.html:180
 msgid "Last activity"
 msgstr "Letzte Aktivität"
 
-#: course/templates/course/gradebook-single.html:201
 #, python-format
 msgid "(grade not available) (%(max_points)s points achievable)"
 msgstr "(Note nicht verfügbar) (%(max_points)s Punkte erreichbar)"
 
-#: course/templates/course/gradebook-single.html:211
 msgid " Notes:"
 msgstr " Notizen:"
 
-#: course/templates/course/gradebook-single.html:224
 #, fuzzy
 #| msgid "Page ID"
 msgid "Page"
 msgstr "Seiten-ID"
 
-#: course/templates/course/gradebook-single.html:225
 msgid "Percent"
 msgstr "Prozent"
 
-#: course/templates/course/gradebook-single.html:276
-msgid "Expire"
-msgstr ""
+#, fuzzy
+#| msgid "At deadline:"
+msgid "Impose deadline"
+msgstr "Wenn fällig:"
 
-#: course/templates/course/gradebook-single.html:280
 msgid "End and grade"
 msgstr "Beenden und benoten"
 
-#: course/templates/course/gradebook-single.html:289
 msgid "Recalculate grade"
 msgstr "Note neu berechnen"
 
-#: course/templates/course/grading-statistics.html:5
-msgid "Grading Statistics"
+#, fuzzy
+#| msgid "Grading statistics"
+msgid "Grader Statistics"
+msgstr "Benotungsstatistik"
+
+#, fuzzy
+#| msgid "Grading statistics"
+msgid "Grader Statistics: "
+msgstr "Benotungsstatistik"
+
+msgid ""
+"(No information about grading work distribution for human-graded problems "
+"available.)"
 msgstr ""
 
-#: course/templates/course/grading-statistics.html:9
-msgid "Grading Statistics: "
-msgstr ""
-
-#: course/templates/course/grading-statistics.html:23
-#: course/templates/course/grading-statistics.html:35
 msgid "Total"
 msgstr ""
 
-#: course/templates/course/home.html:7
 #, python-format
 msgid " Welcome to %(RELATE)s "
 msgstr "Willkommen bei %(RELATE)s "
 
-#: course/templates/course/home.html:8
 msgid "RELATE is an Environment for Learning And TEaching"
 msgstr ""
 "RELATE is an Environment for Learning And TEaching -- eine Umgebung fürs "
 "Lernen und Lehren"
 
-#: course/templates/course/home.html:10
 msgid "Learn more"
 msgstr "Mehr erfahren"
 
-#: course/templates/course/home.html:21
-#: course/templates/course/list-exams.html:20
 msgid "View"
 msgstr "Ansehen"
 
-#: course/templates/course/home.html:27
 msgid "Past Courses"
 msgstr "Vergangene Kurse"
 
-#: course/templates/course/home.html:51
 #, python-format
 msgid "There are no courses hosted on this %(RELATE)s site."
 msgstr ""
 
-#: course/templates/course/home.html:54
 #, python-format
 msgid "<a href=\"%(relate-sign_in_by_user_pw)s\">Sign in</a> to get started."
 msgstr ""
 
-#: course/templates/course/home.html:61 course/versioning.py:312
 msgid "Set up new course"
 msgstr "Neuen Kurs erstellen"
 
-#: course/templates/course/human-feedback-form.html:9
 msgid "Rubric"
 msgstr "Benotungsrichtlinie"
 
-#: course/templates/course/invalid-datespec-list.html:5
 msgid "Event validity check"
 msgstr "Ereignis-Gültigkeitsprüfung"
 
-#: course/templates/course/invalid-datespec-list.html:8
 msgid ""
 "The following events were found in course content that are not present in "
 "the database:"
 msgstr ""
 
-#: course/templates/course/invalid-datespec-list.html:26
 msgid "Unrecognized events were found."
 msgstr ""
 
-#: course/templates/course/invalid-datespec-list.html:30
 msgid ""
 "Check the \"Calendar\" functions in the instructor menu to add the missing "
 "labels."
 msgstr ""
 
-#: course/templates/course/invalid-datespec-list.html:39
 msgid "No unrecognized events were found."
 msgstr ""
 
-#: course/templates/course/keypair.html:5
 msgid "SSH Key Pair"
 msgstr ""
 
-#: course/templates/course/keypair.html:7
 msgid "Private key:"
 msgstr ""
 
-#: course/templates/course/keypair.html:8
 msgid ""
 "Copy and paste this block of text into the 'private key' field in RELATE."
 msgstr ""
 
-#: course/templates/course/keypair.html:13
 msgid "Public key:"
 msgstr ""
 
-#: course/templates/course/keypair.html:14
 msgid ""
 "On Bitbucket, GitHub, or an other repository hosting site, add this snippet "
 "as an \"SSH Key\" to your user profile or as a \"Deployment key\" to your "
 "repository."
 msgstr ""
 
-#: course/templates/course/list-exams.html:5
 msgid "Available Exams"
 msgstr "Verfügbare Prüfungen"
 
-#: course/templates/course/login-by-email.html:7
+msgid "Take exam"
+msgstr ""
+
+msgid "(No exams available.)"
+msgstr ""
+
+msgid "(No exams available. Please sign in to continue.)"
+msgstr ""
+
 msgid "Sign in or create account"
 msgstr "Anmelden oder Konto erstellen"
 
-#: course/templates/course/login-by-email.html:12
 #, python-format
 msgid ""
-"If you cannot or would not like to sign in by email, <a href="
-"\"%(relate-sign_in_choice)s\">please choose a different method to sign in</"
-"a>."
+"If you cannot or would not like to sign in by email, <a href=\"%(relate-"
+"sign_in_choice)s\">please choose a different method to sign in</a>."
 msgstr ""
 
 #. Translators: For courses which require specific email suffix for enrollment, translate the following literals
 #. with your customized email suffix.
 #.
-#: course/templates/course/login-by-email.html:24
 msgid ""
 "Please use the <em>official</em> email address associated with the "
 "institution at which this course is taking place. Some courses may require a "
 "certain email domain (such as \"@illinois.edu\") for enrollment."
 msgstr ""
 
-#: course/templates/course/login.html:12
 #, python-format
 msgid ""
 "If you cannot or would not like to sign in using a RELATE-specific user name "
-"or password, <a href='%(relate-sign_in_choice)s'>please choose a different "
-"method to sign in</a>."
+"or password, <a href='%(relate-sign_in_choice)s%(next_uri)s'>please choose a "
+"different method to sign in</a>."
 msgstr ""
 
-#: course/templates/course/login.html:21
 msgid ""
 "Note that the user name and password needed to use this form is <em>not</em> "
 "the user name and password you may have been assigned by your institution."
 msgstr ""
 
-#: course/templates/course/login.html:31
 #, python-format
 msgid ""
 "If you do not have an account, <a href='%(relate-sign_up)s'>sign up</a>."
@@ -4322,25 +4287,24 @@ msgstr ""
 "Falls Sie kein Konto haben, <a href='%(relate-sign_up)s'>erstellen Sie "
 "eines</a>."
 
-#: course/templates/course/login.html:36
 #, python-format
 msgid ""
 "If you do not remember your password, <a href=\"%(relate-reset_password)s\"> "
 "reset your password </a>."
 msgstr ""
 
+#, fuzzy
+#| msgid "State"
+msgid "Status"
+msgstr "Zustand"
+
 #. Translators: "set-up" stands for set-up code for code question
-#: course/templates/course/prompt-code-question.html:10
 msgid "Problem set-up code"
 msgstr ""
 
-#: course/templates/course/prompt-code-question.html:11
-#: course/templates/course/prompt-code-question.html:40
-#: course/templates/course/prompt-code-question.html:69
 msgid "(click to view)"
 msgstr "(klicken zum Ansehen)"
 
-#: course/templates/course/prompt-code-question.html:18
 msgid ""
 "This is the code that is used to set up the problem and produce test data "
 "for your submission. It is reproduced here for your information, or if you "
@@ -4349,13 +4313,11 @@ msgid ""
 "'behind the scenes' before your submitted code."
 msgstr ""
 
-#: course/templates/course/prompt-code-question.html:39
 #, fuzzy
 #| msgid "Grading code"
 msgid "Testing code"
 msgstr "Benotungs-Code"
 
-#: course/templates/course/prompt-code-question.html:47
 msgid ""
 "This is the code that is used to generate feedback for your submission. It "
 "is reproduced here for your information, or if you would like to run your "
@@ -4365,49 +4327,32 @@ msgid ""
 msgstr ""
 
 #. Translators: starter code for code question
-#: course/templates/course/prompt-code-question.html:68
 msgid "Starter code"
 msgstr "Code zum Loslegen"
 
-#: course/templates/course/query-participations.html:7
-#: course/templates/course/query-participations.html:15
 msgid "Query Participations"
 msgstr "Teilnahmen Durchsuchen"
 
-#: course/templates/course/query-participations.html:24
 msgid "No matches"
 msgstr ""
 
-#: course/templates/course/sandbox-markup.html:12
 msgid "Markup Sandbox"
 msgstr "Markup-Sandkasten"
 
 #. Translators: "[SB]" is abbreviation for "Sandbox"
-#: course/templates/course/sandbox-page.html:10
 #, python-format
 msgid "[SB] %(title)s"
 msgstr ""
 
-#: course/templates/course/sandbox-page.html:14
-#: course/templates/course/sandbox-page.html:29
 msgid "Page Sandbox"
 msgstr "Seiten-Sandkasten"
 
-#: course/templates/course/sandbox-page.html:25
-msgid ""
-"What you type into this page is not saved once you navigate away. Please "
-"make sure to retain a copy."
-msgstr ""
-
-#: course/templates/course/sandbox-page.html:41
 msgid "Warnings were encountered when validating the page:"
 msgstr "Bei der Seitenvalidierung gab es Warnungen:"
 
-#: course/templates/course/sandbox-page.html:89
 msgid "(Page preview appears here)"
 msgstr "(Seitenvorschau erscheint hier)"
 
-#: course/templates/course/sign-in-email.txt:2
 #, python-format
 msgid ""
 "\n"
@@ -4421,25 +4366,20 @@ msgid ""
 "If this was not you, it is safe to disregard this email.\n"
 msgstr ""
 
-#: course/templates/course/static-page.html:6
 msgid "Jump to"
 msgstr "Springen zu"
 
-#: course/templates/course/submit-notify.txt:1
 #, python-format
 msgid "Dear course staff of %(course_identifier)s,"
 msgstr ""
 
-#: course/templates/course/submit-notify.txt:3
 #, python-format
 msgid "Participant '%(participant)s'"
 msgstr "Teilnehmer '%(participant)s'"
 
-#: course/templates/course/submit-notify.txt:3
 msgid "A participant"
 msgstr "Ein Teilnehmer"
 
-#: course/templates/course/submit-notify.txt:3
 #, python-format
 msgid ""
 " has just submitted his/her work on '%(flow_id)s'.\n"
@@ -4448,234 +4388,214 @@ msgid ""
 "%(review_uri)s\n"
 msgstr ""
 
-#: course/templates/course/task-monitor.html:12
 msgid "Task Progress"
 msgstr "Fortschritt"
 
-#: course/templates/course/task-monitor.html:22
 msgid "Progress"
 msgstr "Fortschritt"
 
-#: course/templates/course/task-monitor.html:54
 msgid "The process failed and reported the following error:"
 msgstr ""
 
-#: course/utils.py:345
 msgid "grading rule determination was unable to find a grading rule"
 msgstr ""
 
-#: course/utils.py:581
+#, python-format
+msgid ""
+"Preview revision '%s' does not exist--showing active course content instead."
+msgstr ""
+
 msgid "Press F9 to toggle full-screen mode. "
 msgstr "F9 für Vollbild. "
 
-#: course/utils.py:582
 #, python-format
 msgid "Set editor mode in <a href='%s'>user profile</a>."
 msgstr "Editor-Modus im <a href='%s'>Benutzerprofil</a> einstellen."
 
-#: course/validation.py:55 course/validation.py:63
+msgid ""
+"Error: Columns to be imported contain non-ASCII characters. Please save your "
+"CSV file as utf-8 encoded and import again."
+msgstr ""
+
 msgid "invalid identifier"
 msgstr ""
 
-#: course/validation.py:81
 #, python-format
 msgid "invalid role '%(role)s'"
 msgstr ""
 
-#: course/validation.py:93
 #, python-format
 msgid ""
-"Name of facility not recognized: '%(fac_name)s'. Known facility names: "
-"'%(known_fac_names)s'"
+"Name of facility not recognized: '%(fac_name)s'. Known facility names: '%"
+"(known_fac_names)s'"
 msgstr ""
 
-#: course/validation.py:133
 #, python-format
 msgid "attribute '%(attr)s' missing"
 msgstr ""
 
-#: course/validation.py:151
 #, python-format
 msgid ""
 "attribute '%(attr)s' has wrong type: got '%(name)s', expected '%(allowed)s'"
 msgstr ""
 
-#: course/validation.py:166
 #, python-format
 msgid "extraneous attribute(s) '%(attr)s'"
 msgstr ""
 
-#: course/validation.py:275
 msgid "Uses deprecated 'start' attribute--use 'if_after' instead"
 msgstr ""
 
-#: course/validation.py:281
 msgid "Uses deprecated 'end' attribute--use 'if_before' instead"
 msgstr ""
 
-#: course/validation.py:287
 msgid "Uses deprecated 'roles' attribute--use 'if_has_role' instead"
 msgstr ""
 
-#: course/validation.py:319
 msgid "no title present"
 msgstr "kein Titel vorhanden"
 
-#: course/validation.py:350
 msgid "must have either 'chunks' or 'content'"
 msgstr "muss entweder 'chunks' oder 'content' haben"
 
-#: course/validation.py:377
 #, python-format
 msgid "chunk id '%(chunkid)s' not unique"
 msgstr "Chunk-ID '%(chunkid)s' ist nicht eindeutig"
 
-#: course/validation.py:394
 msgid "flow page has no ID"
 msgstr "Flow-Seite hat keine ID"
 
-#: course/validation.py:412
 msgid "could not instantiate flow page"
 msgstr "Konnte Flow-Seite nicht instantiieren"
 
-#: course/validation.py:448
 #, python-format
 msgid "group '%(group_id)s': group is empty"
 msgstr ""
 
-#: course/validation.py:455
 #, python-format
 msgid "group '%(group_id)s': max_page_count is not positive"
 msgstr ""
 
-#: course/validation.py:468
 #, python-format
 msgid "page id '%(page_desc_id)s' not unique"
 msgstr ""
 
-#: course/validation.py:521
 msgid "attribute 'may_start_new_session' is not present"
 msgstr "Attribut 'may_start_new_session' ist nicht vorhanden"
 
-#: course/validation.py:525
 msgid "attribute 'may_list_existing_sessions' is not present"
 msgstr "Attribut 'may_list_existing_sessions' ist nicht vorhanden"
 
-#: course/validation.py:529
 msgid ""
 "Attribute 'lock_down_as_exam_session' is deprecated and non-functional. Use "
 "the access permission flag 'lock_down_as_exam_session' instead."
 msgstr ""
 
-#: course/validation.py:543 course/validation.py:588 course/validation.py:671
 #, python-format
 msgid "invalid tag '%(tag)s'"
 msgstr "Ungültiges Tag '%(tag)s'"
 
-#: course/validation.py:597
+#, python-format
+msgid "invalid default expiration mode '%(expiremode)s'"
+msgstr ""
+
 #, python-format
 msgid "invalid expiration mode '%(expiremode)s'"
 msgstr ""
 
-#: course/validation.py:638
+msgid ""
+"Rule specifies 'submit_answer' or 'end_session' permissions for non-in-"
+"progress flow. These permissions will be ignored."
+msgstr ""
+
 msgid ""
 "'grade_identifier' attribute found. This attribute is no longer allowed here "
 "and should be moved upward into the 'rules' block."
 msgstr ""
 
-#: course/validation.py:647
 msgid ""
 "'grade_aggregation_strategy' attribute found. This attribute is no longer "
 "allowed here and should be moved upward into the 'rules' block."
 msgstr ""
 
-#: course/validation.py:682
 msgid "'generates_grade' is true, but no 'grade_identifier'is given."
 msgstr ""
 
-#: course/validation.py:711
 msgid ""
 "'rules' block does not have a grade_identifier attribute. This attribute "
 "needs to be moved out of the lower-level 'grading' rules block and into the "
 "'rules' block itself."
 msgstr ""
 
-#: course/validation.py:750
 #, python-format
 msgid ""
-"grading rule that have a grade identifier (%(type)s: %(identifier)s) must "
-"have a grade_aggregation_strategy"
+"flows that have a grade identifier ('%(identifier)s') must have grading "
+"rules with a grade_aggregation_strategy"
 msgstr ""
 
-#: course/validation.py:766
 msgid "invalid grade aggregation strategy"
 msgstr ""
 
-#: course/validation.py:777
 msgid "'grading' block is required if grade_identifier is not null/None."
 msgstr ""
 
-#: course/validation.py:788
 msgid "rules/grading: may not be an empty list"
 msgstr ""
 
-#: course/validation.py:803
 msgid "rules/grading: last grading rule must be unconditional"
 msgstr ""
 
-#: course/validation.py:813
 msgid ""
 "Uses deprecated 'modify' permission--replace by 'submit_answer' and "
 "'end_session'"
 msgstr ""
 
-#: course/validation.py:819
 msgid ""
 "Uses deprecated 'see_answer' permission--replace by "
 "'see_answer_after_submission'"
 msgstr ""
 
-#: course/validation.py:826
 #, python-format
 msgid "invalid flow permission '%(permission)s'"
 msgstr ""
 
-#: course/validation.py:863
 msgid "must have either 'groups' or 'pages'"
 msgstr ""
 
-#: course/validation.py:885
 #, python-format
 msgid "group %(group_index)d ('%(group_id)s'): 'pages' is not a list"
 msgstr ""
 
-#: course/validation.py:900
 #, python-format
 msgid "group %(group_index)d ('%(group_id)s'): no pages found"
 msgstr ""
 
-#: course/validation.py:908
 #, python-format
 msgid "%s: no pages found"
 msgstr ""
 
-#: course/validation.py:921
 #, python-format
 msgid "group id '%(group_id)s' not unique"
 msgstr ""
 
-#: course/validation.py:1030
+#, python-format
+msgid "notify_on_submit: item %d is not a string"
+msgstr ""
+
+#, python-format
+msgid ""
+"Attribute '%s' is deprecated as part of a flow. Specify it as part of a "
+"grading rule instead."
+msgstr ""
+
 msgid "Access class 'public' is deprecated. Use 'unenrolled' instead."
 msgstr ""
 
-#: course/validation.py:1035
 #, python-format
 msgid ""
 "%s: access classes 'public' and 'unenrolled' may not exist simultaneously."
 msgstr ""
 
-#: course/validation.py:1072
-#, python-brace-format
 msgid ""
 "{location}: existing grading opportunity with identifier "
 "'{grade_identifier}' refers to flow '{other_flow_id}', however flow code in "
@@ -4683,177 +4603,143 @@ msgid ""
 "renamed the flow? If so, edit the grading opportunity to match.)"
 msgstr ""
 
-#: course/validation.py:1111
 #, python-format
 msgid ""
 "%(loc)s, group '%(group)s', page '%(page)s': page type ('%(type_new)s') "
 "differs from type used in database ('%(type_old)s')"
 msgstr ""
 
-#: course/validation.py:1142
 #, python-format
 msgid "Your course repository does not have an events file named '%s'."
 msgstr ""
 
-#: course/validation.py:1162
 msgid ""
 "Your course repository has a 'media/' directory. Linking to media files "
 "using 'media:' is discouraged. Use the 'repo:' and 'repocur:' linkng schemes "
 "instead."
 msgstr ""
 
-#: course/validation.py:1187
 msgid ""
 "invalid flow name. Flow names may only contain (roman) letters, numbers, "
 "dashes and underscores."
 msgstr ""
 
-#: course/validation.py:1212
 msgid "flow uses the same grade_identifier as another flow"
 msgstr ""
 
-#: course/validation.py:1251
 msgid ""
 "invalid page name. Page names may only contain alphanumeric characters (any "
 "language) and hyphens."
 msgstr ""
 
-#: course/validation.py:1359
 msgid "WARNINGS: "
 msgstr "WARNUNGEN: "
 
-#: course/versioning.py:189
 msgid "Validate and create"
 msgstr "Validieren und Erstellen"
 
-#: course/versioning.py:194
 msgid "Git source must be specified"
 msgstr "Git-Quelle muss angegeben werden"
 
-#: course/versioning.py:202
-msgid "only staff may create courses"
+msgid ""
+"No refs found in remote repository (i.e. no master branch, no HEAD). This "
+"looks very much like a blank repository. Please create course.yml in the "
+"remote repository before creating your course."
 msgstr ""
 
-#: course/versioning.py:261
 msgid "Course content validated, creation succeeded."
 msgstr "Kurs-Inhalt validiert, Kurs-Erstellung erfolgreich."
 
-#: course/versioning.py:287
 #, python-format
 msgid "Failed to delete unused repository directory '%s'."
 msgstr "Konnte nicht mehr benutztes Repository-Verzeichnis '%s' nicht löschen."
 
-#: course/versioning.py:299
 msgid "Course creation failed"
 msgstr "Kurs-Erstellung fehlgeschlagen"
 
-#: course/versioning.py:348
 msgid "no git source URL specified"
 msgstr ""
 
-#: course/versioning.py:361
 msgid "fetch would discard commits, refusing"
 msgstr "Abholen würde Commits wegwerfen, abgelehnt"
 
-#: course/versioning.py:365
 msgid "Fetch successful."
 msgstr "Abholen erfolgreich."
 
-#: course/versioning.py:374
 msgid "Preview ended."
 msgstr "Vorschau beendet."
 
-#: course/versioning.py:389
 #, python-format
 msgid "Course content did not validate successfully. (%s) Update not applied."
 msgstr ""
 "Kurs-Inhalt nicht erfolgreich validiert. (%s) Aktualisierung nicht "
 "angewendet."
 
-#: course/versioning.py:396
 msgid "Course content validated successfully."
 msgstr "Kurs-Inhalt erfolgreich validiert."
 
-#: course/versioning.py:400
 msgid "Course content validated OK, with warnings: "
 msgstr "Kurs-Inhalt erfolgreich validiert, mit Warnungen:"
 
-#: course/versioning.py:411
 msgid "Preview activated."
 msgstr "Vorschau aktiviert."
 
-#: course/versioning.py:421
 msgid "Update applied. "
 msgstr "Aktualisierung angewendet."
 
-#: course/versioning.py:424 course/versioning.py:527 course/views.py:828
 msgid "invalid command"
 msgstr "ungültiger Befehl"
 
-#: course/versioning.py:463
 msgctxt "new git SHA for revision of course contents"
 msgid "New git SHA"
 msgstr "Neue git SHA"
 
-#: course/versioning.py:466
 msgid "Prevent updating to a git revision prior to the current one"
 msgstr "Aktualisierung auf eine vorherige git-Version verhindern"
 
-#: course/versioning.py:474
 msgid "Fetch and update"
 msgstr "Abholen und aktualisieren"
 
-#: course/versioning.py:478
 msgid "End preview"
 msgstr "Vorschau beenden"
 
-#: course/versioning.py:480
 msgid "Fetch and preview"
 msgstr "Abholen und Vorschau"
 
-#: course/versioning.py:483
 msgid "Fetch"
 msgstr "Abholen"
 
-#: course/versioning.py:494
-msgid "must be instructor or TA to update course"
-msgstr ""
+#, fuzzy
+#| msgid "No events found."
+msgid "- not found -"
+msgstr "Keine Ereignisse gefunden."
 
-#: course/versioning.py:571
 msgid "Git Source URL"
 msgstr "Git Quell-URL"
 
-#: course/versioning.py:576
 msgid "Public active git SHA"
 msgstr "Öffentlich sichtbare git SHA"
 
-#: course/versioning.py:586
 msgid "Current git HEAD"
 msgstr "Aktueller git HEAD"
 
-#: course/versioning.py:597 course/versioning.py:609
 msgid "Current preview git SHA"
 msgstr "Aktuelle git Vorschau-SHA"
 
-#: course/versioning.py:611
 msgid "None"
 msgstr "Kein"
 
-#: course/versioning.py:623
 msgid "Update Course Revision"
 msgstr "Kurs-Version aktualisieren"
 
-#: course/views.py:133
-msgid "only course staff have access"
+msgid "course page is currently hidden"
 msgstr ""
 
-#: course/views.py:157
 msgid ""
 "Your enrollment request is pending. You will be notified once it has been "
 "acted upon."
 msgstr ""
 
-#: course/views.py:167
 #, python-format
 msgid ""
 "This course uses institutional ID for enrollment preapproval, please <a "
@@ -4861,7 +4747,6 @@ msgid ""
 "institutional ID &nbsp;&raquo;</a> in your profile."
 msgstr ""
 
-#: course/views.py:182
 msgid ""
 "Your institutional ID is not verified or preapproved. Please contact your "
 "course staff."
@@ -4869,154 +4754,134 @@ msgstr ""
 
 #. Translators: "set" fake time.
 #. Translators: "set" fake facility.
-#: course/views.py:339 course/views.py:431
 msgid "Set"
 msgstr "Setzen"
 
 #. Translators: "unset" fake time.
 #. Translators: "unset" fake facility.
-#: course/views.py:342 course/views.py:434
 msgid "Unset"
 msgstr "Löschen"
 
-#: course/views.py:370
-msgid "only staff may set fake time"
-msgstr ""
+#, fuzzy
+#| msgid "Set fake time"
+msgid "may not set fake time"
+msgstr "Eine andere Zeit vorgeben"
 
-#: course/views.py:394 relate/templates/base-page-top.html.py:41
-#: relate/templates/base.html:77
 msgid "Set fake time"
 msgstr "Eine andere Zeit vorgeben"
 
-#: course/views.py:420
 msgid "Facilities"
 msgstr "Einrichtungen"
 
-#: course/views.py:421
 msgid "Facilities you wish to pretend to be in"
 msgstr "Einrichtungen, in denen Sie vorgeblich sein wollen"
 
-#: course/views.py:424
 msgid "Custom facilities"
 msgstr "Benutzer-spezifische Einrichtungen"
 
-#: course/views.py:426
 msgid ""
 "More (non-predefined) facility names, separated by commas, which would like "
 "to pretend to be in"
 msgstr ""
 
-#: course/views.py:439
-msgid "only staff may set fake facility"
+msgid "Add fake facililities header"
 msgstr ""
 
-#: course/views.py:469
+msgid ""
+"Add a page header to every page rendered while pretending to be in a "
+"facility, as a reminder that this pretending is in progress."
+msgstr ""
+
 msgid "Pretend to be in Facilities"
 msgstr "Vorgeben, in Einrichtungen zu sein"
 
-#: course/views.py:495
 msgctxt "Duration for instant flow"
 msgid "Duration in minutes"
 msgstr "Dauer in Minuten"
 
-#: course/views.py:500
 msgctxt "Add an instant flow"
 msgid "Add"
 msgstr "Hinzufügen"
 
-#: course/views.py:504
 msgctxt "Cancel all instant flow(s)"
 msgid "Cancel all"
 msgstr "Alle abbrechen"
 
-#: course/views.py:511
-msgid "must be instructor to manage instant flow requests"
-msgstr ""
-
-#: course/views.py:558
 msgid "Manage Instant Flow Requests"
 msgstr "Sofort-Flow-Anforderungen verwalten"
 
-#: course/views.py:580
 msgctxt "Start an activity"
 msgid "Go"
 msgstr "Los"
 
-#: course/views.py:590
-msgid "must be instructor or TA to test flows"
-msgstr ""
-
-#: course/views.py:611
 msgid "Test Flow"
 msgstr "Flow testen"
 
-#: course/views.py:642
 msgid "Select participant for whom exception is to be granted."
 msgstr ""
 
-#: course/views.py:656 course/views.py:744
 msgctxt "Next step"
 msgid "Next"
 msgstr "Weiter"
 
-#: course/views.py:666 course/views.py:754 course/views.py:969
-msgid "must be instructor or TA to grant exceptions"
-msgstr ""
+#, fuzzy
+#| msgid "Grant exception"
+msgid "may not grant exceptions"
+msgstr "Ausnahme gewähren"
 
-#: course/views.py:686 course/views.py:865 course/views.py:1129
 msgid "Grant Exception"
 msgstr "Ausnahme gewähren"
 
 #. Translators: %s is the string of the start time of a session.
-#: course/views.py:693
 #, python-format
 msgid "started at %s"
 msgstr "begonnen am %s"
 
-#: course/views.py:710
 msgid ""
 "If you click 'Create session', this tag will be applied to the new session."
 msgstr ""
 
-#: course/views.py:712
 msgid "Access rules tag for new session"
 msgstr ""
 
-#: course/views.py:718
 msgid "Create session (override rules)"
 msgstr ""
 
-#: course/views.py:723
 msgid "Create session"
 msgstr "Sitzung erstellen"
 
-#: course/views.py:734
 msgid ""
 "The rules that currently apply to selected session will provide the default "
 "values for the rules on the next page."
 msgstr ""
 
-#: course/views.py:763
 #, python-format
 msgid "Granting exception to '%(participation)s' for '%(flow_id)s'."
 msgstr ""
 
-#: course/views.py:784 course/views.py:788
 msgid "NONE"
 msgstr ""
 
-#: course/views.py:800
 msgid ""
 "Creating a new session is (technically) not allowed by course rules. "
 "Clicking 'Create Session' anyway will override this rule."
 msgstr ""
 
-#: course/views.py:875
+msgid "Exception only applies to sessions with the above tag"
+msgstr ""
+
+msgid "If set, an exception for the access rules will be created."
+msgstr ""
+
+#, fuzzy
+#| msgid "Set access rules tag"
+msgid "Create access rule exception"
+msgstr "Zugriffsregel-Tag setzen"
+
 msgctxt "Time when access expires"
 msgid "Access expires"
 msgstr ""
 
-#: course/views.py:876
 msgid ""
 "At the specified time, the special access granted below will expire and "
 "revert to being the same as for the rest of the class. This field may be "
@@ -5025,126 +4890,126 @@ msgid ""
 "remain valid indefinitely, unless overridden by another exception."
 msgstr ""
 
-#: course/views.py:901
-msgid "Exception only applies to sessions with the above tag"
+msgid "If set, an exception for the grading rules will be created."
 msgstr ""
 
-#: course/views.py:920
+#, fuzzy
+#| msgid "Flow rule exception"
+msgid "Create grading rule exception"
+msgstr "Flow-Regel-Ausnahme"
+
 msgid "If set, the 'Due' field will be disregarded."
 msgstr ""
 
-#: course/views.py:923
 msgid "Due same as access expiration"
 msgstr ""
 
-#: course/views.py:928
 msgid ""
 "The due time shown to the student. Also, the time after which any session "
 "under these rules is subject to expiration."
 msgstr ""
 
-#: course/views.py:936
+#, fuzzy
+#| msgid "Average grade"
+msgid "Generates grade"
+msgstr "Durchschnittsnote"
+
 msgid "Credit percent"
 msgstr ""
 
-#: course/views.py:949
+#, fuzzy
+#| msgid "Max points"
+msgid "Bonus points"
+msgstr "Maximal-Punktzahl"
+
+msgid "Maximum number of points (for percentage)"
+msgstr ""
+
+msgid "Maximum number of points (enforced cap)"
+msgstr ""
+
 msgid "Save"
 msgstr "Sichern"
 
-#: course/views.py:958
 msgid ""
 "Must specify access expiration if 'due same as access expiration' is set."
 msgstr ""
 
-#: course/views.py:1030 course/views.py:1089
 msgid "newly created exception"
 msgstr ""
 
-#: course/views.py:1059
 msgid "Granted excecption"
 msgstr ""
 
-#: course/views.py:1061
 msgid "credit"
 msgstr ""
 
-#: course/views.py:1106
 #, python-format
 msgid "Exception granted to '%(participation)s' for '%(flow_id)s'."
 msgstr ""
 
-#: course/views.py:1132
 #, python-format
 msgid ""
-"Granting exception to '%(participation)s' for '%(flow_id)s' (session "
-"%(session)s)."
+"Granting exception to '%(participation)s' for '%(flow_id)s' (session %"
+"(session)s)."
 msgstr ""
 
-#: course/views.py:1149
 msgid "only staff may use this tool"
 msgstr ""
 
-#: course/views.py:1191
 #, python-format
 msgid "%(current)d out of %(total)d items processed."
 msgstr ""
 
-#: relate/templates/403.html:5
+#, fuzzy
+#| msgid "Edit course"
+msgid "Edit Course"
+msgstr "Kurs bearbeiten"
+
 msgid "403 Forbidden"
 msgstr ""
 
-#: relate/templates/403.html:7
 msgid "Access to the page you requested was denied."
 msgstr ""
 
-#: relate/templates/403.html:9
 msgid "Here are a few things you could try:"
 msgstr ""
 
-#: relate/templates/403.html:17
 #, python-format
 msgid ""
 "You're not currently signed in. Access to the resource is restricted, and "
 "since the site has no way of knowing who you are, it denied you accesss. "
-"Once you're signed in, navigate back to your course from the <a href="
-"\"%(relate-home)s\"> home page </a> and retry your last action."
+"Once you're signed in, navigate back to your course from the <a href=\"%"
+"(relate-home)s\"> home page </a> and retry your last action."
 msgstr ""
 
-#: relate/templates/403.html:42
 msgid " Sorry, and thanks for your patience! "
 msgstr ""
 
-#: relate/templates/404.html:5
 msgid "404 Not Found"
 msgstr "404 Nicht gefunden"
 
-#: relate/templates/404.html:8
 msgid "Request URL"
 msgstr "Anforderungs-URL"
 
-#: relate/templates/404.html:12
 msgid ""
 "Oops. Either the URL you entered was invalid, or you stumbled on a dead "
 "link. If it was the latter, please get in touch with your course staff to "
 "let them know what you were doing when the error occurred."
 msgstr ""
 
-#: relate/templates/404.html:20 relate/templates/500.html.py:18
 #, python-format
 msgid ""
 "In the meantime, you may navigate back to  the <a href=\"%(relate-home)s"
 "\">home page</a>."
 msgstr ""
 
-#: relate/templates/404.html:27 relate/templates/500.html.py:25
 msgid "Sorry, and thanks for your patience!"
 msgstr "Entschuldigung, und vielen Dank für Ihre Geduld!"
 
-#: relate/templates/500.html:5
 msgid "500 Server Error"
 msgstr "500 Server-Fehler"
 
-#: relate/templates/500.html:8
 msgid ""
 "Oops. That shouldn't have happened. Technical details of the error have been "
 "recorded. Please get in touch with your course staff to let them know what "
@@ -5152,116 +5017,149 @@ msgid ""
 "sending your report."
 msgstr ""
 
-#: relate/templates/admin/base_site.html:6
 #, python-format
 msgid "%(RELATE)s Administration"
 msgstr ""
 
-#: relate/templates/base-page-top.html:35
 #, python-format
 msgid ""
-"You are currently seeing a preview of what the site would look like at "
-"%(fake_time)s."
+"You are currently seeing a preview of what the site would look like at %"
+"(fake_time)s."
 msgstr ""
 
-#: relate/templates/base-page-top.html:49
 #, python-format
 msgid ""
 "You are currently seeing a preview of what the site would look like from "
 "inside the facilities  <b>%(facilities)s</b>."
 msgstr ""
-"Sie sehen eine Vorschau davon, wie die Seite aus den Eichrichtungen <b>"
-"%(facilities)s</b> aussehen würde."
+"Sie sehen eine Vorschau davon, wie die Seite aus den Eichrichtungen <b>%"
+"(facilities)s</b> aussehen würde."
 
-#: relate/templates/base-page-top.html:55 relate/templates/base.html.py:78
 msgid "Pretend to be in facilities"
 msgstr "Vorgeben in Einrichtungen zu sein"
 
-#: relate/templates/base-page-top.html:63
-#, fuzzy, python-format
-#| msgid ""
-#| "Now impersonating %(last_name)s, %(first_name)s (user: %(username)s, "
-#| "email: %(email)s)."
-msgid "Now impersonating %(full_name)s (user: %(username)s, email: %(email)s)."
-msgstr ""
-"Jetzt als %(last_name)s, %(first_name)s (Benutzer: %(username)s, E-Mail: "
-"%(email)s) ausgegeben."
+#, fuzzy
+#| msgid "Stop impersonating"
+msgid "Now impersonating"
+msgstr "Nicht mehr als anderer Benutzer ausgeben"
 
-#: relate/templates/base.html:66
 msgid "Staff"
 msgstr "Mitarbeiter"
 
-#: relate/templates/base.html:69
 msgid "Admin site"
 msgstr "Verwaltungs-Site"
 
-#: relate/templates/base.html:71
-msgid "Test/Troubleshoot"
-msgstr "Testen/Fehler beheben"
-
-#: relate/templates/base.html:85
 msgid "Issue exam tickets"
 msgstr "Prüfungstickets ausgeben"
 
-#: relate/templates/base.html:86
 msgid "Exam check-in"
 msgstr "Prüfungs-Check-In"
 
-#: relate/templates/base.html:96
+msgid "Test/Troubleshoot"
+msgstr "Testen/Fehler beheben"
+
 #, python-format
 msgid "Signed in as %(username)s"
 msgstr "Als %(username)s angemeldet"
 
-#: relate/templates/base.html:103
 msgid "(impersonated)"
 msgstr "(ausgegeben als)"
 
-#: relate/templates/djangosaml2/wayf.html:5
 msgid "Institutional Login (SAML2)"
 msgstr "Institutions-Login (SAML2)"
 
-#: relate/templates/djangosaml2/wayf.html:6
 msgid "Please select your Identity Provider from the following list:"
 msgstr "Bitte wählen Sie Ihren Identity Provider aus der folgenden Liste:"
 
-#: relate/templates/maintenance.html:8
 #, python-format
 msgid ""
 "%(RELATE)s is currently in maintenance mode. Sorry for the interruption, "
 "we'll be back shortly."
 msgstr ""
 
-#: relate/templates/sign-in-choice.html:5
 msgid "Sign in to RELATE"
 msgstr "Bei RELATE Anmelden"
 
-#: relate/templates/sign-in-choice.html:14
 msgid "Sign in using your institution's login"
 msgstr "Via Institutions-Login anmelden"
 
-#: relate/templates/sign-in-choice.html:23
 msgid "Sign in using your email"
 msgstr "Via Email anmelden"
 
-#: relate/templates/sign-in-choice.html:32
 msgid "Sign up for an account"
 msgstr "Neues Konto erstellen"
 
-#: relate/templates/sign-in-choice.html:41
 msgid "Sign in using an exam ticket"
 msgstr "Mit Prüfungsticket anmelden"
 
-#: relate/templates/sign-in-choice.html:49
 msgid "Sign in with a RELATE-specific user name and password"
 msgstr "Mit einem RELATE-spezifischen Benutzernamen anmelden"
 
-#: relate/templates/user-profile-form.html:7
+msgid "You're already signed in"
+msgstr ""
+
+msgid "Would you like to sign out and proceed with your previous operation?"
+msgstr ""
+
+msgid "Sign out"
+msgstr "Abmelden"
+
 msgid "User Profile"
 msgstr "Benutzerprofil"
 
-#: relate/templates/user-profile-form.html:12
-msgid "Sign out"
-msgstr "Abmelden"
+#~ msgid "only instructors and TAs may do that"
+#~ msgstr "Nur Instruktoren und Assistenten dürfen das"
+
+#~ msgctxt "Participation role"
+#~ msgid "Observer"
+#~ msgstr "Beobachter"
+
+#~ msgctxt "Participation role"
+#~ msgid "Auditor"
+#~ msgstr "Auditor"
+
+#~ msgid "Session expired."
+#~ msgstr "Sitzung abgelaufen."
+
+#, fuzzy
+#~| msgid "must be at least TA to view analytics"
+#~ msgid "must be at least TA to download submissions"
+#~ msgstr "muss mindestens Kurs-Assistent sein um Analytics anzusehen"
+
+#~ msgid "Choices"
+#~ msgstr "Auswahl"
+
+#, fuzzy
+#~| msgid "Participations"
+#~ msgid "Edit Participations (admin)"
+#~ msgstr "Teilnahmen"
+
+#~ msgid "Edit Grading Opportunities (admin)"
+#~ msgstr "Benotungsmöglichkeiten bearbeiten (Admin)"
+
+#~ msgid "You are currently seeing a preview of revision"
+#~ msgstr "Sie sehen eine Vorschau von Revision"
+
+#~ msgid "View revisions"
+#~ msgstr "Versionen ansehen"
+
+#, fuzzy
+#~| msgid "Submit answer"
+#~ msgid "Submit assignment"
+#~ msgstr "Antwort einreichen"
+
+#~ msgid "in progress"
+#~ msgstr "im Gange"
+
+#, fuzzy
+#~| msgid ""
+#~| "Now impersonating %(last_name)s, %(first_name)s (user: %(username)s, "
+#~| "email: %(email)s)."
+#~ msgid ""
+#~ "Now impersonating %(full_name)s (user: %(username)s, email: %(email)s)."
+#~ msgstr ""
+#~ "Jetzt als %(last_name)s, %(first_name)s (Benutzer: %(username)s, E-Mail: %"
+#~ "(email)s) ausgegeben."
 
 #~ msgid "Emails"
 #~ msgstr "Email-Adressen"

--- a/locale/zh_CN/LC_MESSAGES/django.po
+++ b/locale/zh_CN/LC_MESSAGES/django.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-10-17 15:25+0800\n"
+"POT-Creation-Date: 2017-04-10 00:22+0800\n"
 "Last-Translator:  Dong Zhuang <dzhuang.scut@gmail.com>\n"
 "Language-Team: Dong Zhuang <dzhuang.scut@gmail.com>\n"
 "MIME-Version: 1.0\n"
@@ -17,113 +17,86 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: \n"
 
-#: .\accounts\apps.py:8
 msgid "Accounts"
 msgstr "帐户管理"
 
-#: .\accounts\models.py:42
 msgid "username"
 msgstr "用户名"
 
-#: .\accounts\models.py:46
 msgid "Required. 30 characters or fewer. Letters, digits and @/./+/-/_ only."
 msgstr ""
 
-#: .\accounts\models.py:50
 msgid ""
 "Enter a valid username. This value may contain only letters, numbers and @/./"
 "+/-/_ characters."
 msgstr ""
 
-#: .\accounts\models.py:55 .\course\auth.py:415
 msgid "A user with that username already exists."
 msgstr ""
 
-#: .\accounts\models.py:58
 msgid "first name"
 msgstr "名"
 
-#: .\accounts\models.py:59
 msgid "last name"
 msgstr "姓"
 
-#: .\accounts\models.py:60 .\course\auth.py:537
 msgid "email address"
 msgstr "电子邮件"
 
-#: .\accounts\models.py:63
 msgid "Name verified"
 msgstr "姓名(已验证)"
 
-#: .\accounts\models.py:66
 msgid ""
 "Indicates that this user's name has been verified as being associated with "
 "the individual able to sign in to this account."
 msgstr "表明该用户的姓名已经验证，即他(她)关联到了这个登录帐户."
 
-#: .\accounts\models.py:72
 msgctxt "User status"
 msgid "active"
 msgstr "正常"
 
-#: .\accounts\models.py:75
 msgid ""
 "Designates whether this user should be treated as active. Unselect this "
 "instead of deleting accounts."
 msgstr "指定该用户是否应被视为正常用户. 取消勾选而不是删除帐户."
 
-#: .\accounts\models.py:79
 msgid "date joined"
 msgstr "加入日期"
 
-#: .\accounts\models.py:84
 msgid "staff status"
 msgstr "职员状态"
 
-#: .\accounts\models.py:86
 msgid "Designates whether the user can log into this admin site."
 msgstr "指定该用户是否可以登入管理界面."
 
-#: .\accounts\models.py:90 .\course\auth.py:492 .\course\enrollment.py:397
-#: .\course\grades.py:1026 .\course\models.py:515
-#: .\course\templates\course\participation-table.html:12
-#: .\relate\templates\reset-passwd-form.html:20
 msgid "Institutional ID"
 msgstr "学号"
 
-#: .\accounts\models.py:93
 msgid "Institutional ID verified"
 msgstr "学号(已验证)"
 
-#: .\accounts\models.py:96
 msgid ""
 "Indicates that this user's institutional ID has been verified as being "
 "associated with the individual able to log in to this account."
 msgstr "表明该用户的学号已经验证，即他(她)关联到了这个登录帐户."
 
-#: .\accounts\models.py:103
 msgid "User status"
 msgstr "用户状态"
 
-#: .\accounts\models.py:106
 msgid "The sign in token sent out in email."
 msgstr "用户登录网站的token(用邮件发送)."
 
 #. Translators: the sign in token of the user.
-#: .\accounts\models.py:109
 msgid "Sign in key"
 msgstr "登录key"
 
-#: .\accounts\models.py:112
 msgid "The time stamp of the sign in token."
 msgstr "用户登录网站token的时间戳."
 
 #. Translators: the time when the token is sent out.
-#: .\accounts\models.py:114
 msgid "Key time"
 msgstr "登录key的时间"
 
-#: .\accounts\models.py:117
 msgid ""
 "Which key bindings you prefer when editing larger amounts of text or code. "
 "(If you do not understand what this means, leave it as 'Default'.)"
@@ -131,148 +104,101 @@ msgstr ""
 "当你编辑大量文字或代码时偏爱使用的编辑器模式. (如果你不明白是什么意思，请保持"
 "该选项为\"默认\")."
 
-#: .\accounts\models.py:122
 msgid "Default"
 msgstr "默认"
 
 #. Translators: the text editor used by participants
-#: .\accounts\models.py:129
 msgid "Editor mode"
 msgstr "编辑器模式"
 
-#: .\accounts\models.py:132
 msgid "A hash of the authentication token to be used for direct git access."
 msgstr "直接用于访问git时使用的验证token的哈希值"
 
-#: .\accounts\models.py:135
 msgid "Hash of git authentication token"
 msgstr "验证token的哈希值"
 
-#: .\accounts\models.py:141 .\accounts\models.py:219
 msgid "user"
 msgstr "用户"
 
-#: .\accounts\models.py:142
 msgid "users"
 msgstr "用户"
 
-#: .\accounts\models.py:152
 msgid "(blank)"
 msgstr "(空)"
 
-#: .\course\admin.py:262
 msgid "Tags must belong to same course as participation."
 msgstr "Tags必须与同一课程中的participation一致. "
 
-#: .\course\admin.py:269
 msgid "Role must belong to same course as participation."
 msgstr "Role必须与participation从属于同一课程. "
 
-#: .\course\admin.py:279 .\course\admin.py:353 .\course\enrollment.py:393
-#: .\course\models.py:423 .\course\models.py:521
 msgid "Roles"
 msgstr "在课程中的角色"
 
-#: .\course\admin.py:298 .\course\exam.py:196
-#: .\course\templates\course\gradebook-by-opp.html:118
-#: .\course\templates\course\gradebook-participant.html:30
-#: .\course\templates\course\gradebook.html:18
-#: .\course\templates\course\participation-table.html:10
 msgctxt "real name of a user"
 msgid "Name"
 msgstr "姓名"
 
-#: .\course\admin.py:418 .\course\admin.py:632 .\course\admin.py:743
-#: .\course\admin.py:818 .\course\admin.py:900 .\course\exam.py:99
-#: .\course\templates\course\gradebook-single.html:17 .\course\views.py:703
 msgid "Participant"
 msgstr "参与者"
 
-#: .\course\admin.py:516 .\course\admin.py:627 .\course\admin.py:733
-#: .\course\admin.py:813 .\course\models.py:219 .\course\models.py:256
-#: .\course\models.py:301 .\course\models.py:336 .\course\models.py:416
-#: .\course\models.py:517 .\course\models.py:680 .\course\models.py:715
-#: .\course\models.py:1325 .\course\models.py:1729
 msgid "Course"
 msgstr "课程"
 
-#: .\course\admin.py:521 .\course\flow.py:2575 .\course\models.py:682
-#: .\course\models.py:730 .\course\models.py:1151 .\course\models.py:1223
-#: .\course\models.py:1346 .\course\models.py:1733
-#: .\course\templates\course\gradebook-opp-list.html:26
-#: .\course\templates\course\gradebook-single.html:138 .\course\views.py:551
-#: .\course\views.py:633 .\course\views.py:708
 msgid "Flow ID"
 msgstr ""
 
-#: .\course\admin.py:526
 msgid "not in use"
 msgstr "未使用"
 
-#: .\course\admin.py:535 .\course\grades.py:1340 .\course\models.py:851
 msgid "Page ID"
 msgstr ""
 
-#: .\course\admin.py:542
 msgid "anonymous"
 msgstr "匿名"
 
-#: .\course\admin.py:544
 msgid "Owner"
 msgstr "所有者"
 
-#: .\course\admin.py:549
 msgid "Has answer"
 msgstr "已经回答"
 
-#: .\course\admin.py:554
 msgid "Flow Session ID"
 msgstr ""
 
-#: .\course\admin.py:738
 msgid "Opportunity"
 msgstr "机会"
 
-#: .\course\admin.py:947
 msgid "Revoke Exam Tickets"
 msgstr "撤销测验Ticket"
 
-#: .\course\analytics.py:59 .\course\analytics.py:446
-#: .\course\analytics.py:488
 msgid "may not view analytics"
 msgstr "不允许查看分析统计"
 
-#: .\course\analytics.py:107
 msgctxt "No data"
 msgid "None"
 msgstr "无"
 
-#: .\course\analytics.py:116
 msgctxt "Value of grade"
 msgid "value greater than max"
 msgstr "分值高于允许的最高值"
 
-#: .\course\analytics.py:124
 msgctxt "Value of grade"
 msgid "value smaller than min"
 msgstr "分值低于允许的最低值"
 
-#: .\course\analytics.py:169
 msgctxt "Value in histogram"
 msgid "<out of bounds>"
 msgstr "<溢出边界>"
 
-#: .\course\analytics.py:271 .\course\analytics.py:419
 msgctxt "Status of session"
 msgid "in progress"
 msgstr "进行中"
 
-#: .\course\analytics.py:413
 msgctxt "Minute (time unit)"
 msgid "min"
 msgstr "分钟"
 
-#: .\course\analytics.py:456
 #, python-format
 msgid ""
 "Flow '%s' was not found in the repository, but it exists in the database--"
@@ -280,245 +206,161 @@ msgid ""
 msgstr ""
 "Flow '%s'在repository中未找到，但是它存在于数据库中--它是不是已经被删除了？"
 
-#: .\course\apps.py:8
 msgid "Course module"
 msgstr "课程模块"
 
-#: .\course\auth.py:117 .\course\auth.py:121
 msgid "Error while impersonating."
 msgstr "虚拟用户时出现错误. "
 
-#: .\course\auth.py:159
 msgid "Select user to impersonate."
 msgstr "选择您想模拟的用户. "
 
-#: .\course\auth.py:161 .\course\exam.py:195 .\course\models.py:725
-#: .\course\models.py:912
-#: .\course\templates\course\grade-import-preview.html:19
 msgid "User"
 msgstr "用户"
 
-#: .\course\auth.py:166
 msgid "Add impersonation header"
 msgstr "添加模拟用户header"
 
-#: .\course\auth.py:167
 msgid ""
 "Add impersonation header to every page rendered while impersonating, as a "
 "reminder that impersonation is in progress."
 msgstr "为每个模拟用户的页面添加header，作为正在模拟用户的一个提示. "
 
-#: .\course\auth.py:171
 msgid "Impersonate"
 msgstr "用户模拟"
 
-#: .\course\auth.py:179
 msgid "Already impersonating someone."
 msgstr "已经模拟了某个用户. "
 
-#: .\course\auth.py:196
 msgid "Impersonating that user is not allowed."
 msgstr "不允许模拟该用户. "
 
-#: .\course\auth.py:202 .\relate\templates\base.html:75
 msgid "Impersonate user"
 msgstr "用户模拟"
 
-#: .\course\auth.py:212 .\relate\templates\base-page-top.html:64
-#: .\relate\templates\base.html:73
 msgid "Stop impersonating"
 msgstr "停止模拟用户"
 
-#: .\course\auth.py:218
 msgid "Not currently impersonating anyone."
 msgstr "当前未模拟任何用户. "
 
-#: .\course\auth.py:225
 msgid "No longer impersonating anyone."
 msgstr "未模拟任何用户. "
 
-#: .\course\auth.py:234
 msgid "Stop impersonating user"
 msgstr "停止模拟用户"
 
-#: .\course\auth.py:323 .\course\templates\course\course-page.html:17
-#: .\course\templates\course\flow-start.html:210
-#: .\course\templates\course\login.html:7 .\relate\templates\403.html:14
-#: .\relate\templates\base.html:114
 msgid "Sign in"
 msgstr "登录"
 
-#: .\course\auth.py:377
 msgid "Username"
 msgstr "用户名"
 
-#: .\course\auth.py:381
 msgid "Enter a valid username."
 msgstr ""
 
-#: .\course\auth.py:382
 msgid "This value may contain only letters, numbers and @/./+/-/_ characters."
 msgstr ""
 
-#: .\course\auth.py:398 .\course\auth.py:486 .\course\auth.py:498
 msgid "Send email"
 msgstr "发送邮件"
 
-#: .\course\auth.py:407 .\course\auth.py:513 .\course\auth.py:632
 msgid "self-registration is not enabled"
 msgstr "自主注册未启用"
 
-#: .\course\auth.py:420
 #, python-format
 msgid ""
 "That email address is already in use. Would you like to <a href='%s'>reset "
 "your password</a> instead?"
 msgstr "该电子邮件已经注册, 您是否需要 <a href='%s'>重置密码</a> ？"
 
-#: .\course\auth.py:450 .\course\auth.py:568 .\course\auth.py:600
-#: .\course\auth.py:677 .\course\auth.py:733
-#: .\course\templates\course\analytics-flow.html:5
-#: .\course\templates\course\analytics-flows.html:5
-#: .\course\templates\course\analytics-page.html:5
-#: .\course\templates\course\broken-code-question-email.txt:6
-#: .\course\templates\course\calendar.html:8
-#: .\course\templates\course\course-base.html:8
-#: .\course\templates\course\flow-completion-grade.html:6
-#: .\course\templates\course\flow-completion.html:6
-#: .\course\templates\course\flow-confirm-completion.html:6
-#: .\course\templates\course\flow-page.html:9
-#: .\course\templates\course\flow-start.html:6
-#: .\course\templates\course\grade-flow-page.html:7
-#: .\course\templates\course\gradebook-by-opp.html:8
-#: .\course\templates\course\gradebook-opp-list.html:8
-#: .\course\templates\course\gradebook-participant-list.html:7
-#: .\course\templates\course\gradebook-participant.html:7
-#: .\course\templates\course\gradebook-single.html:5
-#: .\course\templates\course\gradebook.html:5
-#: .\course\templates\course\grading-statistics.html:5
-#: .\course\templates\course\home.html:6
-#: .\course\templates\course\home.html:50
-#: .\course\templates\course\query-participations.html:7
-#: .\course\templates\course\sandbox-page.html:17
-#: .\course\templates\course\sign-in-email.txt:2
-#: .\relate\templates\admin\base_site.html:5 .\relate\templates\base.html:11
-#: .\relate\templates\base.html:56 .\relate\templates\maintenance.html:7
 msgid "RELATE"
 msgstr ""
 
-#: .\course\auth.py:451
 msgid "Verify your email"
 msgstr "验证您的电子邮件"
 
-#: .\course\auth.py:465 .\course\auth.py:589 .\course\auth.py:747
 msgid "Email sent. Please check your email and click the link."
 msgstr "Email已发送, 请进入邮箱并点击相关的链接. "
 
-#: .\course\auth.py:474
 msgid "Sign up"
 msgstr "注册"
 
-#: .\course\auth.py:480 .\course\auth.py:687 .\course\enrollment.py:396
-#: .\course\models.py:513 .\relate\templates\reset-passwd-form.html:17
 msgid "Email"
 msgstr "Email"
 
-#: .\course\auth.py:538
 msgid "institutional ID"
 msgstr "学号"
 
-#: .\course\auth.py:541
 #, python-format
 msgid ""
 "That %(field)s doesn't have an associated user account. Are you sure you've "
 "registered?"
 msgstr "该%(field)s不存在关联的用户帐号, 您确定已经注册了么？"
 
-#: .\course\auth.py:549
 msgid "The account with that institution ID doesn't have an associated email."
 msgstr "与该学号关联的帐号中未设置关联的电子邮件."
 
-#: .\course\auth.py:569
 msgid "Password reset"
 msgstr "密码重置"
 
-#: .\course\auth.py:584
 #, python-format
 msgid "The email address associated with that account is %s."
 msgstr "该帐号的注册电子邮件为%s."
 
-#: .\course\auth.py:599 .\course\auth.py:676
 #, python-format
 msgid "Password reset on %(site_name)s"
 msgstr "重置我的%(site_name)s密码"
 
-#: .\course\auth.py:607
 msgid "Password"
 msgstr "密码"
 
-#: .\course\auth.py:609
 msgid "Password confirmation"
 msgstr ""
 
-#: .\course\auth.py:615 .\course\auth.py:860 .\course\enrollment.py:904
-#: .\course\grades.py:1555 .\course\versioning.py:517 .\course\views.py:1312
 msgid "Update"
 msgstr "更新"
 
-#: .\course\auth.py:623
 msgid "The two password fields didn't match."
 msgstr ""
 
-#: .\course\auth.py:636 .\course\auth.py:772
 msgid "Invalid sign-in token. Perhaps you've used an old token email?"
 msgstr "登录链接无效, 您可能使用了一个旧邮件中的链接？"
 
-#: .\course\auth.py:638 .\course\auth.py:646 .\course\auth.py:651
-#: .\course\auth.py:774 .\course\auth.py:779
 msgid "invalid sign-in token"
 msgstr "登录链接无效"
 
-#: .\course\auth.py:650 .\course\auth.py:778
 msgid "Account disabled."
 msgstr "帐户已禁用. "
 
-#: .\course\auth.py:661 .\course\auth.py:785
 msgid ""
 "Successfully signed in. Please complete your registration information below."
 msgstr "成功登录, 请在下面完善您的注册信息. "
 
-#: .\course\auth.py:668 .\course\auth.py:792
 msgid "Successfully signed in."
 msgstr "成功登录. "
 
-#: .\course\auth.py:695
 msgid "Send sign-in email"
 msgstr "发送登录邮件"
 
-#: .\course\auth.py:704 .\course\auth.py:765
 msgid "Email-based sign-in is not being used"
 msgstr "基于邮件链接登录的方式未启用"
 
-#: .\course\auth.py:733
 #, python-format
 msgid "Your %(RELATE)s sign-in link"
 msgstr "您的%(RELATE)s登录链接"
 
-#: .\course\auth.py:808
 msgid "Institutional ID Confirmation"
 msgstr "学号(再次输入)"
 
-#: .\course\auth.py:811
 msgid "I have no Institutional ID"
 msgstr "我没有学号"
 
-#: .\course\auth.py:812
 msgid ""
 "Check the checkbox if you are not a student or you forget your institutional "
 "id."
 msgstr "如果您不是学生或者暂时忘记了学号, 请勾选该选项."
 
-#: .\course\auth.py:834
 #, python-format
 msgid ""
 "The unique ID your university or school provided, which may be used by some "
@@ -528,683 +370,557 @@ msgstr ""
 "您所在的学校提供给您的唯一ID，在本网站中，一些课程的加入可能需要学号匹配. <b>"
 "注意：学号一旦%(submitted_or_verified)s将无法更改</b>."
 
-#: .\course\auth.py:841
 msgid "verified"
 msgstr "通过验证"
 
-#: .\course\auth.py:841
 msgid "submitted"
 msgstr "提交"
 
-#: .\course\auth.py:899
 msgid "This field is required."
 msgstr ""
 
-#: .\course\auth.py:901
 msgid "Inputs do not match."
 msgstr "您的输入不匹配."
 
-#: .\course\auth.py:929
 msgid "Profile data saved."
 msgstr "用户信息已更新. "
 
-#: .\course\auth.py:966
 msgid "Reset"
 msgstr "重置"
 
-#: .\course\auth.py:983
 #, python-format
 msgid "A new authentication token has been set: %s."
 msgstr "一个新的git认证token已设定: %s."
 
-#: .\course\auth.py:989
 msgid "An authentication token has previously been set."
 msgstr "之前已经设定了一个git认证token."
 
-#: .\course\auth.py:992
 msgid "No authentication token has previously been set."
 msgstr "之前尚未设定了git认证token."
 
-#: .\course\auth.py:997 .\course\templates\course\course-base.html:100
 msgid "Manage Git Authentication Token"
 msgstr "管理Git认证token"
 
 #. Translators: format of event kind in Event model
-#: .\course\calendar.py:55 .\course\calendar.py:199 .\course\models.py:259
 msgid "Should be lower_case_with_underscores, no spaces allowed."
 msgstr "只允许小写字母和下划线, 不允许有空格. "
 
-#: .\course\calendar.py:57 .\course\calendar.py:201
 msgctxt "Kind of event"
 msgid "Kind of event"
 msgstr "event的类型(kind)"
 
-#: .\course\calendar.py:61
 msgctxt "Starting time of event"
 msgid "Starting time"
 msgstr "开始时间"
 
-#: .\course\calendar.py:63
 msgid "Duration in minutes"
 msgstr "时长(分钟)"
 
-#: .\course\calendar.py:66
+msgid "All-day event"
+msgstr "全天事件"
+
+#. Translators: for when the due time is "All day", how the webpage
+#. of a event is displayed.
+msgid ""
+"Only affects the rendering in the class calendar, in that a start time is "
+"not shown"
+msgstr "只会影响课程日历页面的渲染, 其效果为开始时间(start time)不显示. "
+
+msgid "Shown in calendar"
+msgstr "在日历中显示"
+
 msgid "Weekly"
 msgstr "以星期为单位"
 
-#: .\course\calendar.py:67
 msgid "Bi-Weekly"
 msgstr "每隔两周"
 
-#: .\course\calendar.py:69
 msgctxt "Interval of recurring events"
 msgid "Interval"
 msgstr "时间间隔"
 
-#: .\course\calendar.py:72 .\course\calendar.py:204
 msgctxt "Starting ordinal of recurring events"
 msgid "Starting ordinal"
 msgstr "开始的序号"
 
-#: .\course\calendar.py:74
 msgctxt "Count of recurring events"
 msgid "Count"
 msgstr "次数"
 
-#: .\course\calendar.py:80
 msgid "Create"
 msgstr "创建"
 
-#: .\course\calendar.py:108
 #, python-format
 msgid "'%(event_kind)s %(event_ordinal)d' already exists"
 msgstr "%(event_kind)s %(event_ordinal)d' 已经存在"
 
-#: .\course\calendar.py:121
 msgctxt "Unkown time interval"
 msgid "unknown interval"
 msgstr "未知的时间间隔"
 
-#: .\course\calendar.py:137 .\course\calendar.py:218
 msgid "may not edit events"
 msgstr "不允许编辑event"
 
-#: .\course\calendar.py:167 .\course\calendar.py:179
 msgid "No events created."
 msgstr "未创建event. "
 
-#: .\course\calendar.py:185
 msgid "Events created."
 msgstr "Event创建成功. "
 
-#: .\course\calendar.py:193 .\course\templates\course\course-base.html:127
 msgid "Create recurring events"
 msgstr "创建重复进行的event"
 
-#: .\course\calendar.py:210
 msgid "Renumber"
 msgstr "重新编号"
 
-#: .\course\calendar.py:250
 msgid "Events renumbered."
 msgstr "Event重新编号完成. "
 
-#: .\course\calendar.py:253
 msgid "No events found."
 msgstr "未找到Event. "
 
-#: .\course\calendar.py:260 .\course\templates\course\course-base.html:128
 msgid "Renumber events"
 msgstr "重新编号"
 
-#: .\course\calendar.py:285
 msgid "may not view calendar"
 msgstr "不允许查看日历"
 
-#: .\course\constants.py:45
 msgctxt "User status"
 msgid "Unconfirmed"
 msgstr "未确认"
 
-#: .\course\constants.py:46
 msgctxt "User status"
 msgid "Active"
 msgstr "正常"
 
-#: .\course\constants.py:61
 msgctxt "Participation status"
 msgid "Requested"
 msgstr "已请求"
 
-#: .\course\constants.py:63
 msgctxt "Participation status"
 msgid "Active"
 msgstr "正常(Active)"
 
-#: .\course\constants.py:65
 msgctxt "Participation status"
 msgid "Dropped"
 msgstr "已删除"
 
-#: .\course\constants.py:67
 msgctxt "Participation status"
 msgid "Denied"
 msgstr "已拒绝"
 
-#: .\course\constants.py:135
 msgctxt "Participation permission"
 msgid "Edit course"
 msgstr "编辑课程"
 
-#: .\course\constants.py:137
 msgctxt "Participation permission"
 msgid "Use admin interface"
 msgstr "使用管理界面"
 
-#: .\course\constants.py:139
 msgctxt "Participation permission"
 msgid "Impersonate role"
 msgstr "用户模拟"
 
-#: .\course\constants.py:141
 msgctxt "Participation permission"
 msgid "Set fake time"
 msgstr "设置虚拟时间"
 
-#: .\course\constants.py:143
 msgctxt "Participation permission"
 msgid "Pretend to be in facility"
 msgstr "假装置身于教学设施中"
 
-#: .\course\constants.py:145
 msgctxt "Participation permission"
 msgid "Edit course permissions"
 msgstr "更新对课程内容的修订"
 
-#: .\course\constants.py:147
 msgctxt "Participation permission"
 msgid "View hidden course page"
 msgstr "查看隐藏的课程"
 
-#: .\course\constants.py:149
 msgctxt "Participation permission"
 msgid "View calendar"
 msgstr "查看日历"
 
-#: .\course\constants.py:151
 msgctxt "Participation permission"
 msgid "Send instant message"
 msgstr "发送即时信息"
 
-#: .\course\constants.py:153
 msgctxt "Participation permission"
 msgid "Access files for"
 msgstr "访问以下用户的文件:"
 
-#: .\course\constants.py:156
 msgctxt "Participation permission"
 msgid "Included in grade statistics"
 msgstr "包含在得分统计中"
 
-#: .\course\constants.py:159
 msgctxt "Participation permission"
 msgid "Edit exam"
 msgstr "编辑测验"
 
-#: .\course\constants.py:161
 msgctxt "Participation permission"
 msgid "Issue exam ticket"
 msgstr "发布测验ticket"
 
-#: .\course\constants.py:163
 msgctxt "Participation permission"
 msgid "Batch issue exam ticket"
 msgstr "批量发布测验ticket"
 
-#: .\course\constants.py:167
 msgctxt "Participation permission"
 msgid "View flow sessions from role "
 msgstr "查看flow session"
 
-#: .\course\constants.py:169
 msgctxt "Participation permission"
 msgid "View gradebook"
 msgstr "查看得分"
 
-#: .\course\constants.py:171
 msgctxt "Participation permission"
 msgid "Edit grading opportunity"
 msgstr "编辑得分机会"
 
-#: .\course\constants.py:173
 msgctxt "Participation permission"
 msgid "Assign grade"
 msgstr "评分 "
 
-#: .\course\constants.py:175
 msgctxt "Participation permission"
 msgid "View grader stats"
 msgstr "查看得分统计"
 
-#: .\course\constants.py:177
 msgctxt "Participation permission"
 msgid "Batch-import grades"
 msgstr "批量导入成绩"
 
-#: .\course\constants.py:179
 msgctxt "Participation permission"
 msgid "Batch-export grades"
 msgstr "批量导出成绩"
 
-#: .\course\constants.py:181
 msgctxt "Participation permission"
 msgid "Batch-download submissions"
 msgstr "批量下载提交的内容"
 
-#: .\course\constants.py:185
 msgctxt "Participation permission"
 msgid "Impose flow session deadline"
 msgstr "实施session的截止"
 
-#: .\course\constants.py:188
 msgctxt "Participation permission"
 msgid "Batch-impose flow session deadline"
 msgstr "批量实施session的截止"
 
-#: .\course\constants.py:190
 msgctxt "Participation permission"
 msgid "End flow session"
 msgstr "结束session"
 
-#: .\course\constants.py:192
 msgctxt "Participation permission"
 msgid "Batch-end flow sessions"
 msgstr "批量结束session"
 
-#: .\course\constants.py:194
 msgctxt "Participation permission"
 msgid "Regrade flow session"
 msgstr "重新评分"
 
-#: .\course\constants.py:197
 msgctxt "Participation permission"
 msgid "Batch-regrade flow sessions"
 msgstr "批量重新评分"
 
-#: .\course\constants.py:200
 msgctxt "Participation permission"
 msgid "Recalculate flow session grade"
 msgstr "重新计算评分"
 
-#: .\course\constants.py:203
 msgctxt "Participation permission"
 msgid "Batch-recalculate flow sesssion grades"
 msgstr "批量重新计算评分"
 
-#: .\course\constants.py:206
 msgctxt "Participation permission"
 msgid "Reopen flow session"
 msgstr "重新打开session"
 
-#: .\course\constants.py:208
 msgctxt "Participation permission"
 msgid "Grant exception"
 msgstr "给予破例"
 
-#: .\course\constants.py:210
 msgctxt "Participation permission"
 msgid "View analytics"
 msgstr "查看分析统计"
 
-#: .\course\constants.py:213
 msgctxt "Participation permission"
 msgid "Preview content"
 msgstr "预览内容. "
 
-#: .\course\constants.py:215
 msgctxt "Participation permission"
 msgid "Update content"
 msgstr "更新内容"
 
-#: .\course\constants.py:217
 msgctxt "Participation permission"
 msgid "Use markup sandbox"
 msgstr "使用Markup沙箱"
 
-#: .\course\constants.py:219
 msgctxt "Participation permission"
 msgid "Use page sandbox"
 msgstr "使用Page沙箱"
 
-#: .\course\constants.py:221
 msgctxt "Participation permission"
 msgid "Test flow"
 msgstr "测试flow"
 
-#: .\course\constants.py:224
 msgctxt "Participation permission"
 msgid "Edit events"
 msgstr "编辑event"
 
-#: .\course\constants.py:227
 msgctxt "Participation permission"
 msgid "Query participation"
 msgstr "查询课程参与"
 
-#: .\course\constants.py:229
 msgctxt "Participation permission"
 msgid "Edit participation"
 msgstr "编辑课程参与"
 
-#: .\course\constants.py:231
 msgctxt "Participation permission"
 msgid "Preapprove participation"
 msgstr "课程参与预批准"
 
-#: .\course\constants.py:235
 msgctxt "Participation permission"
 msgid "Manage instant flow requests"
 msgstr "管理即时flow"
 
-#: .\course\constants.py:273
 msgctxt "Flow expiration mode"
 msgid "Submit session for grading"
 msgstr "提交session用于评分"
 
-#: .\course\constants.py:276
 msgctxt "Flow expiration mode"
 msgid "Do not submit session for grading"
 msgstr "不要提交session并评分"
 
-#: .\course\constants.py:289
 msgid "unknown expiration mode"
 msgstr "未知的过期模式"
 
-#: .\course\constants.py:380
 msgctxt "Flow permission"
 msgid "View the flow"
 msgstr "查看flow"
 
-#: .\course\constants.py:382
 msgctxt "Flow permission"
 msgid "Submit answers"
 msgstr "提交回答"
 
-#: .\course\constants.py:384
 msgctxt "Flow permission"
 msgid "End session"
 msgstr "结束session"
 
-#: .\course\constants.py:386
 msgctxt "Flow permission"
 msgid "Change already-graded answer"
 msgstr "修改已经评分的回答"
 
-#: .\course\constants.py:389
 msgctxt "Flow permission"
 msgid "See whether an answer is correct"
 msgstr "查看答案是否正确"
 
-#: .\course\constants.py:392
 msgctxt "Flow permission"
 msgid "See the correct answer before answering"
 msgstr "在回答前查看正确的答案"
 
-#: .\course\constants.py:395
 msgctxt "Flow permission"
 msgid "See the correct answer after answering"
 msgstr "在回答后查看正确的答案"
 
-#: .\course\constants.py:398
 msgctxt "Flow permission"
 msgid "Cannot see flow result"
 msgstr "可以查看flow的结果"
 
-#: .\course\constants.py:401
 msgctxt "Flow permission"
 msgid "Set the session to 'roll over' expiration mode"
 msgstr "将这个session设为“展期”的过期模式"
 
-#: .\course\constants.py:403
 msgctxt "Flow permission"
 msgid "See session time"
 msgstr "查看session时间"
 
-#: .\course\constants.py:405
 msgctxt "Flow permission"
 msgid "Lock down as exam session"
 msgstr "锁定为测验session"
 
-#: .\course\constants.py:408
 msgctxt "Flow permission"
 msgid "Send emails about the flow page to course staff"
 msgstr "向课务人员发送关于本页面的答疑邮件."
 
-#: .\course\constants.py:422
 msgctxt "Flow rule kind choices"
 msgid "Session Start"
 msgstr "session开始"
 
-#: .\course\constants.py:424
 msgctxt "Flow rule kind choices"
 msgid "Session Access"
 msgstr "session访问"
 
-#: .\course\constants.py:426
 msgctxt "Flow rule kind choices"
 msgid "Grading"
 msgstr "评分"
 
-#: .\course\constants.py:466
 msgctxt "Grade aggregation strategy"
 msgid "Use the max grade"
 msgstr "使用最高分"
 
-#: .\course\constants.py:468
 msgctxt "Grade aggregation strategy"
 msgid "Use the avg grade"
 msgstr "使用平均分"
 
-#: .\course\constants.py:470
 msgctxt "Grade aggregation strategy"
 msgid "Use the min grade"
 msgstr "使用最低分"
 
-#: .\course\constants.py:472
 msgctxt "Grade aggregation strategy"
 msgid "Use the earliest grade"
 msgstr "使用最早的得分"
 
-#: .\course\constants.py:474
 msgctxt "Grade aggregation strategy"
 msgid "Use the latest grade"
 msgstr "使用最迟的得分"
 
-#: .\course\constants.py:495
 msgctxt "Grade state change"
 msgid "Grading started"
 msgstr "评分已经开始"
 
-#: .\course\constants.py:497
 msgctxt "Grade state change"
 msgid "Graded"
 msgstr "已评分"
 
-#: .\course\constants.py:499
 msgctxt "Grade state change"
 msgid "Retrieved"
 msgstr "已获取"
 
-#: .\course\constants.py:501
 msgctxt "Grade state change"
 msgid "Unavailable"
 msgstr "无法获取"
 
-#: .\course\constants.py:503
 msgctxt "Grade state change"
 msgid "Extension"
 msgstr "延期"
 
-#: .\course\constants.py:505
 msgctxt "Grade state change"
 msgid "Report sent"
 msgstr "报告已发送"
 
-#: .\course\constants.py:507
 msgctxt "Grade state change"
 msgid "Do-over"
 msgstr "重新开始"
 
-#: .\course\constants.py:509
 msgctxt "Grade state change"
 msgid "Exempt"
 msgstr "剔除"
 
-#: .\course\constants.py:525
 msgctxt "Exam ticket state"
 msgid "Valid"
 msgstr "已通过有效性验证"
 
-#: .\course\constants.py:527
 msgctxt "Exam ticket state"
 msgid "Used"
 msgstr "已使用"
 
-#: .\course\constants.py:529
 msgctxt "Exam ticket state"
 msgid "Revoked"
 msgstr "已撤回"
 
-#: .\course\content.py:234
+#, python-format
+msgid "commit sha '%s' not found"
+msgstr "未找到commit sha '%s'"
+
 #, python-format
 msgid "resource '%s' is a file, not a directory"
 msgstr "资源\"%s\"是一个文件，不是一个文件夹"
 
-#: .\course\content.py:245
 msgid "repo root is a directory, not a file"
 msgstr "repo根目录是一个文件夹，不是一个文件"
 
-#: .\course\content.py:261
 #, python-format
 msgid "resource '%s' is a directory, not a file"
 msgstr "资源\"%s\"是一个文件夹，不是一个文件"
 
-#: .\course\content.py:266
 #, python-format
 msgid "resource '%s' not found"
 msgstr "未找到资源\"%s\""
 
-#: .\course\content.py:665
 msgid "I have no idea what a processing instruction is."
 msgstr "我也不知道处理的指令是什么"
 
-#: .\course\content.py:1035
 #, python-format
 msgid "invalid period: %s"
 msgstr "无效的周期：%s"
 
-#: .\course\content.py:1147
 #, python-format
 msgid "unrecognized date/time specification: '%s' (interpreted as 'now')"
 msgstr "无法识别的日期/时间设定: '%s' (被解释为\"现在\")"
 
-#: .\course\content.py:1160
 #, python-format
 msgid "event '%s' has no end time, using start time instead"
 msgstr "事件'%s'没有结束时间，请使用开始时间"
 
-#: .\course\content.py:1342
 #, python-format
 msgid "page '%(group_id)s/%(page_id)s' in flow '%(flow_id)s'"
 msgstr "page \"%(group_id)s/%(page_id)s\" (在flow \"%(flow_id)s\"中)"
 
-#: .\course\content.py:1402
 #, python-format
 msgid "repo page class must conist of two dotted components (invalid: '%s')"
 msgstr "repo类型的page必须包括两个dotted组件 (无效: \"%s\")"
 
-#: .\course\enrollment.py:173
 msgid "Already enrolled. Cannot re-renroll."
 msgstr "已经加入课程, 不能再次申请加入. "
 
-#: .\course\enrollment.py:178
 msgid "Course is not accepting enrollments."
 msgstr "本课程不接受加入申请. "
 
-#: .\course\enrollment.py:185
 msgid "Can only enroll using POST request"
 msgstr "必须用POST请求的方式申请加入课程"
 
-#: .\course\enrollment.py:192
 msgid ""
 "Your email address is not yet confirmed. Confirm your email to continue."
 msgstr "您的电子邮件地址尚未确定, 请先确定邮件再继续. "
 
-#: .\course\enrollment.py:219
 #, python-format
 msgid "Enrollment not allowed. Please use your '%s' email to enroll."
 msgstr "不允许加入, 请使用您的电子邮件\"%s\"申请加入课程. "
 
-#: .\course\enrollment.py:249
 msgid "New enrollment request"
 msgstr "新的加入课程申请"
 
-#: .\course\enrollment.py:260
 msgid ""
 "Enrollment request sent. You will receive notifcation by email once your "
 "request has been acted upon."
 msgstr "加入课程的申请已经发送, 如果您的要求被批准, 您将会收到邮件通知. "
 
-#: .\course\enrollment.py:267 .\course\enrollment.py:984
 msgid "Successfully enrolled."
 msgstr "成功加入课程"
 
-#: .\course\enrollment.py:271
 msgid "A participation already exists. Enrollment attempt aborted."
 msgstr "该课程参与已经存在，加入课程申请的请求被放弃."
 
 #. Translators: how many enroll requests have ben processed.
-#: .\course\enrollment.py:327
 #, python-format
 msgid "%d requests processed."
 msgstr "%d个加入申请已处理. "
 
-#: .\course\enrollment.py:356
 msgid "Your enrollment request"
 msgstr "对您加入课程申请的答复"
 
-#: .\course\enrollment.py:371
 msgctxt "Admin"
 msgid "Approve enrollment"
 msgstr "批准加入"
 
-#: .\course\enrollment.py:377
 msgid "Deny enrollment"
 msgstr "拒绝加入"
 
-#: .\course\enrollment.py:400
 msgid "Preapproval type"
 msgstr "预先批准类型"
 
-#: .\course\enrollment.py:403
 msgid ""
 "Enter fully qualified data according to the \"Preapproval type\" you "
 "selected, one per line."
 msgstr "输入允许加入课程用户\"预先批准类型\"字段的数据, 每行一个. "
 
-#: .\course\enrollment.py:405
 msgid "Preapproval data"
 msgstr "预先批准数据"
 
-#: .\course\enrollment.py:408
 msgid "Preapprove"
 msgstr "预先批准"
 
-#: .\course\enrollment.py:416
 msgid "may not preapprove participation"
 msgstr "不允许预先批准课程参与"
 
-#: .\course\enrollment.py:519
 #, python-format
 msgid ""
 "%(n_created)d preapprovals created, %(n_exist)d already existed, %"
@@ -1213,110 +929,98 @@ msgstr ""
 "新加入了%(n_created)d个预批准, 有%(n_exist)d个是之前已经批准的, 批准了%"
 "(n_requested_approved)d个之前已经提交的申请. "
 
-#: .\course\enrollment.py:534
 msgid "Create Participation Preapprovals"
 msgstr "用户加入课程预批准"
 
-#: .\course\enrollment.py:745
 msgid "Enter queries, one per line."
 msgstr "输入查询语句，每行一条."
 
-#: .\course\enrollment.py:746
 msgid "Allowed"
 msgstr "允许的语法"
 
-#: .\course\enrollment.py:762
 msgid "Queries"
 msgstr "查询"
 
-#: .\course\enrollment.py:765
 msgid "Apply tag"
 msgstr "应用tag"
 
-#: .\course\enrollment.py:766
 msgid "Remove tag"
 msgstr "移除tag"
 
-#: .\course\enrollment.py:767 .\course\enrollment.py:913
 msgid "Drop"
 msgstr "删除"
 
-#: .\course\enrollment.py:769
 msgid "Operation"
 msgstr "操作"
 
-#: .\course\enrollment.py:771
 msgid "Tag"
 msgstr "标签"
 
-#: .\course\enrollment.py:772
 msgid "Tag to apply or remove"
 msgstr "准备应用或移除的tag"
 
-#: .\course\enrollment.py:779 .\course\exam.py:190
 msgid "List"
 msgstr "列表"
 
-#: .\course\enrollment.py:781
 msgid "Apply operation"
 msgstr "应用操作"
 
-#: .\course\enrollment.py:789
 msgid "may not query participations"
 msgstr "不允许查询课程参与"
 
-#: .\course\enrollment.py:814
 #, python-format
 msgid "Error in line %(lineno)d: %(error_type)s: %(error)s"
 msgstr "在第%(lineno)d行出现错误: %(error_type)s: %(error)s"
 
-#: .\course\enrollment.py:897
 msgid ""
 "Permissions for this participant in addition to those granted by their role"
 msgstr "为该课程参与赋予的、在其角色之外的权限"
 
-#: .\course\enrollment.py:907
 msgid "Approve"
 msgstr "批准"
 
-#: .\course\enrollment.py:910
 msgid "Deny"
 msgstr "拒绝"
 
-#: .\course\enrollment.py:993
+msgid "Changes saved."
+msgstr "变更保存成功. "
+
 msgid "Successfully denied."
 msgstr "成功地拒绝了."
 
-#: .\course\enrollment.py:1000
 msgid "Successfully dropped."
 msgstr "成功地剔除了."
 
-#: .\course\enrollment.py:1009
 msgid "Edit Participation"
 msgstr "编辑课程参与"
 
-#: .\course\exam.py:97
 msgid "Select participant for whom ticket is to be issued."
 msgstr "选择发放ticket的的用户. "
 
-#: .\course\exam.py:113 .\course\exam.py:284 .\course\models.py:1745
-#: .\course\models.py:1761
 msgid "Exam"
 msgstr "测验"
 
-#: .\course\exam.py:116
+msgid "Start validity"
+msgstr "开始的有效性"
+
+msgid "End validity"
+msgstr "结束的有效性"
+
+msgid "Restrict to facility"
+msgstr "限制允许访问的设施"
+
+msgid "If not blank, the exam ticket may only be used in the given facility"
+msgstr "如果非空，测验的ticket只能在给定的教学设施内使用"
+
 msgid "Revoke prior exam tickets for this user"
 msgstr "撤回之前发给这个用户的测验ticket"
 
-#: .\course\exam.py:123
 msgid "Issue ticket"
 msgstr "发布ticket"
 
-#: .\course\exam.py:144
 msgid "User is not enrolled in course."
 msgstr "用户未参与本课程. "
 
-#: .\course\exam.py:168
 #, python-format
 msgid ""
 "Ticket issued for <b>%(participation)s</b>. The ticket code is <b>%"
@@ -1325,20 +1029,16 @@ msgstr ""
 "发给用户<b>%(participation)s</b>的ticket. 该ticket的代码是<b>%(ticket_code)"
 "s</b>."
 
-#: .\course\exam.py:180
 msgid "Issue Exam Ticket"
 msgstr "发布测验ticket"
 
-#: .\course\exam.py:197 .\course\exam.py:242
 msgctxt "ticket code required to login exam"
 msgid "Code"
 msgstr "登录代码"
 
-#: .\course\exam.py:220
 msgid "Instructions for {{ ticket.exam.description }}"
 msgstr "对 {{ ticket.exam.description }} 的使用说明"
 
-#: .\course\exam.py:224
 msgid ""
 "These are personalized instructions for {{ ticket.participation.user."
 "get_full_name }}."
@@ -1346,44 +1046,35 @@ msgstr ""
 "以下是对 {{ ticket.participation.user.get_full_name }}user.first_name }} 个人"
 "的说明."
 
-#: .\course\exam.py:227
 msgid ""
 "If this is not you, please let the proctor know so that you can get the "
 "correct set of instructions."
 msgstr "如果这不是你，请与监考人联系，以保证你得到正确的使用说明."
 
-#: .\course\exam.py:230
 msgid ""
 "Please sit down at your workstation and open a browser at this location:"
 msgstr "请坐在您的电脑前，然后用web浏览器打开网站:"
 
-#: .\course\exam.py:233
 msgid "Exam URL"
 msgstr "测验URL"
 
-#: .\course\exam.py:235
 msgid ""
 "You should see boxes prompting for your user name and a one-time check-in "
 "code."
 msgstr "您应该会看到一个弹出盒子要求您输入用户名和一次性的登入代码."
 
-#: .\course\exam.py:238
 msgid "Enter the following information"
 msgstr "请输入以下信息"
 
-#: .\course\exam.py:240 .\course\exam.py:451
 msgid "User name"
 msgstr "用户名"
 
-#: .\course\exam.py:244
 msgid "You have one hour to complete the exam."
 msgstr "您有一个小时时间完成这个测验. "
 
-#: .\course\exam.py:246
 msgid "Good luck!"
 msgstr "祝你好运! "
 
-#: .\course\exam.py:265
 msgid ""
 "Enter <a href=\"http://documen.tician.de/relate/content.html#relate-markup"
 "\">RELATE markup</a> containing Django template statements to render your "
@@ -1400,68 +1091,65 @@ msgstr ""
 "<tt>{{ tkt.code }}</tt>, <tt>{{ tkt.exam.description }}</tt>, 以及<tt>"
 "{{ checkin_uri }}</tt> 作为占位符. 请参考以上的例子."
 
-#: .\course\exam.py:286
 msgid "Ticket Format"
 msgstr "ticket格式"
 
-#: .\course\exam.py:292
 msgid "Revoke prior exam tickets"
 msgstr "撤回之前的测验ticket"
 
-#: .\course\exam.py:299
 msgid "Issue tickets"
 msgstr "发布ticket"
 
-#: .\course\exam.py:305
 msgid "may not batch-issue tickets"
 msgstr "不允许批量发布测验ticket"
 
-#: .\course\exam.py:358 .\course\exam.py:366
 msgid "Template rendering failed"
 msgstr "模板渲染失败"
 
-#: .\course\exam.py:372
 #, python-format
 msgid "%d tickets issued."
 msgstr "%d个ticket已发布. "
 
-#: .\course\exam.py:380
 msgid "Batch-Issue Exam Tickets"
 msgstr "批量发布测验ticket"
 
-#: .\course\exam.py:402
 msgid "User name or ticket code not recognized."
 msgstr "用户名或ticket代码无法识别. "
 
-#: .\course\exam.py:408
 msgid "Ticket is not in usable state. (Has it been revoked?)"
 msgstr "ticket不处于可用状态. (它有没有被激活？)"
 
-#: .\course\exam.py:418
 msgid "Ticket has exceeded its validity period."
 msgstr "ticket已经超过了验证时间. "
 
-#: .\course\exam.py:421
+msgid "Exam is not active."
+msgstr "测验没有激活. "
+
 msgid "Exam has not started yet."
 msgstr "测验还没有开始. "
 
-#: .\course\exam.py:426
 msgid "Exam has ended."
 msgstr "测验已经结束. "
 
-#: .\course\exam.py:428
-msgid "Ticket is valid."
-msgstr "ticket无效."
+#, python-format
+msgid "Exam ticket requires presence in facility '%s'."
+msgstr "测验ticket要求在教学设施'%s'中使用"
 
-#: .\course\exam.py:454
+msgid "Exam ticket is not yet valid."
+msgstr "测验ticket还未生效."
+
+msgid "Exam ticket has expired."
+msgstr "测验ticket已经过期. "
+
+msgid "Ticket is valid."
+msgstr "ticket有效."
+
 msgid "This is typically your full email address."
 msgstr "通常是你的完整电子邮件. "
 
-#: .\course\exam.py:455
 msgid "Code"
 msgstr "代码"
 
-#: .\course\exam.py:457
 msgid ""
 "This is not your password, but a code that was given to you by a staff "
 "member. If you do not have one, please follow the link above to log in."
@@ -1469,15 +1157,12 @@ msgstr ""
 "它不是你的密码，而是课务人员发给你的一个代码. 如果你没有这个代码，请跟随以上"
 "的链接来完成登录."
 
-#: .\course\exam.py:465
 msgid "Check in"
 msgstr "登入"
 
-#: .\course\exam.py:523 .\course\templates\course\exam-check-in.html:7
 msgid "Check in for Exam"
 msgstr "登入测验"
 
-#: .\course\exam.py:615
 msgid ""
 "Access to flows in an exams-only facility is only granted if the flow is "
 "locked down. To do so, add 'lock_down_as_exam_session' to your flow's access "
@@ -1486,119 +1171,97 @@ msgstr ""
 "只有当flow被锁定时，用户才能访问\"仅用于测验\"的设施. 如需锁定，在你的flow的"
 "access permissions里添加'lock_down_as_exam_session'."
 
-#: .\course\exam.py:642
 msgid "Error while processing exam lockdown: flow session not found."
 msgstr "处理测验锁定时出错：未找到该flow session. "
 
-#: .\course\exam.py:703
 msgid ""
 "Your RELATE session is currently locked down to this exam flow. Navigating "
-"to other parts of RELATE is not currently allowed. To abandon this exam, log "
+"to other parts of RELATE is not currently allowed. To exit this exam, log "
 "out."
 msgstr ""
-"你的session目前被锁定到这个测验flow. 目前不允许浏览本网站的其它内容. 要舍弃这"
+"你的session目前被锁定到这个测验flow. 目前不允许浏览本网站的其它内容. 要离开这"
 "个测验，请登出."
 
-#: .\course\flow.py:323
 msgid "cannot grade ungraded answer"
 msgstr "无法为未评分的回答进行评分"
 
-#: .\course\flow.py:900
 msgid "Can't end a session that's already ended"
 msgstr "无法结束已经结束的session"
 
-#: .\course\flow.py:948
 msgid "Can't expire a session that's not in progress"
 msgstr "无法将已经过期的session设为过期"
 
-#: .\course\flow.py:950
 msgid "Can't expire an anonymous flow session"
 msgstr "无法将匿名的session设为过期"
 
-#: .\course\flow.py:1001
 #, python-format
 msgid "invalid expiration mode '%(mode)s' on flow session ID %(session_id)d"
 msgstr "flow session ID %(session_id)d的过期模式\"%(mode)s\"为无效"
 
 #. Translators: grade flow: calculating grade.
-#: .\course\flow.py:1033
 #, python-format
 msgid "Counted at %(percent).1f%% of %(point).1f points"
 msgstr "计分为满分%(point).1f中的%(percent).1f%%"
 
-#: .\course\flow.py:1103
 msgid "Cannot reopen a session that's already in progress"
 msgstr "无法重新打开为正在进行中的session"
 
-#: .\course\flow.py:1106
 msgid "Cannot reopen anonymous sessions"
 msgstr "无法重新打开匿名的session"
 
-#: .\course\flow.py:1114
 #, python-format
 msgid ""
 "Session reopened at %(now)s, previous completion time was '%(complete_time)"
 "s'."
 msgstr "在%(now)s重新打开Session, 上一次结束的时间为'%(complete_time)s. "
 
-#: .\course\flow.py:1209
 #, python-format
 msgid "Session regraded at %(time)s."
 msgstr "Session在%(time)s已重新评分. "
 
-#: .\course\flow.py:1229
 msgid "cannot recalculate grade on in-progress session"
 msgstr "无法为正在进行中的session重新计算得分"
 
-#: .\course\flow.py:1238
 #, python-format
 msgid "Session grade recomputed at %(time)s."
 msgstr "本session的评分在%(time)s已重新计算. "
 
-#: .\course\flow.py:1401
 msgid "new session not allowed"
 msgstr "不允许开始新的session"
 
-#: .\course\flow.py:1508
 msgid "may not view other people's sessions"
 msgstr "不允许查看其他人的session"
 
-#: .\course\flow.py:1584
 msgid "Save answer"
 msgstr "保存回答"
 
-#: .\course\flow.py:1591
 msgid "Submit answer for feedback"
 msgstr "提交以取得反馈"
 
-#: .\course\flow.py:1596
 msgid "Submit final answer"
 msgstr "提交最终回答"
 
-#: .\course\flow.py:1605
 msgid "Save answer and move on"
 msgstr "保存回答并继续"
 
-#: .\course\flow.py:1613
 msgid "Save answer and finish"
 msgstr "保存回答并结束"
 
-#: .\course\flow.py:1657
 msgid ""
 "No in-progress session record found for this flow. Redirected to flow start "
 "page."
 msgstr "本flow没有找到正在进行中的session, 跳转到flow的起始页面. "
 
-#: .\course\flow.py:1712
 msgid "not allowed to view flow"
 msgstr "不允许查看该flow"
 
-#: .\course\flow.py:1770
 #, python-format
-msgid "Viewing prior submission dated %(date)s."
-msgstr "正在查看提交日期%(date)s之前的状态."
+msgid "Viewing prior submission dated %(date)s. "
+msgstr "正在查看本页面于%(date)s的提交."
 
-#: .\course\flow.py:1824
+msgid "Go back"
+msgstr "返回"
+
 msgid ""
 "The page data stored in the database was found to be invalid for the page as "
 "given in the course content. Likely the course content was changed in an "
@@ -1606,100 +1269,82 @@ msgid ""
 "changing the question ID. The precise error encountered was the following: "
 msgstr ""
 
-#: .\course\flow.py:1869
 msgid ""
 "Changes to this session are being prevented because this session yields a "
 "permanent grade, but you have not completed your enrollment process in this "
 "course."
 msgstr ""
 
-#: .\course\flow.py:1974
 msgid "could not find which button was pressed"
 msgstr "无法找到哪一个按钮被按下"
 
-#: .\course\flow.py:2001
 msgid "Answer submission not allowed."
 msgstr "不允许提交回答. "
 
-#: .\course\flow.py:2010
 msgid "Already have final answer."
 msgstr "已经有最终的回答. "
 
-#: .\course\flow.py:2032
 msgid "Answer saved."
 msgstr "回答保存成功. "
 
-#: .\course\flow.py:2121
 msgid "Failed to submit answer."
 msgstr "回答提交失败."
 
-#: .\course\flow.py:2239
 #, python-format
 msgid "Interaction request from %(username)s"
 msgstr "来自%(username)s的答疑请求"
 
-#: .\course\flow.py:2261
 msgid "Email sent, and notice that you will also receive a copy of the email."
 msgstr "邮件已发送，注意该邮件的一个副本也发送到了您的邮箱."
 
-#: .\course\flow.py:2273
 msgid "Send interaction email"
 msgstr "发送flow页面的答疑邮件"
 
-#: .\course\flow.py:2283
-msgid "Your question about the page. "
-msgstr "您对于该页面的疑问. "
+#, python-format
+msgid "Your questions about page %s . "
+msgstr "您对于页面 %s 的疑问. "
 
-#: .\course\flow.py:2285
+msgid ""
+"Notice that <strong>only</strong> questions for that page will be answered."
+msgstr "注意，<strong>只有</strong>针对该页面的问题才会被回答."
+
 msgid "Message"
 msgstr "内容"
 
-#: .\course\flow.py:2288
 msgid "Send Email"
 msgstr "发送邮件"
 
-#: .\course\flow.py:2296
 msgid "At least 20 characters are required for submission."
 msgstr "至少要输入20个以上的字符才允许提交."
 
-#: .\course\flow.py:2307 .\course\flow.py:2340
 msgid "only POST allowed"
 msgstr "只允许POST操作"
 
-#: .\course\flow.py:2313 .\course\flow.py:2348
 msgid "may only change your own flow sessions"
 msgstr "只允许更改您自己的flow session"
 
-#: .\course\flow.py:2317
 msgid "invalid bookmark state"
 msgstr "无效的收藏状态"
 
-#: .\course\flow.py:2351
 msgid "may only change in-progress flow sessions"
 msgstr "只能更改正在进行中的session"
 
-#: .\course\flow.py:2356
 msgid "invalid expiration mode"
 msgstr "无效的过期模式"
 
-#: .\course\flow.py:2444
 msgid "odd POST parameters"
 msgstr "怪异的POST参数设置"
 
-#: .\course\flow.py:2448
 msgid "Cannot end a session that's already ended"
 msgstr "无法结束已经结束的session"
 
-#: .\course\flow.py:2452
 msgid "not permitted to end session"
 msgstr "不允许结束session"
 
-#: .\course\flow.py:2491
 #, python-format
 msgid "Submission by %(participation)s"
 msgstr "提交，来自%(participation)s"
 
-#: .\course\flow.py:2579
 msgid ""
 "If non-empty, limit the regrading to sessions started under this access "
 "rules tag."
@@ -1707,35 +1352,27 @@ msgstr ""
 "如果access rules的设置不为空, 则对该规则下开始的session进行重新评分受到该规则"
 "的限制. "
 
-#: .\course\flow.py:2581 .\course\models.py:753
 msgid "Access rules tag"
 msgstr "访问规则tag"
 
-#: .\course\flow.py:2585
 msgid "Regrade in-progress and not-in-progress sessions"
 msgstr "为进行中的和不在进行中的session重新评分"
 
-#: .\course\flow.py:2587
 msgid "Regrade in-progress sessions only"
 msgstr "仅为进行中的session重新评分"
 
-#: .\course\flow.py:2589
 msgid "Regrade not-in-progress sessions only"
 msgstr "仅为非进行中的session重新评分"
 
-#: .\course\flow.py:2591
 msgid "Regraded session in progress"
 msgstr "为正在进行的session重新评分"
 
-#: .\course\flow.py:2594 .\course\templates\course\gradebook-single.html:272
 msgid "Regrade"
 msgstr "重新评分"
 
-#: .\course\flow.py:2601 .\course\grades.py:440
 msgid "may not batch-regrade flows"
 msgstr "不允许为flow批量重新评分"
 
-#: .\course\flow.py:2631
 msgid ""
 "This regrading process is only intended for flows that donot show up in the "
 "grade book. If you would like to regradefor-credit flows, use the "
@@ -1744,98 +1381,87 @@ msgstr ""
 "这个重新评分的过程旨在针对不在“成绩册”中显示的的flow. 如果您想对计入成绩的"
 "flow重新评分, 请使用“成绩册”中的对应功能. "
 
-#: .\course\flow.py:2636
 msgid "Regrade not-for-credit Flow Sessions"
 msgstr "为不计入成绩的flow session重新评分"
 
-#: .\course\grades.py:75
+msgid "Re-allow changes"
+msgstr "重新允许修改回答"
+
+msgid "Cancel"
+msgstr "放弃"
+
+msgid "Flow page changes reallowed. "
+msgstr "flow页面的回答变更已重新批准"
+
+msgid "Re-allow Changes to Flow Page"
+msgstr "重新允许修改flow页面的回答"
+
 msgid "must be enrolled to view grades"
 msgstr "必须加入课程才能查看成绩"
 
-#: .\course\grades.py:86 .\course\grades.py:813
 msgid "may not view other people's grades"
 msgstr "不允许查看其他人的成绩"
 
-#: .\course\grades.py:159 .\course\grades.py:179 .\course\grades.py:276
-#: .\course\grades.py:395 .\course\grading.py:84
 msgid "may not view grade book"
 msgstr "不允许查看成绩册"
 
-#: .\course\grades.py:298
 msgid "may not batch-export grades"
 msgstr "不允许批量导出成绩"
 
-#: .\course\grades.py:357
 msgid "Session tag"
 msgstr ""
 
-#: .\course\grades.py:361
 msgid ""
 "Only act on in-progress sessions that are past their access rule's due date "
 "(applies to 'expire')"
 msgstr "只能对进行中且已经超过了截止日期的session执行该操作(针对'过期'选项)"
 
 #. Translators: see help text above.
-#: .\course\grades.py:364
 msgid "Past due only"
 msgstr "仅针对已过期的session"
 
-#: .\course\grades.py:367
 msgid "Impose deadline (Expire sessions)"
 msgstr "实施截止(使session过期)"
 
-#: .\course\grades.py:371
 msgid "Regrade ended sessions"
 msgstr "为已经结束的session重新评分"
 
-#: .\course\grades.py:373
 msgid "Recalculate grades of ended sessions"
 msgstr "重新计算已结束session的评分"
 
-#: .\course\grades.py:400
 msgid "opportunity from wrong course"
 msgstr "机会与课程不符"
 
-#: .\course\grades.py:430
 msgid "may not impose deadline"
 msgstr "不允许实施截止"
 
-#: .\course\grades.py:435
 msgid "may not batch-end flows"
 msgstr "不允许批量实施截止flow"
 
-#: .\course\grades.py:446
 msgid "may not batch-recalculate grades"
 msgstr "不允许批量重新计算评分"
 
-#: .\course\grades.py:449 .\course\views.py:584 .\course\views.py:611
-#: .\course\views.py:658
 msgid "invalid operation"
 msgstr "无效操作"
 
-#: .\course\grades.py:653 .\course\views.py:949
 msgid "Set access rules tag"
 msgstr "设置访问规则tag"
 
-#: .\course\grades.py:657 .\course\models.py:1181 .\course\models.py:1235
-#: .\course\models.py:1438 .\course\views.py:1031
+msgid "Re-allow changes to already-submitted questions"
+msgstr "重新批准修改已回答问题的回答"
+
 msgid "Comment"
 msgstr "评论"
 
-#: .\course\grades.py:661 .\course\templates\course\flow-page.html:100
-#: .\course\templates\course\gradebook-single.html:292
 msgid "Reopen"
 msgstr "重新打开"
 
-#: .\course\grades.py:670
 msgid "may not reopen session"
 msgstr "不允许重新打开session"
 
-#: .\course\grades.py:690
 msgid "Cannot reopen a session that's already in progress."
 msgstr "无法重新打开为正在进行中的session"
 
-#: .\course\grades.py:704
 #, python-format
 msgid ""
 "Session reopened at %(now)s by %(user)s, previous completion time was '%"
@@ -1844,343 +1470,262 @@ msgstr ""
 "由%(user)s在%(now)s重新打开了本Session, 上一次结束的时间为%(completion_time)"
 "s: %(comment)s. "
 
-#: .\course\grades.py:728
 msgid "Reopen session"
 msgstr "重新打开session"
 
-#: .\course\grades.py:794
 msgid "participation does not match course"
 msgstr "参与和课程不符"
 
-#: .\course\grades.py:804
 msgid "This grade is not shown in the grade book."
 msgstr "该评分不会显示在成绩册中. "
 
-#: .\course\grades.py:807
 msgid "This grade is not shown in the student grade book."
 msgstr "该评分不会显示在学生的成绩册中. "
 
-#: .\course\grades.py:819
 msgid "grade has not been released"
 msgstr "评分还未发布"
 
-#: .\course\grades.py:832
 msgid "unknown action"
 msgstr "未知的操作"
 
-#: .\course\grades.py:855
 msgid "Session deadline imposed."
 msgstr "该session已实施. "
 
-#: .\course\grades.py:865
 msgid "Session ended."
 msgstr "该session已结束. "
 
-#: .\course\grades.py:874
 msgid "Session regraded."
 msgstr "该session已重新评分. "
 
-#: .\course\grades.py:883
 msgid "Session grade recalculated."
 msgstr "该session评分已重新计算. "
 
-#: .\course\grades.py:886
 msgid "invalid session operation"
 msgstr "无效的session操作"
 
-#: .\course\grades.py:892 .\course\grades.py:1287 .\course\utils.py:972
-#: .\course\versioning.py:603
 msgctxt "Starting of Error message"
 msgid "Error"
 msgstr "错误"
 
-#: .\course\grades.py:1003
 #, python-format
 msgid ""
 "Click to <a href='%s' target='_blank'>create</a> a new grading opportunity. "
 "Reload this form when done."
 msgstr "点击 <a href='%s' target='_blank'>创建</a> 一个新的得分机会. "
 
-#: .\course\grades.py:1007
 msgctxt "Field name in Import grades form"
 msgid "Grading opportunity"
 msgstr "得分机会"
 
-#: .\course\grades.py:1012 .\course\models.py:1429
 msgid "Attempt ID"
 msgstr ""
 
-#: .\course\grades.py:1014
 msgid "File"
 msgstr "文件"
 
-#: .\course\grades.py:1018
 msgid "CSV with Header"
 msgstr "带有表头的CSV文件"
 
-#: .\course\grades.py:1021
 msgid "Format"
 msgstr "格式"
 
-#: .\course\grades.py:1025
 msgid "Email or NetID"
 msgstr "Email或用户名"
 
-#: .\course\grades.py:1028
 msgid "User attribute"
 msgstr "用户属性"
 
 #. Translators: the following strings are for the format
 #. informatioin for a CSV file to be imported.
-#: .\course\grades.py:1033
 msgid ""
 "1-based column index for the user attribute selected above to locate student "
 "record"
 msgstr "上面所选用户属性的所在的列，从1起"
 
-#: .\course\grades.py:1036
 msgid "User attribute column"
 msgstr "用户属性列"
 
-#: .\course\grades.py:1038
 msgid "1-based column index for the (numerical) grade"
 msgstr "学生的(数值)得分所在列，从1起"
 
-#: .\course\grades.py:1040
 msgid "Points column"
 msgstr "得分列"
 
-#: .\course\grades.py:1042
 msgid "1-based column index for further (textual) feedback"
 msgstr "对学生作业的进一步（文字）反馈所在列，从1起"
 
-#: .\course\grades.py:1044
 msgid "Feedback column"
 msgstr "反馈所在列"
 
 #. Translators: "Max point" refers to full credit in points.
-#: .\course\grades.py:1048 .\course\models.py:1025 .\course\models.py:1435
 msgid "Max points"
 msgstr "满分分值"
 
-#: .\course\grades.py:1050 .\course\sandbox.py:77
-#: .\course\templates\course\course-base.html:161
-#: .\course\templates\course\grade-import-preview.html:15
-#: .\course\versioning.py:523
 msgid "Preview"
 msgstr "预览"
 
-#: .\course\grades.py:1051
 msgid "Import"
 msgstr "导入"
 
 #. Translators: use institutional_id_string to find user
 #. (participant).
-#: .\course\grades.py:1095
 #, python-format
 msgid "no participant found with institutional ID '%(inst_id_string)s'"
 msgstr "用学号\"%(inst_id_string)s\"找不到学员"
 
-#: .\course\grades.py:1100
 #, python-format
 msgid ""
 "more than one participant found with institutional ID '%(inst_id_string)s'"
 msgstr "用学号\"%(inst_id_string)s\"找到超过1个学员"
 
 #. Translators: use id_string to find user (participant).
-#: .\course\grades.py:1135
 #, python-format
 msgid "no participant found for '%(id_string)s'"
 msgstr "用\"%(id_string)s\"找不到参与者"
 
-#: .\course\grades.py:1139
 #, python-format
 msgid "more than one participant found for '%(id_string)s'"
 msgstr "用\"%(id_string)s\"找到超过1个参与者"
 
-#: .\course\grades.py:1184
 #, python-format
 msgid "Unknown user attribute '%(attr_type)s'"
 msgstr "未知的用户属性 '%(attr_type)s'"
 
-#: .\course\grades.py:1221 .\course\templates\course\grade-flow-page.html:44
 msgid "points"
 msgstr "得分"
 
-#: .\course\grades.py:1223
 msgid "max_points"
 msgstr "满分分值"
 
-#: .\course\grades.py:1225
 msgid "comment"
 msgstr "反馈"
 
-#: .\course\grades.py:1231
 msgid "updated"
 msgstr "已更新"
 
-#: .\course\grades.py:1252
 msgid "may not batch-import grades"
 msgstr "不允许批量导入成绩"
 
-#: .\course\grades.py:1295
 #, python-format
 msgid "%(total)d grades found, %(unchaged)d unchanged."
 msgstr "找到%(total)d个评分, %(unchaged)d个未更改. "
 
-#: .\course\grades.py:1309
 #, python-format
 msgid "%d grades imported."
 msgstr "%d个评分导入成功. "
 
-#: .\course\grades.py:1322
 msgid "Import Grade Data"
 msgstr "导入成绩数据"
 
-#: .\course\grades.py:1343
 msgid "Least recent attempt"
 msgstr "最早的一次尝试"
 
-#: .\course\grades.py:1344
 msgid "Most recent attempt"
 msgstr "最近的一次尝试"
 
-#: .\course\grades.py:1345
 msgid "All attempts"
 msgstr "所有尝试"
 
-#: .\course\grades.py:1347
 msgid "Attempts to include."
 msgstr "将包含的尝试"
 
-#: .\course\grades.py:1349
 msgid "Every submission to the page counts as an attempt."
 msgstr "将该page的所有提交视为一次尝试."
 
-#: .\course\grades.py:1353
 msgid "Only download sessions tagged with this rules tag."
 msgstr "只下载使用该rules tag的session."
 
-#: .\course\grades.py:1354
 msgid "Restrict to rules tag"
 msgstr "限制的rules tag"
 
-#: .\course\grades.py:1358
 msgid "Only download submissions from non-in-progress sessions"
 msgstr "只下载非进行状态的session的提交"
 
-#: .\course\grades.py:1360
 msgid "Non-in-progress only"
 msgstr "只选择非进行中的"
 
-#: .\course\grades.py:1364
 msgid "Include provided feedback as text file in zip"
 msgstr "将反馈作为文本文件包含在zip文件中"
 
-#: .\course\grades.py:1365
 msgid "Include feedback"
 msgstr "包含反馈"
 
-#: .\course\grades.py:1367
 msgid "Additional File"
 msgstr "额外的文件"
 
-#: .\course\grades.py:1369
 msgid ""
 "If given, the uploaded file will be included in the zip archive. If the "
 "produced archive is to be used for plagiarism detection, then this may be "
 "used to include the reference solution."
 msgstr ""
 
-#: .\course\grades.py:1377
 msgid "Download"
 msgstr "下载"
 
-#: .\course\grades.py:1383 .\course\im.py:159
 msgid "may not batch-download submissions"
 msgstr "下载批量下载提交的内容"
 
-#: .\course\grades.py:1396 .\course\grades.py:1400
 msgid "ALL"
 msgstr "所有"
 
-#: .\course\grades.py:1535
 msgid "Download All Submissions in Zip file"
 msgstr "以Zip文件下载所有提交"
 
-#: .\course\grades.py:1603
 msgid "Edit Grading Opportunity"
 msgstr "编辑得分机会"
 
-#: .\course\grading.py:90
 msgid "Flow session not part of specified course"
 msgstr "该flow session不是选定课程的内容"
 
-#: .\course\grading.py:93
 msgid "Cannot grade anonymous session"
 msgstr "无法为匿名session评分"
 
-#: .\course\grading.py:208
 msgid "may not assign grades"
 msgstr "不允许评分"
 
-#: .\course\grading.py:262 .\course\templates\course\flow-page.html:180
 msgid "Submit"
 msgstr "提交"
 
-#: .\course\grading.py:362
 msgid "may not view grader stats"
 msgstr "不允许查看得分统计"
 
-#: .\course\im.py:54
 msgctxt "Instant message"
 msgid "Message"
 msgstr "即时消息"
 
 #. Translators: literals in this file are about
 #. the instant messaging function.
-#: .\course\im.py:66
 msgctxt "Send instant messages"
 msgid "Send"
 msgstr "发送"
 
-#: .\course\im.py:144
 msgid "unable to connect"
 msgstr "无法连接"
 
-#: .\course\im.py:166
 msgid "Instant messaging is not enabled for this course."
 msgstr "本课程未设置即时通信功能. "
 
-#: .\course\im.py:172
 msgid "Recipient is <span class='label label-success'>Online</span>."
 msgstr "接收者为<span class='label label-success'>在线状态</span>. "
 
-#: .\course\im.py:175
 msgid "Recipient is <span class='label label-danger'>Offline</span>."
 msgstr "接收者为<span class='label label-danger'>离线状态</span>. "
 
-#: .\course\im.py:189
 msgid "no recipient XMPP ID"
 msgstr "无接收者XMPP ID"
 
-#: .\course\im.py:192
 msgid "no XMPP password"
 msgstr "无XMPP密码"
 
-#: .\course\im.py:204
 msgid "An error occurred while sending the message. Sorry."
 msgstr "对不起, 发送信息时出现了错误. "
 
-#: .\course\im.py:208
 msgid "Message sent."
 msgstr "信息已发送. "
 
-#: .\course\im.py:217 .\course\templates\course\course-base.html:34
 msgid "Send instant message"
 msgstr "发送即时信息"
 
-#: .\course\models.py:76
 msgid ""
 "A course identifier. Alphanumeric with dashes, no spaces. This is visible in "
 "URLs and determines the location on your file system where the course's git "
@@ -2191,69 +1736,53 @@ msgstr ""
 "课程的git仓库放在您的系统中的哪个文件夹下. 课程一经创建，除非把该课程在服务器"
 "上的git做相应的更改, 否则<em>不允许</em>修改这个值."
 
-#: .\course\models.py:81
 msgid "Course identifier"
 msgstr "课程ID"
 
-#: .\course\models.py:87 .\course\models.py:1336
 msgid "Identifier may only contain letters, numbers, and hypens ('-')."
 msgstr "Identifier只能包含英文字母, 数字, 和中划线（即减号\"-\"). "
 
-#: .\course\models.py:94
 msgid "Course name"
 msgstr "课程名称"
 
-#: .\course\models.py:95
 msgid "A human-readable name for the course. (e.g. 'Numerical Methods')"
 msgstr "一个易于理解的课程名(例如：'数值方法')."
 
-#: .\course\models.py:100
 msgid "Course number"
 msgstr "课程编号"
 
-#: .\course\models.py:101
 msgid "A human-readable course number/ID for the course (e.g. 'CS123')"
 msgstr "一个易于理解的课程编号或ID(例如：'CS123')"
 
-#: .\course\models.py:106
 msgid "Time Period"
 msgstr "时间范围描述"
 
-#: .\course\models.py:107
 msgid ""
 "A human-readable description of the time period for the course (e.g. 'Fall "
 "2014')"
 msgstr "一个易于理解的课程周期的表述(例如：'2014年秋季') "
 
-#: .\course\models.py:111
 msgid "Start date"
 msgstr "开始日期"
 
-#: .\course\models.py:114
 msgid "End date"
 msgstr "结束日期"
 
-#: .\course\models.py:119
 msgid "Is the course only accessible to course staff?"
 msgstr "本课程是否只有课务人员才能访问？"
 
-#: .\course\models.py:120
 msgid "Only visible to course staff"
 msgstr "本课程是否只对课务人员显示？"
 
-#: .\course\models.py:123
 msgid "Should the course be listed on the main page?"
 msgstr "该课程是否放在主页上？"
 
-#: .\course\models.py:124
 msgid "Listed on main page"
 msgstr "在主页上显示"
 
-#: .\course\models.py:127
 msgid "Accepts enrollment"
 msgstr "允许申请加入课程"
 
-#: .\course\models.py:130
 msgid ""
 "A Git URL from which to pull course updates. If you're just starting out, "
 "enter <tt>git://github.com/inducer/relate-sample</tt> to get some sample "
@@ -2262,11 +1791,9 @@ msgstr ""
 "一个git网址, 课程的内容更新将从它pull取得. 如果您刚刚开始使用, 可输入"
 "<tt>git://github.com/inducer/relate-sample</tt>来取得一些示范内容. "
 
-#: .\course\models.py:134
 msgid "git source"
 msgstr "Git源地址"
 
-#: .\course\models.py:136
 msgid ""
 "An SSH private key to use for Git authentication. Not needed for the sample "
 "URL above.You may use <a href='/generate-ssh-key'>this tool</a> to generate "
@@ -2276,11 +1803,9 @@ msgstr ""
 "课程不需设置. 你可以使用<a href='/generate-ssh-key'>这个工具</a>来生成一对密"
 "钥. "
 
-#: .\course\models.py:140
 msgid "SSH private key"
 msgstr "SSH私有密钥"
 
-#: .\course\models.py:143
 msgid ""
 "Subdirectory <em>within</em> the git repository to use as course root "
 "directory. Not required, and usually blank. Use only if your course content "
@@ -2290,78 +1815,62 @@ msgstr ""
 "一个<em>在git仓库目录下</em>的子目录. 一般情况下不要求填写, 除非你的课程内容"
 "放在git仓库的某个子目录下. 填写时不要包含斜杠."
 
-#: .\course\models.py:148
 msgid "Course root in repository"
 msgstr "在仓库下的课程根目录"
 
-#: .\course\models.py:152
 msgid ""
 "Name of a YAML file in the git repository that contains the root course "
 "descriptor."
 msgstr "git仓库中包含了课程内容描述的YAML文件的文件名, 默认为course.yml. "
 
-#: .\course\models.py:154
 msgid "Course file"
 msgstr "课程主页文件"
 
-#: .\course\models.py:157
 msgid ""
 "Name of a YAML file in the git repository that contains calendar information."
 msgstr "git仓库中包含了课程教学日历信息的YAML文件的文件名, 默认为events.yml. "
 
-#: .\course\models.py:159 .\course\validation.py:1302
 msgid "Events file"
 msgstr "events(事件)文件"
 
-#: .\course\models.py:163
 msgid "If set, each enrolling student must be individually approved."
 msgstr "如果选择该项, 每个加入课程的请求必须单独批准. "
 
-#: .\course\models.py:165
 msgid "Enrollment approval required"
 msgstr "申请加入课程必须得到批准"
 
-#: .\course\models.py:168
 msgid ""
 "If set, students cannot get participation preapproval using institutional ID "
 "if the institutional ID they provided is not verified."
 msgstr "如果勾选，学号未经验证的学员将无法通过学号获得参加课程的预先批准."
 
-#: .\course\models.py:172
 msgid "Prevent preapproval by institutional ID if not verified?"
 msgstr "对未经验证的学号，不给予预先批准？"
 
-#: .\course\models.py:176
 msgid ""
 "Enrollee's email addresses must end in the specified suffix, such as "
 "'@illinois.edu'."
 msgstr "申请加入课程的电子邮件必须使用特定的后缀, 比如\"@qq.com\". "
 
-#: .\course\models.py:178
 msgid "Enrollment required email suffix"
 msgstr "申请加入课程的电子邮件地址必须有的后缀"
 
 #. Translators: replace "RELATE" with the brand name of your
 #. website if necessary.
-#: .\course\models.py:183
 msgid ""
 "This email address will be used in the 'From' line of automated emails sent "
 "by RELATE."
 msgstr "这个电子邮件地址用于RELATE自动发送电子邮件时的发件人. "
 
-#: .\course\models.py:185
 msgid "From email"
 msgstr "发送邮件的邮箱"
 
-#: .\course\models.py:188
 msgid "This email address will receive notifications about the course."
 msgstr "这个电子邮件地址用于接收关于本课程的事务通知. "
 
-#: .\course\models.py:190
 msgid "Notify email"
 msgstr "接收通知的邮箱"
 
-#: .\course\models.py:195
 msgid ""
 "(Required only if the instant message feature is desired.) The Jabber/XMPP "
 "ID (JID) the course will use to sign in to an XMPP server."
@@ -2369,106 +1878,72 @@ msgstr ""
 "本课程将使用的Jabber/XMPP ID (JID), 用于登录某个XMPP服务器(仅在需要使用即时通"
 "信功能时才需填写). "
 
-#: .\course\models.py:198
 msgid "Course xmpp ID"
 msgstr "课程的xmpp ID"
 
-#: .\course\models.py:200
 msgid ""
 "(Required only if the instant message feature is desired.) The password to "
 "go with the JID above."
 msgstr "以上设置的JID的密码(仅在需要使用即时通信功能时才需填写). "
 
-#: .\course\models.py:202
 msgid "Course xmpp password"
 msgstr "课程的XMPP密码"
 
-#: .\course\models.py:205
 msgid ""
 "(Required only if the instant message feature is desired.) The JID to which "
 "instant messages will be sent."
 msgstr "接收即时信息的JID(仅在需要使用即时通信功能时才需填写). "
 
-#: .\course\models.py:207
 msgid "Recipient xmpp ID"
 msgstr "接收者的xmpp ID"
 
-#: .\course\models.py:213 .\course\models.py:728
 msgid "Active git commit SHA"
 msgstr "已启用的git commit SHA"
 
-#: .\course\models.py:220
 msgid "Courses"
 msgstr "课程"
 
-#: .\course\models.py:261
 msgid "Kind of event"
 msgstr "event的类型(kind)"
 
 #. Translators: ordinal of event of the same kind
-#: .\course\models.py:264
 msgid "Ordinal of event"
 msgstr "event的序号(ordinal)"
 
-#: .\course\models.py:266 .\course\models.py:684 .\course\models.py:732
-#: .\course\templates\course\flow-start.html:23
 msgid "Start time"
 msgstr "开始时间"
 
-#: .\course\models.py:268 .\course\models.py:686
 msgid "End time"
 msgstr "结束时间"
 
-#. Translators: for when the due time is "All day", how the webpage
-#. of a event is displayed.
-#: .\course\models.py:272
-msgid ""
-"Only affects the rendering in the class calendar, in that a start time is "
-"not shown"
-msgstr "只会影响课程日历页面的渲染, 其效果为开始时间(start time)不显示. "
-
-#: .\course\models.py:274
 msgid "All day"
 msgstr "全天"
 
-#: .\course\models.py:277
-msgid "Shown in calendar"
-msgstr "在日历中显示"
-
-#: .\course\models.py:280
 msgid "Event"
 msgstr "事件(event)"
 
-#: .\course\models.py:281
 msgid "Events"
 msgstr "事件(event)"
 
 #. Translators: name format of ParticipationTag
-#: .\course\models.py:304
 msgid "Format is lower-case-with-hyphens. Do not use spaces."
 msgstr "格式：只允许小写字母与减号, 不允许有空格."
 
-#: .\course\models.py:306
 msgid "Name of participation tag"
 msgstr "课程参与tag的名称"
 
-#: .\course\models.py:308
 msgid "Shown to pariticpant"
 msgstr "向学员显示"
 
-#: .\course\models.py:319 .\course\models.py:362
 msgid "Name contains invalid characters."
 msgstr "名称包含无效字符. "
 
-#: .\course\models.py:328
 msgid "Participation tag"
 msgstr "课程参与标签"
 
-#: .\course\models.py:329
 msgid "Participation tags"
 msgstr "课程参与标签"
 
-#: .\course\models.py:339
 msgid ""
 "A symbolic name for this role, used in course code. "
 "lower_case_with_underscores, no spaces. May be any string. The name "
@@ -2477,269 +1952,196 @@ msgstr ""
 "一个该角色的符号化的名称，用于课程代码中. 小写字母和下划线，允许是任何字符"
 "串. 'unenrolled'被专用于未加入课程的人."
 
-#: .\course\models.py:343
 msgid "Role identifier"
 msgstr "角色identifier"
 
-#: .\course\models.py:345
 msgid "A human-readable description of this role."
 msgstr "一个易于理解的关于该角色的描述. "
 
-#: .\course\models.py:346
 msgid "Role name"
 msgstr "角色名称"
 
-#: .\course\models.py:349
 msgid "Is default role for new participants"
 msgstr "是否是新参与者的默认角色？"
 
-#: .\course\models.py:351
 msgid "Is default role for unenrolled users"
 msgstr "是否是未参与的默认角色？"
 
-#: .\course\models.py:365
 #, python-format
 msgid "%(identifier)s in %(course)s"
 msgstr "课程%(course)s中的%(identifier)s"
 
-#: .\course\models.py:373
 msgid "Participation role"
 msgstr "参与该课程的角色"
 
-#: .\course\models.py:374
 msgid "Participation roles"
 msgstr "参与该课程的角色"
 
-#: .\course\models.py:382 .\course\models.py:1206
 msgid "Permission"
 msgstr "权限"
 
-#: .\course\models.py:385
 msgid "Argument"
 msgstr "参数"
 
-#: .\course\models.py:402
-#: .\course\templates\course\participation-table.html:11
 msgid "Role"
 msgstr "在课程中的角色"
 
-#: .\course\models.py:406
 msgid "Participation role permission"
 msgstr "参与课程的权限"
 
-#: .\course\models.py:407
 msgid "Participation role permissions"
 msgstr "参与课程的权限"
 
-#: .\course\models.py:413 .\course\templates\course\gradebook-by-opp.html:117
-#: .\course\templates\course\gradebook-participant.html:26
-#: .\course\templates\course\gradebook.html:17
-#: .\course\templates\course\participation-table.html:5
 msgid "User ID"
 msgstr "用户ID"
 
-#: .\course\models.py:419
 msgid "Enroll time"
 msgstr "加入课程时间"
 
-#: .\course\models.py:421 .\course\models.py:519
 msgid "Role (unused)"
 msgstr ""
 
-#: .\course\models.py:427
 msgid "Participation status"
 msgstr "课程参与状态"
 
-#: .\course\models.py:432
 msgid "Multiplier for time available on time-limited flows"
 msgstr "对于有时限的flow，其可用时间的乘数."
 
-#: .\course\models.py:434
 msgid "Time factor"
 msgstr "时间乘数"
 
-#: .\course\models.py:438
 msgid "Preview git commit SHA"
 msgstr "预览的git commit SHA"
 
-#: .\course\models.py:441
-#: .\course\templates\course\gradebook-participant.html:38
-#: .\course\templates\course\participation-table.html:13
 msgid "Tags"
 msgstr "标签"
 
-#: .\course\models.py:443 .\course\page\base.py:868
 msgid "Notes"
 msgstr "注释"
 
 #. Translators: displayed format of Participation: some user in some
 #. course as some role
-#: .\course\models.py:448
 #, python-format
 msgid "%(user)s in %(course)s as %(role)s"
 msgstr "%(user)s在课程%(course)s中(作为%(role)s)"
 
-#: .\course\models.py:459 .\course\models.py:502 .\course\models.py:719
-#: .\course\models.py:1149 .\course\models.py:1225 .\course\models.py:1416
-#: .\course\models.py:1705 .\course\models.py:1764
-#: .\course\templates\course\course-base.html:139
 msgid "Participation"
 msgstr "课程参与"
 
-#: .\course\models.py:460
 msgid "Participations"
 msgstr "课程参与"
 
-#: .\course\models.py:506
 msgid "Participation permission"
 msgstr "参与该课程的角色"
 
-#: .\course\models.py:507
 msgid "Participation permissionss"
 msgstr "用户加入课程预批准"
 
-#: .\course\models.py:524 .\course\models.py:1167 .\course\models.py:1230
-#: .\course\models.py:1444 .\course\models.py:1767
 msgid "Creator"
 msgstr "创建者"
 
-#: .\course\models.py:526 .\course\models.py:1169 .\course\models.py:1232
-#: .\course\models.py:1357 .\course\models.py:1769
 msgid "Creation time"
 msgstr "创建时间"
 
 #. Translators: somebody's email in some course in Participation
 #. Preapproval
-#: .\course\models.py:532
 #, python-format
 msgid "Email %(email)s in %(course)s"
 msgstr "电子邮件%(email)s在课程%(course)s中的预批准"
 
 #. Translators: somebody's Institutional ID in some course in
 #. Participation Preapproval
-#: .\course\models.py:537
 #, python-format
 msgid "Institutional ID %(inst_id)s in %(course)s"
 msgstr "学号%(inst_id)s在课程%(course)s中的预批准"
 
-#: .\course\models.py:544
 msgid "Participation preapproval"
 msgstr "用户加入课程预批准"
 
-#: .\course\models.py:545
 msgid "Participation preapprovals"
 msgstr "用户加入课程预批准"
 
-#: .\course\models.py:641
 msgid "Instructor"
 msgstr "任课老师"
 
-#: .\course\models.py:645
 msgid "Teaching Assistant"
 msgstr "助教"
 
-#: .\course\models.py:649
 msgid "Student"
 msgstr "学员"
 
-#: .\course\models.py:654
 msgid "Unenrolled"
 msgstr "未加入"
 
-#: .\course\models.py:688
 msgid "Cancelled"
 msgstr "已取消的"
 
-#: .\course\models.py:691
 msgid "Instant flow request"
 msgstr "即时flow"
 
-#: .\course\models.py:692 .\course\templates\course\course-base.html:149
 msgid "Instant flow requests"
 msgstr "即时flow"
 
-#: .\course\models.py:695
 #, python-format
 msgid "Instant flow request for %(flow_id)s in %(course)s at %(start_time)s"
 msgstr "%(start_time)s时，对课程%(course)s中%(flow_id)s的即时flow请求"
 
-#: .\course\models.py:734
 msgid "Completion time"
 msgstr "完成时间"
 
-#: .\course\models.py:736
 msgid "Page count"
 msgstr "page数"
 
-#: .\course\models.py:744
 msgid "Page data at course revision"
 msgstr "课程内容修订的页面数据(page data)"
 
-#: .\course\models.py:746
 msgid "Page set-up data is up-to date for this revision of the course material"
 msgstr "对于当前课程材料的修订版本，页面的设置数据是最新的."
 
-#: .\course\models.py:750
 msgid "In progress"
 msgstr "进行中的"
 
-#: .\course\models.py:757 .\course\templates\course\gradebook-single.html:166
 msgid "Expiration mode"
 msgstr "过期模式"
 
-#: .\course\models.py:766 .\course\models.py:1433
-#: .\course\templates\course\gradebook-single.html:226
 msgid "Points"
 msgstr "分值"
 
-#: .\course\models.py:769
 msgid "Max point"
 msgstr "满分"
 
-#: .\course\models.py:771
 msgid "Result comment"
 msgstr "结果评论"
 
-#: .\course\models.py:774 .\course\models.py:838 .\course\models.py:901
-#: .\course\models.py:1450 .\course\templates\course\grade-flow-page.html:96
 msgid "Flow session"
 msgstr ""
 
-#: .\course\models.py:775 .\course\templates\course\gradebook-single.html:131
 msgid "Flow sessions"
 msgstr ""
 
-#: .\course\models.py:780
 #, python-format
 msgid "anonymous session %(session_id)d on '%(flow_id)s'"
 msgstr "flow \"%(flow_id)s\"中匿名的session %(session_id)d "
 
-#: .\course\models.py:784
 #, python-format
 msgid "%(user)s's session %(session_id)d on '%(flow_id)s'"
 msgstr "%(user)s在flow \"%(flow_id)s\"的session %(session_id)d"
 
-#: .\course\models.py:840
 msgid "Ordinal"
 msgstr "序号"
 
-#: .\course\models.py:845
 msgid "Page type as indicated in course content"
 msgstr "课程内容中所确定的Page类型"
 
-#: .\course\models.py:849
 msgid "Group ID"
 msgstr "分组ID"
 
-#: .\course\models.py:856
 msgid "Data"
 msgstr "数据"
 
-#: .\course\models.py:858
 msgid "Page Title"
 msgstr "Page标题"
 
-#: .\course\models.py:861
 msgid ""
 "A user-facing 'marking' feature to allow participants to easily return to "
 "pages that still need their attention."
@@ -2747,15 +2149,12 @@ msgstr ""
 "一个用户可以看到的\"书签\"特性，让参与者可以很容易回到那些需要引起他们关注的"
 "page."
 
-#: .\course\models.py:863
 msgid "Bookmarked"
 msgstr "已加书签"
 
-#: .\course\models.py:866 .\course\models.py:867
 msgid "Flow page data"
 msgstr "flow page的数据"
 
-#: .\course\models.py:871
 #, python-format
 msgid ""
 "Data for page '%(group_id)s/%(page_id)s' (ordinal %(ordinal)s) in %"
@@ -2763,23 +2162,18 @@ msgid ""
 msgstr ""
 "%(flow_session)s中page %(group_id)s/%(page_id)s(序号为%(ordinal)s)的数据"
 
-#: .\course\models.py:904 .\course\models.py:1078
 msgid "Page data"
 msgstr "page数据"
 
-#: .\course\models.py:906
 msgid "Visit time"
 msgstr "访问时间"
 
-#: .\course\models.py:908
 msgid "Remote address"
 msgstr "来访的ip地址"
 
-#: .\course\models.py:915
 msgid "Impersonated by"
 msgstr "由谁模拟"
 
-#: .\course\models.py:918
 msgid ""
 "Synthetic flow page visits are generated for unvisited pages once a flow is "
 "finished. This is needed since grade information is attached to a visit, and "
@@ -2788,264 +2182,202 @@ msgstr ""
 "如果一个flow结束，则对未访问的page生成\"合成\"的flow page访问。这是因为评分信"
 "息是附在访问中的，它需要有一个去处。"
 
-#: .\course\models.py:922
 msgid "Is synthetic"
 msgstr "是否合成"
 
 #. Translators: "Answer" is a Noun.
-#: .\course\models.py:928 .\course\page\code.py:66 .\course\page\text.py:101
 msgid "Answer"
 msgstr "回答"
 
 #. Translators: determine whether the answer is a final,
 #. submitted answer fit for grading.
-#: .\course\models.py:941
 msgid "Is submitted answer"
 msgstr "是否为用于评分的回答"
 
 #. Translators: flow page visit
-#: .\course\models.py:946
 #, python-format
 msgid "'%(group_id)s/%(page_id)s' in '%(session)s' on %(time)s"
 msgstr "在%(time)s时, \"%(session)s'中的'%(group_id)s/%(page_id)s\""
 
 #. Translators: flow page visit: if an answer is
 #. provided by user then append the string.
-#: .\course\models.py:956
 msgid " (with answer)"
 msgstr "（和回答）"
 
-#: .\course\models.py:964
 msgid "Flow page visit"
 msgstr "flow page访问"
 
-#: .\course\models.py:965
 msgid "Flow page visits"
 msgstr "flow page访问"
 
-#: .\course\models.py:1000
 msgid "Visit"
 msgstr "访问"
 
-#: .\course\models.py:1004 .\course\templates\course\gradebook-single.html:228
 msgid "Grader"
 msgstr "评分者"
 
-#: .\course\models.py:1006 .\course\models.py:1446
 msgid "Grade time"
 msgstr "评分时间"
 
-#: .\course\models.py:1010
 msgid "Graded at git commit SHA"
 msgstr "评分，于git commit SHA"
 
-#: .\course\models.py:1015
 msgid "Grade data"
 msgstr "评分数据"
 
 #. Translators: max point in grade
-#: .\course\models.py:1023
 msgid "Point value of this question when receiving full credit."
 msgstr "该问题取得满分时取得的分值. "
 
 #. Translators: correctness in grade
-#: .\course\models.py:1028
 msgid ""
 "Real number between zero and one (inclusively) indicating the degree of "
 "correctness of the answer."
 msgstr "属于范围[0,1]的数值, 用于表示回答的正确性. "
 
-#: .\course\models.py:1030
 msgid "Correctness"
 msgstr "正确性"
 
 #. Translators: "Feedback" stands for the feedback of answers.
-#: .\course\models.py:1041
-#: .\course\templates\course\grade-import-preview.html:21
 msgid "Feedback"
 msgstr "反馈"
 
-#: .\course\models.py:1056
 msgid "Flow page visit grade"
 msgstr "flow page 访问的得分"
 
-#: .\course\models.py:1057
 msgid "Flow page visit grades"
 msgstr "flow page 访问的得分"
 
 #. Translators: return the information of the grade of a user
 #. by percentage.
-#: .\course\models.py:1067
 #, python-format
 msgid "grade of %(visit)s: %(percentage)s"
 msgstr "%(visit)s的得分(百分比): %(percentage)s"
 
-#: .\course\models.py:1080
-#: .\course\templates\course\grade-import-preview.html:20
-#: .\course\templates\course\gradebook-participant.html:53
-#: .\course\templates\course\gradebook-single.html:72
 msgid "Grade"
 msgstr "得分"
 
-#: .\course\models.py:1085
 msgid "Bulk feedback"
 msgstr "批量反馈"
 
-#: .\course\models.py:1123
 msgid "stipulations must be a dictionary"
 msgstr "规定必须为一个字典型数据，即：(项目, 项目的值)"
 
-#: .\course\models.py:1128
 msgid "unrecognized keys in stipulations"
 msgstr "无法识别的规定"
 
-#: .\course\models.py:1134
 msgid "credit_percent must be a float"
 msgstr "credit_percent必须是一个浮点数"
 
-#: .\course\models.py:1140
 msgid "'allowed_session_count' must be a non-negative integer"
 msgstr "allowed_session_count必须是一个非负的整数"
 
-#: .\course\models.py:1153 .\course\models.py:1227
 msgid "Expiration"
 msgstr "过期"
 
 #. Translators: help text for stipulations in FlowAccessException
 #. (deprecated)
-#: .\course\models.py:1158
 msgid ""
 "A dictionary of the same things that can be added to a flow access rule, "
 "such as allowed_session_count or credit_percent. If not specified here, "
 "values will default to the stipulations in the course content."
 msgstr ""
 
-#: .\course\models.py:1164
 msgid "Stipulations"
 msgstr "条款"
 
 #. Translators: deprecated
-#: .\course\models.py:1174
 msgid ""
 "Check if a flow started under this exception rule set should stay under this "
 "rule set until it is expired."
 msgstr ""
 
 #. Translators: deprecated
-#: .\course\models.py:1178
 msgid "Is sticky"
 msgstr ""
 
 #. Translators: flow access exception in admin (deprecated)
-#: .\course\models.py:1186
 #, python-format
 msgid "Access exception for '%(user)s' to '%(flow_id)s' in '%(course)s'"
 msgstr "对用户\"%(user)s'破例访问课程'%(course)s'中的'%(flow_id)s\". "
 
-#: .\course\models.py:1203
 msgid "Exception"
 msgstr "破例处理"
 
 #. Translators: FlowAccessExceptionEntry (deprecated)
-#: .\course\models.py:1210
 msgid "Flow access exception entries"
 msgstr "破例访问flow的条目"
 
-#: .\course\models.py:1239
 msgid "Kind"
 msgstr "类型"
 
-#: .\course\models.py:1241
 msgid "Rule"
 msgstr "规则"
 
-#: .\course\models.py:1244
 msgctxt "Is the flow rule exception activated?"
 msgid "Active"
 msgstr "生效"
 
 #. Translators: For FlowRuleException
-#: .\course\models.py:1249
 #, python-format
 msgid "%(kind)s exception for '%(user)s' to '%(flow_id)s'in '%(course)s'"
 msgstr "在课程%(course)s的%(flow_id)s中, 给予%(user)s破例的类型%(kind)s"
 
-#: .\course\models.py:1265
 msgid "grading rules may not expire"
 msgstr "评分规则不会过期"
 
-#: .\course\models.py:1308
 msgid "invalid rule kind: "
 msgstr "无效的规则类型："
 
-#: .\course\models.py:1312
 msgid "invalid existing_session_rules: "
 msgstr "无效的existing_session_rules:"
 
-#: .\course\models.py:1315
 msgid "Flow rule exception"
 msgstr "flow rule破例"
 
-#: .\course\models.py:1316
 msgid "Flow rule exceptions"
 msgstr "flow rule破例"
 
 #. Translators: format of identifier for GradingOpportunity
-#: .\course\models.py:1329
 msgid "A symbolic name for this grade. lower_case_with_underscores, no spaces."
 msgstr "这个评分的字符化名称, 只允许小写字母和下划线, 不允许有空格. "
 
-#: .\course\models.py:1331
 msgid "Grading opportunity ID"
 msgstr "得分机会ID"
 
 #. Translators: name for GradingOpportunity
-#: .\course\models.py:1341
 msgid "A human-readable identifier for the grade."
 msgstr "一个易于理解的标识, 用于评分. "
 
-#: .\course\models.py:1342
 msgid "Grading opportunity name"
 msgstr "得分机会的名称"
 
-#: .\course\models.py:1344
 msgid "Flow identifier that this grading opportunity is linked to, if any"
 msgstr "这个评分机会所属的Flow ID, 如果有评分机会的话"
 
 #. Translators: strategy on how the grading of mutiple sessioins
 #. are aggregated.
-#: .\course\models.py:1352 .\course\templates\course\gradebook-by-opp.html:31
-#: .\course\templates\course\gradebook-opp-list.html:27
-#: .\course\templates\course\gradebook-single.html:119
 msgid "Aggregation strategy"
 msgstr "多session评分累积策略"
 
-#: .\course\models.py:1355 .\course\models.py:1441
-#: .\course\templates\course\gradebook-opp-list.html:28 .\course\views.py:1007
 msgid "Due time"
 msgstr "截止时间"
 
-#: .\course\models.py:1360
 msgid "Shown in grade book"
 msgstr "在成绩册中显示"
 
-#: .\course\models.py:1362
 msgid "Shown in student grade book"
 msgstr "在学生的成绩册中显示"
 
-#: .\course\models.py:1364
 msgid "Result shown in student grade book"
 msgstr "在学生的成绩册中显示评分结果"
 
-#: .\course\models.py:1367
 msgid "Scores for individual pages are shown in the participants' grade book"
 msgstr "在学员的'成绩册'中将显示的每个独立page的得分"
 
-#: .\course\models.py:1370
 msgid "Hide superseded grade history before"
 msgstr "隐藏之前被覆盖的评分历史"
 
-#: .\course\models.py:1373
 msgid ""
 "Grade changes dated before this date that are superseded by later grade "
 "changes will not be shown to participants. This can help avoid discussions "
@@ -3056,29 +2388,22 @@ msgstr ""
 "助于避免因对预先发布的评分进行修改而引起异议. 可以设为空. 在这种情况下，所有"
 "的评分历史都将显示给学员."
 
-#: .\course\models.py:1382 .\course\models.py:1413
 msgid "Grading opportunity"
 msgstr "得分机会"
 
-#: .\course\models.py:1383
 msgid "Grading opportunities"
 msgstr "得分机会"
 
 #. Translators: For GradingOpportunity
-#: .\course\models.py:1390
 #, python-format
 msgid "%(opportunity_name)s (%(opportunity_id)s) in %(course)s"
 msgstr "课程%(course)s中的评分机会%(opportunity_name)s (%(opportunity_id)s) "
 
 #. Translators: something like 'status'.
-#: .\course\models.py:1421 .\course\templates\course\flow-start.html:24
-#: .\course\templates\course\gradebook-single.html:139
-#: .\course\templates\course\task-monitor.html:17
 msgid "State"
 msgstr "状态"
 
 #. Translators: help text of "attempt_id" in GradeChange class
-#: .\course\models.py:1426
 msgid ""
 "Grade changes are grouped by their 'attempt ID' where later grades with the "
 "same attempt ID supersede earlier ones."
@@ -3086,199 +2411,184 @@ msgstr ""
 "评分的变化是根据它们的\"attempt ID'进行分组, 在相同的'attempt ID\"下, 后面的"
 "评分将覆盖前面的评分. "
 
-#: .\course\models.py:1453
 msgid "Grade change"
 msgstr "评分变更"
 
-#: .\course\models.py:1454
 msgid "Grade changes"
 msgstr "评分变更"
 
 #. Translators: information for GradeChange
-#: .\course\models.py:1459
 #, python-format
 msgid "%(participation)s %(state)s on %(opportunityname)s"
 msgstr "%(opportunityname)s中, %(participation)s %(state)s"
 
-#: .\course\models.py:1471
 msgid "Participation and opportunity must live in the same course"
 msgstr "参与(Participation)和评分机会(opportunity)必须属于同一门课程"
 
-#: .\course\models.py:1535
 msgid "cannot accept grade once opportunity has been marked 'unavailable'"
 msgstr "一旦评分机会被标记为\"无效(unavailable)\", 将无法进行评分"
 
-#: .\course\models.py:1539
 msgid "cannot accept grade once opportunity has been marked 'exempt'"
 msgstr "一旦评分机会被标记为\"剔除(exempt)\", 将无法进行评分"
 
-#: .\course\models.py:1582
 #, python-format
 msgid "invalid grade change state '%s'"
 msgstr "无效的评分改变状态 \"%s\""
 
-#: .\course\models.py:1628
 #, python-format
 msgid "invalid grade aggregation strategy '%s'"
 msgstr "无效的多session评分累积策略 \"%s\""
 
 #. Translators: display the name of a flow
-#: .\course\models.py:1678
 #, python-format
 msgid "Flow: %(flow_desc_title)s"
 msgstr ""
 
-#: .\course\models.py:1707
 msgid "Text"
 msgstr "文字"
 
-#: .\course\models.py:1709 .\course\templates\course\gradebook-single.html:69
-#: .\course\views.py:368
 msgid "Time"
 msgstr "时间"
 
-#: .\course\models.py:1712
 msgid "Instant message"
 msgstr "即时信息"
 
-#: .\course\models.py:1713
 msgid "Instant messages"
 msgstr "即时信息"
 
-#: .\course\models.py:1731
 msgid "Description"
 msgstr "描述"
 
-#: .\course\models.py:1736
-msgid "Currently active"
-msgstr "当前生效"
+msgid "Active"
+msgstr "正常"
 
-#: .\course\models.py:1739
+msgid "Currently active, i.e. may be used to log in via an exam ticket"
+msgstr "当前正常，即，可以使用测验ticket登陆"
+
+msgid "Listed"
+msgstr "列出"
+
+msgid "Shown in the list of current exams"
+msgstr "在当前的测验列表中显示"
+
 msgid "No exams before"
 msgstr "之前未有测验"
 
-#: .\course\models.py:1742
 msgid "No exams after"
 msgstr "之后未有测验"
 
-#: .\course\models.py:1746 .\course\templates\course\course-base.html:81
-#: .\relate\templates\base.html:84
 msgid "Exams"
 msgstr "测验"
 
-#: .\course\models.py:1750
 #, python-format
 msgid "Exam  %(description)s in %(course)s"
 msgstr "课程%(course)s中的测验: %(description)s"
 
-#: .\course\models.py:1771
+msgid "Usage time"
+msgstr "使用时间"
+
 msgid "Date and time of first usage of ticket"
 msgstr "第一次使用ticket的日期时间"
 
-#: .\course\models.py:1776
 msgid "Exam ticket state"
 msgstr "测验ticket的状态"
 
-#: .\course\models.py:1781
+msgid "End valid period"
+msgstr "终止有效时段"
+
+msgid ""
+"If not blank, date and time at which this exam ticket starts being valid/"
+"usable"
+msgstr "如果非空，表示该测验ticket开始 有效/可使用的日期和时间"
+
+msgid ""
+"If not blank, date and time at which this exam ticket stops being valid/"
+"usable"
+msgstr "如果非空，表示该测验ticket结束 有效/可使用的日期和时间"
+
+msgid "If not blank, this exam ticket may only be used in the given facility"
+msgstr "如果非空，该测验ticket只能在指定的教学设施内使用."
+
 msgid "Exam ticket"
 msgstr "测验ticket"
 
-#: .\course\models.py:1782
 msgid "Exam tickets"
 msgstr "测验ticket"
 
-#: .\course\models.py:1785
 msgid "Can issue exam tickets to student"
 msgstr "可以向学生发布测验ticket"
 
-#: .\course\models.py:1789
 #, python-format
 msgid "Exam  ticket for %(participation)s in %(exam)s"
 msgstr "%(participation)s在%(exam)s中的测验ticket."
 
-#: .\course\models.py:1802
 msgid "Participation and exam must live in the same course"
 msgstr "参与者和测验必须属于同一门课程"
 
-#: .\course\page\base.py:145
 msgid "No information on correctness of answer."
 msgstr "未知回答正确与否. "
 
-#: .\course\page\base.py:147
 msgid "Your answer is not correct."
 msgstr "您的回答不正确. "
 
-#: .\course\page\base.py:149
 msgid "Your answer is correct."
 msgstr "您的回答是正确的. "
 
-#: .\course\page\base.py:153
 msgid "Your answer is correct and earned bonus points."
 msgstr "您的回答是正确的, 并且得到了加分. "
 
-#: .\course\page\base.py:159
 msgid "Your answer is mostly correct."
 msgstr "您的回答基本正确. "
 
-#: .\course\page\base.py:165
 msgid "Your answer is somewhat correct. "
 msgstr "您的回答在一定程度上正确. "
 
-#: .\course\page\base.py:196
 msgid "Invalid correctness value"
 msgstr "无效的正确性数值"
 
-#: .\course\page\base.py:343
 msgid "Not passing page_desc to PageBase.__init__ is deprecated"
-msgstr ""
+msgstr "不将page_desc传递到PageBase.__init__的作法已经淘汰了."
 
-#: .\course\page\base.py:400
 #, python-format
 msgid "%s is using the make_page_data compatiblity hook, which is deprecated."
 msgstr ""
 
-#: .\course\page\base.py:511
 #, python-format
 msgid "%s is using the post_form compatiblity hook, which is deprecated."
 msgstr ""
 
-#: .\course\page\base.py:592
 #, python-format
 msgid ""
 "%s is using the update_grade_data_from_grading_form compatiblity hook, which "
 "is deprecated."
 msgstr ""
 
-#: .\course\page\base.py:705
 #, python-format
 msgid ""
 "PageBaseWithTitle subclass '%s' does not implement markdown_body_for_title()"
 msgstr "PageBaseWithTitle的子类\"%s\"未使用markdown_body_for_title()方法"
 
-#: .\course\page\base.py:716
 msgid "no title found in body or title attribute"
 msgstr "没有在body中找到title，也没有title属性"
 
-#: .\course\page\base.py:815
+msgid "Attribute 'value' should be removed when 'is_optional_page' is True."
+msgstr "当'is_optional_page'为True时，不允许设定'value'."
+
 msgid "Grade assigned, in percent"
 msgstr "给予的评分（百分比）"
 
-#: .\course\page\base.py:821
 msgid "Grade percent"
 msgstr "得分的百分比"
 
-#: .\course\page\base.py:827
 #, python-format
 msgid ""
 "Grade assigned, as points out of %.1f. Fill out either this or 'grade "
 "percent'."
 msgstr "给予的评分, %.1f分中取得的分值. 填入此项或者\"得分的百分比\". "
 
-#: .\course\page\base.py:835
 msgid "Grade points"
 msgstr "得分的分值"
 
-#: .\course\page\base.py:841
 msgid ""
 "Feedback to be shown to student, using <a href='http://documen.tician.de/"
 "relate/content.html#relate-markup'>RELATE-flavored Markdown</a>"
@@ -3286,29 +2596,23 @@ msgstr ""
 "将反馈给学生的信息, 建议使用<a href='http://documen.tician.de/relate/content."
 "html#relate-markup'>RELATE方式的Markdown模式</a>. "
 
-#: .\course\page\base.py:845
 msgid "Feedback text"
 msgstr "反馈文字"
 
-#: .\course\page\base.py:848
 msgid ""
 "Checking this box and submitting the form will notify the participant with a "
 "generic message containing the feedback text"
 msgstr "勾选此项并提交这个表单, 将会向参与者发送一个包含了反馈信息的邮件. "
 
-#: .\course\page\base.py:851
 msgid "Notify"
 msgstr "发送通知"
 
-#: .\course\page\base.py:854
 msgid "Allow recipient to reply to this email?"
 msgstr "允许收件人回复本邮件？"
 
-#: .\course\page\base.py:855
 msgid "May reply email to me"
 msgstr "允许回复给我"
 
-#: .\course\page\base.py:858
 msgid ""
 "Whether the grade and feedback are to be shown to student. (If you would "
 "like to release all grades at once, do not use this. Instead, use the 'shown "
@@ -3318,85 +2622,66 @@ msgstr ""
 "是否允许学生看到分数和反馈. (如果您希望把所有成绩一次性发布，请不要使用这一"
 "项, 而是在成绩册管理中的'得分机会'中勾选'展示给学生')."
 
-#: .\course\page\base.py:863
 msgid "Released"
 msgstr "已发布"
 
-#: .\course\page\base.py:866
 msgid "Internal notes, not shown to student"
 msgstr "内部注释, 学生不可见"
 
-#: .\course\page\base.py:871
 msgid ""
 "Checking this box and submitting the form will notify the instructor with a "
 "generic message containing the notes"
 msgstr "勾选此项并提交这个表单, 将会向任课老师发送一个包含以上注释信息的邮件. "
 
-#: .\course\page\base.py:874
 msgid "Notify instructor"
 msgstr "通知任课老师"
 
-#: .\course\page\base.py:887 .\course\page\base.py:901
 msgid "Grade (percent) and Grade (points) disagree"
 msgstr "百分比评分与分值评分不一致"
 
-#: .\course\page\base.py:980
 msgid "New notification"
 msgstr "一条新的通知"
 
-#: .\course\page\base.py:1016
 #, python-format
 msgid "Grading notes from %(ta)s"
 msgstr "来自%(ta)s的评分注释"
 
-#: .\course\page\base.py:1060 .\course\page\choice.py:280
-#: .\course\page\choice.py:477 .\course\page\code.py:579
-#: .\course\page\code.py:991 .\course\page\inline.py:851
-#: .\course\page\text.py:930
 msgid "No answer provided."
 msgstr "未回答. "
 
-#: .\course\page\base.py:1082
 msgid "The following feedback was provided"
 msgstr "有以下的反馈信息"
 
 #. Translators: "choice" in Choice Answer Form in a single-choice question.
-#: .\course\page\choice.py:47
 msgid "Choice"
 msgstr "选项"
 
 #. Translators: "Choice" in Choice Answer Form in a multiple
 #. choice question in which multiple answers can be chosen.
-#: .\course\page\choice.py:58
 msgid "Select all that apply:"
 msgstr "选择所有适合的选项:"
 
-#: .\course\page\choice.py:98 .\course\page\choice.py:608
-#: .\course\page\inline.py:418
 #, python-format
 msgid "choice %(idx)d: unable to convert to string"
 msgstr "选项%(idx)d: 无法转换为字符串"
 
-#: .\course\page\choice.py:161
 msgid ""
 "existing choice permutation not suitable for number of choices in question"
 msgstr "当前的选项排列方式不适用于该问题中选项选择数量的统计"
 
-#: .\course\page\choice.py:234
 #, python-format
 msgid "one or more correct answer(s) expected, %(n_correct)d found"
 msgstr "需要至少1个参考答案，找到%(n_correct)d个"
 
-#: .\course\page\choice.py:244
 msgid "ChoiceQuestion does not allow any choices marked 'disregard'"
 msgstr ""
 
-#: .\course\page\choice.py:294 .\course\page\inline.py:818
-#: .\course\page\text.py:952
+msgid "ChoiceQuestion does not allow any choices marked 'always_correct'"
+msgstr "ChoiceQuestion不允许任何选项被设为'always_correct'"
+
 msgid "A correct answer is"
 msgstr "参考答案"
 
-#: .\course\page\choice.py:395
 msgid ""
 "'allow_partial_credit' or 'allow_partial_credit_subset_only' may not be "
 "specifiedat the same time as 'credit_mode'"
@@ -3404,7 +2689,6 @@ msgstr ""
 "不能将'allow_partial_credit' 和 'allow_partial_credit_subset_only'同时设"
 "为'credit_mode'."
 
-#: .\course\page\choice.py:415
 msgid ""
 "'allow_partial_credit' and 'allow_partial_credit_subset_only' are not "
 "allowed to coexist when both attribute are 'True'"
@@ -3412,12 +2696,10 @@ msgstr ""
 "当'allow_partial_credit' 和 'allow_partial_credit_subset_only'都设"
 "为'True'时，两者不能共存."
 
-#: .\course\page\choice.py:429
 #, python-format
 msgid "unrecognized credit_mode '%(credit_mode)s'"
 msgstr "无法识别的credit_mode '%(credit_mode)s'"
 
-#: .\course\page\choice.py:434
 msgid ""
 "'credit_mode' will be required on multi-select choice questions in a future "
 "version. set 'credit_mode: {}' to match current behavior."
@@ -3425,11 +2707,12 @@ msgstr ""
 "在将来的版本中, 多项选择问题必须设置'credit_mode'. 目前，可用'credit_mode："
 "{}'的方式来对应当前的行为. "
 
-#: .\course\page\choice.py:534
 msgid "The correct answer is"
 msgstr "正确答案"
 
-#: .\course\page\code.py:478
+msgid "Additional acceptable options are"
+msgstr "其它允许的选项是"
+
 msgid ""
 "code question does not explicitly allow multiple submission. Either add "
 "access_rules/add_permssions/change_answer or add 'single_submission: True' "
@@ -3437,15 +2720,12 @@ msgid ""
 "you're at it, consider adding access_rules/add_permssions/see_correctness."
 msgstr ""
 
-#: .\course\page\code.py:666
 msgid "code question execution failed"
 msgstr "编程问题执行失败"
 
-#: .\course\page\code.py:671
 msgid "<unknown flow>"
 msgstr "<未知的flow>"
 
-#: .\course\page\code.py:686
 msgid ""
 "Both the grading code and the attempt to notify course staff about the issue "
 "failed. Please contact the course or site staff and inform them of this "
@@ -3454,17 +2734,14 @@ msgstr ""
 "您的代码错误和通知课务人员的邮件尝试都未成功. 请与课程或网站人员联系, 并告知"
 "全部的错误信息。"
 
-#: .\course\page\code.py:694
 msgid ""
 "Sending an email to the course staff about the following failure failed with "
 "the following error message:"
 msgstr "向课管人员发送电子邮件，在邮件中包含以下的代码失败信息."
 
-#: .\course\page\code.py:700
 msgid "The original failure message follows:"
 msgstr "错误发生时的信息如下:"
 
-#: .\course\page\code.py:728
 msgid ""
 "The grading code failed. Sorry about that. The staff has been informed, and "
 "if this problem is due to an issue with the grading code, it will be fixed "
@@ -3475,7 +2752,6 @@ msgstr ""
 "分的代码引起的，我们将尽快地修复它。同时，你也可以在下面查看traceback信息，它"
 "将帮助你了解是哪里出了问题。"
 
-#: .\course\page\code.py:740
 #, python-format
 msgid ""
 "Your code took too long to execute. The problem specifies that your code may "
@@ -3484,66 +2760,79 @@ msgstr ""
 "你的代码执行时间过长。本问题要求你的代码执行时间不得超过%s秒钟，由于超时所以"
 "代码执行被取消。"
 
-#: .\course\page\code.py:752
 msgid "Your code failed to compile. An error message is below."
 msgstr "你的代码编译失败，下面是错误信息。"
 
-#: .\course\page\code.py:760
 msgid "Your code failed with an exception. A traceback is below."
 msgstr "你的代码执行失败且有一条exception，下面是traceback信息。"
 
-#: .\course\page\code.py:771
 msgid "Here is some feedback on your code"
 msgstr "这是关于你的代码的反馈"
 
-#: .\course\page\code.py:780
 msgid "This is the exception traceback"
 msgstr "这是exception traceback"
 
-#: .\course\page\code.py:793
 #, python-format
 msgid "Your code ran on %s."
 msgstr ""
 
-#: .\course\page\code.py:799
 msgid "Your code printed the following output"
 msgstr "你的代码打印出以下的输出结果"
 
-#: .\course\page\code.py:806
 msgid "Your code printed the following error messages"
 msgstr "你的代码打印出以下的错误信息"
 
-#: .\course\page\code.py:812
 msgid "Your code produced the following plots"
 msgstr "你的代码得到以下的图"
 
-#: .\course\page\code.py:822
 msgid "Figure"
 msgstr "图"
 
-#: .\course\page\code.py:899
 msgid "The following code is a valid answer"
 msgstr "以下的代码是一个有效的回答"
 
-#: .\course\page\code.py:973
+msgid ""
+"'human_feedback_value' and 'human_feedback_percentage' are not allowed to "
+"coexist"
+msgstr "'human_feedback_value'和'human_feedback_percentage'只能设置一个."
+
+msgid ""
+"expecting either 'human_feedback_value' or 'human_feedback_percentage', "
+"found neither."
+msgstr ""
+"应有'human_feedback_value'和'human_feedback_percentage'中的一项，未找到."
+
+msgid ""
+"Used deprecated 'human_feedback_value' attribute--use "
+"'human_feedback_percentage' instead."
+msgstr ""
+"使用了已淘汰的(deprecated)'human_feedback_value'属性 -- 请使"
+"用'human_feedback_percentage'"
+
+msgid ""
+"'human_feedback_value' attribute is not allowed if value of question is 0, "
+"use 'human_feedback_percentage' instead"
+msgstr ""
+"当题目的分值为0时，不允许使用'human_feedback_value'，请使"
+"用'human_feedback_percentage'."
+
 msgid "human_feedback_value greater than overall value of question"
 msgstr "人工评分(human_feedback_value)大于这个问题的总分值"
 
-#: .\course\page\inline.py:134
+msgid "the value of human_feedback_percentage must be between 0 and 100"
+msgstr "'human_feedback_percentage'必须在0到100内."
+
 #, python-format
 msgid "unknown embedded question type '%(type)s'"
 msgstr "未知的嵌入型问题类型\"%(type)s\""
 
-#: .\course\page\inline.py:148
 msgid "must be struct"
 msgstr "必须是一个struct型的数据"
 
-#: .\course\page\inline.py:239
 #, python-format
 msgid "unrecogonized width attribute string: '%(width_attr)s'"
 msgstr "无法识别的宽度字符串: '%(width_attr)s'"
 
-#: .\course\page\inline.py:250
 #, python-format
 msgid ""
 "unsupported length unit '%(length_unit)s', expected length unit can be %"
@@ -3552,106 +2841,84 @@ msgstr ""
 "不支持的长度单位'%(length_unit)s', 可使用的长度单位包括%(allowed_length_unit)"
 "s"
 
-#: .\course\page\inline.py:293 .\course\page\text.py:895
 msgid "at least one answer must be provided"
 msgstr "至少要提供一个回答"
 
 #. Translators: refers to optional
 #. correct answer for checking
 #. correctness sumbitted by students.
-#: .\course\page\inline.py:316
 msgid "answer"
 msgstr "回答"
 
-#: .\course\page\inline.py:326 .\course\page\text.py:910
 msgid "no matcher is able to provide a plain-text correct answer"
 msgstr "现有的匹配类无法提供一个普通文本型的标准答案"
 
-#: .\course\page\inline.py:435
 #, python-format
 msgid ""
 "one or more correct answer(s) expected  for question '%(question_name)s', %"
 "(n_correct)d found"
 msgstr "问题'%(question_name)s'至少要有1个答案，找到%(n_correct)d个"
 
-#: .\course\page\inline.py:626
 msgid "InlineMultiQuestion requires at least one answer field to be defined."
 msgstr ""
 
-#: .\course\page\inline.py:637
 #, python-format
 msgid "invalid answers name %s. "
 msgstr "无效的答案名称%s. "
 
-#: .\course\page\inline.py:638 .\course\page\inline.py:656
 msgid ""
 "A valid name should start with letters. Alphanumeric with underscores. Do "
 "not use spaces."
 msgstr "一个有效的名称应以字母开头，允许包含数字和下划线, 不允许有空格. "
 
-#: .\course\page\inline.py:655
 #, python-format
 msgid "invalid embedded question name %s. "
 msgstr "无效的嵌入型问题名称%s. "
 
-#: .\course\page\inline.py:673
 #, python-format
 msgid "embedded question name %s not unique."
 msgstr "嵌入问题的名称%s不是唯一的."
 
-#: .\course\page\inline.py:684
 #, python-format
 msgid "correct answer(s) not provided for question %s."
 msgstr "未为问题%s提供正确答案. "
 
-#: .\course\page\inline.py:692
 #, python-format
 msgid "redundant answers %s provided for non-existing question(s)."
 msgstr "为不存在的问题提供了多余的答案%s. "
 
-#: .\course\page\inline.py:719
 #, python-format
 msgid "have unpaired '%s'."
 msgstr "有未配对的\"%s\"."
 
-#: .\course\page\text.py:156
 #, python-format
 msgid "page must be of type '%s'"
 msgstr "page必须是\"%s\"类型"
 
-#: .\course\page\text.py:179
 msgid "unknown validator type"
 msgstr "未知的验证器类型"
 
-#: .\course\page\text.py:189 .\course\page\text.py:605
 msgid "must be struct or string"
 msgstr "必须是一个struct或string型的数据"
 
-#: .\course\page\text.py:288
 #, python-format
 msgid "regex '%(pattern)s' did not compile"
 msgstr "正则表达式(regex)\"%(pattern)s\"无法编译"
 
-#: .\course\page\text.py:344
 msgid "unable to check symbolic expression"
 msgstr "无法检查symbolic表达式"
 
-#: .\course\page\text.py:448 .\course\page\text.py:459
-#: .\course\page\text.py:477
 msgid "does not provide a valid float literal"
 msgstr "提供了一个无效的float字符串"
 
-#: .\course\page\text.py:466
 msgid "not allowed when 'value' is zero"
 msgstr "不允许'value'的值为0"
 
-#: .\course\page\text.py:482
 msgid ""
 "Float match for 'value' zero should have atol--otherwise it will match any "
 "number"
 msgstr "对于0值，float匹配器需包括'atol'项，否则任何数字都将被视为正确答案. "
 
-#: .\course\page\text.py:494
 msgid ""
 "Float match should have either rtol or atol--otherwise it will match any "
 "number"
@@ -3661,68 +2928,53 @@ msgstr ""
 #. Translators: a "matcher" is used to determine
 #. if the answer to text question (blank filling
 #. question) is correct.
-#: .\course\page\text.py:552
 #, python-format
 msgid "%(matcherclassname)s only accepts '%(matchertype)s' patterns"
 msgstr "%(matcherclassname)s 只接受 \"%(matchertype)s\" 模式"
 
-#: .\course\page\text.py:564
 #, python-format
 msgid "unknown match type '%(matchertype)s'"
 msgstr "未知的匹配(match)类型\"%(matchertype)s\""
 
-#: .\course\page\text.py:583
 msgid "does not specify match type"
 msgstr "无法确定匹配(match)类型"
 
-#: .\course\page\text.py:591
 msgid "uses deprecated 'matcher:answer' style"
 msgstr "使用了已淘汰了的(deprecated) \"matcher:answer\" 类型"
 
-#: .\course\page\text.py:612
 msgid "matcher must supply 'type'"
 msgstr "matcher必须提供\"type\""
 
-#: .\course\page\text.py:663
 msgid "unrecognized widget type"
 msgstr "无法识别的构件(widget)类型"
 
-#: .\course\page\upload.py:47
 msgid "Uploaded file"
 msgstr "已上传的文件"
 
-#: .\course\page\upload.py:74
 #, python-format
 msgid ""
 "Please keep file size under %(allowedsize)s. Current filesize is %"
 "(uploadedsize)s."
 msgstr "请将文件大小控制在%(allowedsize)s以下, 当前的大小为%(uploadedsize)s. "
 
-#: .\course\page\upload.py:81
 msgid "Uploaded file is not a PDF."
 msgstr "上传的文档不是pdf文件. "
 
-#: .\course\page\upload.py:167
 msgid "unrecognized mime types"
 msgstr "无法识别的文件类型(mime type)"
 
-#: .\course\page\upload.py:177
 msgid "upload question does not have assigned point value"
 msgstr "上传问题未设定分值"
 
-#: .\course\sandbox.py:66
 msgid "Press Alt/Cmd+(Shift+)P to preview."
 msgstr "按下 Alt/Cmd+(Shift+)P 进行预览."
 
-#: .\course\sandbox.py:69
 msgid "Content"
 msgstr "内容"
 
-#: .\course\sandbox.py:80 .\course\templates\course\grade-flow-page.html:346
 msgid "Clear"
 msgstr "清除"
 
-#: .\course\sandbox.py:97
 msgid ""
 "Enter <a href=\"http://documen.tician.de/relate/content.html#relate-markup"
 "\">RELATE markup</a>."
@@ -3730,347 +2982,259 @@ msgstr ""
 "使用<a href='http://documen.tician.de/relate/content.html#relate-"
 "markup'>RELATE方式的Markdown模式</a>. "
 
-#: .\course\sandbox.py:119
 msgid "Markup failed to render"
 msgstr "Markup渲染失败"
 
-#: .\course\sandbox.py:169
 msgid "Clear Response Data"
 msgstr "清除response数据"
 
-#: .\course\sandbox.py:208
 msgid "Enter YAML markup for a flow page."
 msgstr "输入flow page的YAML markup. "
 
-#: .\course\sandbox.py:242 .\course\sandbox.py:287
 msgid "Page failed to load/validate"
 msgstr "page加载/验证失败"
 
-#: .\course\sandbox.py:359
 msgid "Page failed to load/validate (change page ID to clear faults)"
 msgstr "page加载/验证失败 (修改Page id以清除错误)"
 
-#: .\course\sandbox.py:371
 msgid "Submit answer"
 msgstr "提交回答"
 
-#: .\course\tasks.py:66
 #, python-format
 msgid "%d sessions expired."
 msgstr "%d个session已经过期. "
 
-#: .\course\tasks.py:103
 #, python-format
 msgid "%d sessions ended."
 msgstr "%d个session已结束. "
 
-#: .\course\tasks.py:134
 #, python-format
 msgid "Grades recalculated for %d sessions."
 msgstr "%d个session已重新计算评分. "
 
-#: .\course\tasks.py:168
 #, python-format
 msgid "%d sessions regraded."
 msgstr "%d个session已重新评分. "
 
-#: .\course\templates\course\analytics-flow.html:5
-#: .\course\templates\course\analytics-flows.html:5
-#: .\course\templates\course\analytics-page.html:5
-#: .\course\templates\course\analytics-page.html:9
 msgid "Analytics"
 msgstr "分析统计"
 
-#: .\course\templates\course\analytics-flow.html:9
 #, python-format
 msgid " Analytics: <tt>%(flow_identifier)s</tt> "
 msgstr "分析统计: <tt>%(flow_identifier)s</tt> "
 
-#: .\course\templates\course\analytics-flow.html:11
 msgid "Grade Distribution"
 msgstr "成绩分布"
 
 #. Translators: the following are the options when showing attempts of particiants in
 #. grade analytics.
 #.
-#: .\course\templates\course\analytics-flow.html:19
-#: .\course\templates\course\analytics-page.html:23
 msgid "Showing results for <i>only the first attempt</i> by each participant."
 msgstr "仅显示每个参与者<b>第一次尝试</b>的结果. "
 
-#: .\course\templates\course\analytics-flow.html:23
-#: .\course\templates\course\analytics-page.html:27
 msgid "Show all attempts"
 msgstr "显示所有尝试"
 
-#: .\course\templates\course\analytics-flow.html:26
-#: .\course\templates\course\analytics-page.html:30
 msgid "Showing results for <i>all attempts</i> by each participant."
 msgstr "显示每个参与者<b>所有尝试</b>的结果. "
 
-#: .\course\templates\course\analytics-flow.html:28
-#: .\course\templates\course\analytics-page.html:32
 msgid "Show only the first attempt"
 msgstr "仅显示第一次尝试"
 
-#: .\course\templates\course\analytics-flow.html:33
 #, python-format
 msgid "%(weight)s grade"
 msgid_plural "%(weight)s grades"
 msgstr[0] "%(weight)s个评分"
 msgstr[1] "%(weight)s个评分"
 
-#: .\course\templates\course\analytics-flow.html:39
 #, python-format
 msgid "(from %(participant_count)s distinct participant)"
 msgid_plural "(from %(participant_count)s distinct participants)"
 msgstr[0] "在%(participant_count)s个参与者中"
 msgstr[1] "在%(participant_count)s个参与者中"
 
-#: .\course\templates\course\analytics-flow.html:49
 msgid "Page-by-Page Statistics"
 msgstr "逐页的分析结果"
 
-#: .\course\templates\course\analytics-flow.html:61
 #, python-format
 msgid "(%(answer_count)s non-empty response,"
 msgid_plural "(%(answer_count)s non-empty responses,"
 msgstr[0] "(%(answer_count)s个非空的回答, "
 msgstr[1] "(%(answer_count)s个非空的回答, "
 
-#: .\course\templates\course\analytics-flow.html:66
 #, python-format
 msgid "%(total_count)s response total)"
 msgid_plural "%(total_count)s responses total)"
 msgstr[0] "总共有%(total_count)s个回答)"
 msgstr[1] "总共有%(total_count)s个回答)"
 
-#: .\course\templates\course\analytics-flow.html:93
 msgid "Time Distribution"
 msgstr "时间分布"
 
-#: .\course\templates\course\analytics-flows.html:9
 msgid "Analytics: List of Flows with Sessions"
 msgstr "分析: Flows及其Sessions的列表"
 
-#: .\course\templates\course\analytics-flows.html:21
 msgid " No flow sessions have been recorded."
 msgstr "未有flow session的记录. "
 
-#: .\course\templates\course\analytics-page.html:15
 msgid "Answer Distribution"
 msgstr "回答的分布"
 
-#: .\course\templates\course\analytics-page.html:42
 #, python-format
 msgid "(%(astats_count)s response)"
 msgid_plural "(%(astats_count)s responses)"
 msgstr[0] "(%(astats_count)s个回答)"
 msgstr[1] "(%(astats_count)s个回答)"
 
-#: .\course\templates\course\broken-code-question-email.txt:1
 #, python-format
 msgid ""
 "Hi there,\n"
+"This message was sent from %(site)s at %(time)s.\n"
 "Bad news! A code question with ID '%(page_id)s' in '%(course_identifier)s' "
 "has just failed while a user was trying to get his or her code graded.\n"
 "Details of the problem are below:\n"
 "%(error_message)s\n"
 msgstr ""
 "Hi 您好,\n"
+"    这条消息发自网站%(site)s，时间是%(time)s.\n"
 "    坏消息！ 刚才有一位用户在完成编程作业时, 某个编程问题（课程%"
 "(course_identifier)s中，ID为%(page_id)s）崩溃了。\n"
 "    该问题的详细信息如下：\n"
 "%(error_message)s\n"
 
-#: .\course\templates\course\calendar.html:8
-#: .\course\templates\course\calendar.html:21
-#: .\course\templates\course\course-base.html:122
+msgid "You can navigate to the following url to check the problem:"
+msgstr "你可以到以下页面中查看这个问题:"
+
 msgid "Calendar"
 msgstr "教学日历"
 
-#: .\course\templates\course\calendar.html:42
 msgid ""
 "<b>Note:</b> Some calendar entries are clickable and link to entries below."
 msgstr "<b>注释:</b> 一些日历的条目是可点击的, 且与其下方的输入内容相链接. "
 
 #. Translators: The following are names for menu items in course page
-#: .\course\templates\course\course-base.html:31
 msgctxt "menu item"
 msgid "Student"
 msgstr "学员"
 
-#: .\course\templates\course\course-base.html:36
 msgid "View grades"
 msgstr "查看得分"
 
-#: .\course\templates\course\course-base.html:38
 msgid "View calendar"
 msgstr "查看日历"
 
-#: .\course\templates\course\course-base.html:40
 msgid "Back to course page"
 msgstr "返回课程主页面"
 
-#: .\course\templates\course\course-base.html:47
 msgctxt "menu item"
 msgid "Grading"
 msgstr "成绩管理"
 
-#: .\course\templates\course\course-base.html:50
 msgid "Analytics Overview"
 msgstr "分析总览"
 
-#: .\course\templates\course\course-base.html:55
 msgid "Grade Book"
 msgstr "成绩册"
 
-#: .\course\templates\course\course-base.html:56
-#: .\course\templates\course\gradebook-participant-list.html:7
-#: .\course\templates\course\gradebook-participant-list.html:15
 msgid "List of Participants"
 msgstr "参与者列表"
 
-#: .\course\templates\course\course-base.html:57
-#: .\course\templates\course\gradebook-opp-list.html:8
-#: .\course\templates\course\gradebook-opp-list.html:16
 msgid "List of Grading Opportunities"
 msgstr "得分机会列表"
 
-#: .\course\templates\course\course-base.html:58
-#: .\course\templates\course\gradebook-by-opp.html:8
-#: .\course\templates\course\gradebook-by-opp.html:17
-#: .\course\templates\course\gradebook-single.html:5
-#: .\course\templates\course\gradebook.html:5
-#: .\course\templates\course\gradebook.html:13
 msgid "Grade book"
 msgstr "成绩册"
 
-#: .\course\templates\course\course-base.html:60
 msgid "Grade book (CSV export)"
 msgstr "成绩册(CSV导出)"
 
-#: .\course\templates\course\course-base.html:64
 msgid "Import Grades"
 msgstr "导入成绩"
 
-#: .\course\templates\course\course-base.html:68
 msgid "Regrade flows"
 msgstr "重新评分"
 
-#: .\course\templates\course\course-base.html:73
 msgid "Exceptions"
 msgstr "破例处理"
 
-#: .\course\templates\course\course-base.html:74
-#: .\course\templates\course\flow-page.html:108
-#: .\course\templates\course\gradebook-single.html:305
-#: .\course\templates\course\gradebook-single.html:321
 msgid "Grant exception"
 msgstr "给予破例"
 
-#: .\course\templates\course\course-base.html:76
 msgid "Show exceptions"
 msgstr "查看破例的情况"
 
-#: .\course\templates\course\course-base.html:83
 msgid "Edit exams"
 msgstr "编辑测验"
 
-#: .\course\templates\course\course-base.html:86
 msgid "Batch-issue exam tickets"
 msgstr "批量发布测验ticket"
 
-#: .\course\templates\course\course-base.html:95
 msgctxt "menu item"
 msgid "Content"
 msgstr "内容管理"
 
-#: .\course\templates\course\course-base.html:99
 msgid "Retrieve/preview new course revisions"
 msgstr "获取/预览对课程内容的修订"
 
-#: .\course\templates\course\course-base.html:104
 msgid "Edit course"
 msgstr "编辑课程"
 
-#: .\course\templates\course\course-base.html:108
 msgid "Content creation"
 msgstr "内容创建"
 
-#: .\course\templates\course\course-base.html:110
 msgid "Page sandbox"
 msgstr "Page沙箱"
 
-#: .\course\templates\course\course-base.html:113
 msgid "Markup sandbox"
 msgstr "Markup沙箱"
 
-#: .\course\templates\course\course-base.html:118
 msgid "Test flow"
 msgstr "测试flow"
 
-#: .\course\templates\course\course-base.html:124
 msgid "Edit events"
 msgstr "编辑event"
 
-#: .\course\templates\course\course-base.html:137
 msgctxt "menu item"
 msgid "Instructor"
 msgstr "任课老师"
 
-#: .\course\templates\course\course-base.html:141
 msgctxt "menu item"
 msgid "Preapprove enrollments"
 msgstr "加入课程预批准"
 
-#: .\course\templates\course\course-base.html:144
 msgctxt "menu item"
 msgid "Query participations"
 msgstr "查询课程参与"
 
-#: .\course\templates\course\course-base.html:150
 msgid "Manage instant flow requests"
 msgstr "管理即时flow"
 
-#: .\course\templates\course\course-base.html:171
 msgid "There is an interactive activity going on right now."
 msgstr "目前正在进行一项互动活动. "
 
-#: .\course\templates\course\course-base.html:175
-#: .\course\templates\course\course-base.html:182
 msgid "Go to activity"
 msgstr "转到课程活动"
 
-#: .\course\templates\course\course-base.html:178
 msgid "There are some interactive activities going on right now."
 msgstr "目前正在进行一些互动活动. "
 
-#: .\course\templates\course\course-page.html:8
 msgid "This course is only visible to course staff at the moment."
 msgstr "本课程目前只对课务人员显示. "
 
-#: .\course\templates\course\course-page.html:10
 msgctxt "change the visibility of a course"
 msgid "Change"
 msgstr "修改"
 
-#: .\course\templates\course\course-page.html:15
 msgid "You're not currently signed in."
 msgstr "您还未登录. "
 
-#: .\course\templates\course\course-page.html:26
 msgid "Enroll"
 msgstr "加入课程"
 
-#: .\course\templates\course\enrollment-decision-email.txt:1
-#: .\course\templates\course\grade-notify.txt:1
-#: .\course\templates\course\sign-in-email.txt:1
 #, python-format
 msgid "Dear %(username)s,"
 msgstr "尊敬的%(username)s: "
 
-#: .\course\templates\course\enrollment-decision-email.txt:3
 #, python-format
 msgid ""
 "Welcome! Your request to join the course '%(course_identifier)s' has been "
@@ -4084,7 +3248,6 @@ msgstr ""
 "%(course_uri)s\n"
 "    我们希望和您经历一门有效率和效益的学习课程！"
 
-#: .\course\templates\course\enrollment-decision-email.txt:8
 #, python-format
 msgid ""
 "We're sorry to let you know that your request to join the course '%"
@@ -4098,14 +3261,9 @@ msgstr ""
 "很抱歉地告知您, 您参加课程%(course_identifier)s的申请被拒绝. 请与课务人员联"
 "系, 例如回复此邮件来说明您的情况. "
 
-#: .\course\templates\course\enrollment-decision-email.txt:12
-#: .\course\templates\course\enrollment-request-email.txt:8
-#: .\course\templates\course\sign-in-email.txt:11
-#: .\course\templates\course\submit-notify.txt:8
 msgid "- RELATE staff "
 msgstr "- RELATE站务"
 
-#: .\course\templates\course\enrollment-request-email.txt:1
 #, python-format
 msgid ""
 "Dear course staff of %(course_identifier)s,\n"
@@ -4124,7 +3282,6 @@ msgstr ""
 "去批准或拒绝这个申请. 提示: 选定(course participations)课程参与中的相关请求, "
 "然后使用下拉菜单中的\"批准\" 或 \"拒绝\" 来达成. \n"
 
-#: .\course\templates\course\exam-check-in.html:12
 #, python-format
 msgid ""
 "If you have a not been issued an exam ticket by your instructor, please <a "
@@ -4134,120 +3291,107 @@ msgstr ""
 "如果指导老师没有发测验ticket给你，请<a href=\"%(relate-sign_in_choice)s\">使"
 "用别的方法登入</a>."
 
-#: .\course\templates\course\feedback-code-with-human.html:4
-#: .\course\templates\course\gradebook-by-opp.html:126
-#: .\course\templates\course\gradebook-single.html:113
 msgid "Overall grade"
 msgstr "总评"
 
-#: .\course\templates\course\feedback-code-with-human.html:7
 #, python-format
 msgid "The overall grade is %(percentage)s%%."
 msgstr "总评为%(percentage)s%%. "
 
-#: .\course\templates\course\feedback-code-with-human.html:16
 msgid "Autograder feedback"
 msgstr "自动评分反馈"
 
-#: .\course\templates\course\feedback-code-with-human.html:20
 #, python-format
 msgid "The autograder assigned %(feedback_points)s/%(points)s points."
 msgstr "自动评分的结果是%(feedback_points)s/%(points)s分. "
 
-#: .\course\templates\course\feedback-code-with-human.html:33
 msgid "Human feedback"
 msgstr "人工反馈"
 
-#: .\course\templates\course\feedback-code-with-human.html:37
 #, python-format
 msgid "The human grader assigned %(feedback_points)s/%(human_points)s points."
 msgstr "人工评分的结果是%(feedback_points)s/%(human_points)s分. "
 
-#: .\course\templates\course\file-upload-form.html:8
 msgid "Review uploaded file"
 msgstr "回顾上传的文件"
 
-#: .\course\templates\course\file-upload-form.html:10
 msgid "Embed viewer"
 msgstr "网页内嵌查看器(demo)"
 
-#: .\course\templates\course\file-upload-form.html:21
 #, python-format
 msgid ""
 " Your browser reported itself unable to render <tt>%(mime_type)s</tt> "
 "inline. "
 msgstr "您的浏览器不支持对<tt>%(mime_type)s</tt>类型文件的渲染. "
 
-#: .\course\templates\course\flow-completion-grade.html:12
-#: .\course\templates\course\flow-start.html:81
 msgid "Results"
 msgstr "结果"
 
 #. Translators: the following 5 blocks of literals make a sentence. PartI
-#: .\course\templates\course\flow-completion-grade.html:16
 msgid "You have"
 msgstr "您"
 
 #. Translators: PartII
-#: .\course\templates\course\flow-completion-grade.html:19
 msgid "(so far)"
 msgstr "(截至目前)"
 
 #. Translators: PartIII
-#: .\course\templates\course\flow-completion-grade.html:22
 #, python-format
 msgid "achieved <b>%(provisional_points)s</b> out of %(max_points)s points."
 msgstr "得到了%(max_points)s分中的<b>%(provisional_points)s</b>分. "
 
 #. Translators: PartIV
-#: .\course\templates\course\flow-completion-grade.html:29
 msgid "(Some questions are not graded yet, so your grade will likely change.)"
 msgstr "(某些问题还未评分，所以你的得分将可能会有变化.)"
 
 #. Translators: PartV
-#: .\course\templates\course\flow-completion-grade.html:35
 #, python-format
 msgid "(That's <b>%(points_percent)s%%</b>.)"
 msgstr "(即<b>%(points_percent)s%%</b>.)"
 
-#: .\course\templates\course\flow-completion-grade.html:55
 #, python-format
 msgid ""
-"You have answered %(fully_correct_count)s questions correctly, %"
+"You have answered %(fully_correct_count)s grading questions correctly, %"
 "(partially_correct_count)s questions partially correctly, and %"
 "(incorrect_count)s questions incorrectly."
 msgstr ""
-"在您所有的回答, 有%(fully_correct_count)s个完全正确, %"
+"在您回答的所有计分问题中, 有%(fully_correct_count)s个完全正确, %"
 "(partially_correct_count)s个部分正确, %(incorrect_count)s个不正确. "
 
-#: .\course\templates\course\flow-completion-grade.html:62
 #, python-format
 msgid "The grade for %(unknown_count)s questions is not yet known."
 msgstr "有%(unknown_count)s个问题的回答是否正确仍然未知. "
 
-#: .\course\templates\course\flow-completion-grade.html:86
-#: .\course\templates\course\flow-completion.html:15
+#, python-format
+msgid ""
+"There are %(total_count)s optional questions (not for grading). You have "
+"answered %(fully_correct_count)s correctly, %(partially_correct_count)s "
+"partially correctly, and %(incorrect_count)s incorrectly."
+msgstr ""
+"共有%(total_count)s个不计分问题. 您的回答中, 有%(fully_correct_count)s个完全"
+"正确, %(partially_correct_count)s个部分正确, %(incorrect_count)s个不正确. "
+
+#, python-format
+msgid ""
+"The correctness for %(unknown_count)s optional questions is not yet known."
+msgstr "有%(unknown_count)s个不计分问题的回答是否正确仍然未知. "
+
 msgid "Back to start page"
 msgstr "回到起始页面"
 
-#: .\course\templates\course\flow-confirm-completion.html:10
 msgid "End Session"
 msgstr "结束session"
 
-#: .\course\templates\course\flow-confirm-completion.html:15
 msgid "You have left the following question(s) unanswered:"
 msgstr "您还有以下问题未回答:"
 
-#: .\course\templates\course\flow-confirm-completion.html:33
 #, python-format
-msgid "There were %(total_count)s questions."
-msgstr "总共有%(total_count)s个问题. "
+msgid "There were %(required_count)s grading questions."
+msgstr "总共有%(required_count)s个计分问题. "
 
-#: .\course\templates\course\flow-confirm-completion.html:37
 msgid "You have provided an answer for all of them."
 msgstr "您已经回答了所有问题. "
 
-#: .\course\templates\course\flow-confirm-completion.html:41
 #, python-format
 msgid ""
 "You have answered %(answered_count)s and left %(unanswered_count)s "
@@ -4255,50 +3399,30 @@ msgid ""
 msgstr ""
 "您已经回答了%(answered_count)s个问题, 还有%(unanswered_count)s个未回答. "
 
-#: .\course\templates\course\flow-confirm-completion.html:48
 msgid "If you choose to end your session, the following things will happen:"
 msgstr "如果您选择结束这个session, 将发生以下的事情："
 
-#: .\course\templates\course\flow-confirm-completion.html:50
 msgid "You will be prevented from making further changes to your answers."
 msgstr "您将无法修改您的回答. "
 
-#: .\course\templates\course\flow-confirm-completion.html:51
 msgid ""
 "All your currently saved answers, if not graded already, will be graded."
 msgstr "您当前保存的答案, 如果还未被评分, 将会被评分. "
 
-#: .\course\templates\course\flow-confirm-completion.html:52
 msgid ""
 "If possible, a final grade will be computed from all saved, graded answers."
 msgstr "如果可能, 所有已保存的、已评分的结果将会得到一个最终的评分. "
 
-#: .\course\templates\course\flow-confirm-completion.html:61
-msgid "Go back"
-msgstr "返回"
-
-#: .\course\templates\course\flow-confirm-completion.html:65
-#: .\course\templates\course\flow-confirm-completion.html:80
 msgid "Confirm: Submit answers and end session"
 msgstr "确定：提交所有回答并结束本session"
 
-#: .\course\templates\course\flow-confirm-completion.html:69
 msgid "Are you sure you will submit this session with questions unanswered?"
 msgstr "您是否坚持在(部分)问题未回答的前提下仍提交此session?"
 
-#: .\course\templates\course\flow-confirm-completion.html:71
-#: .\course\templates\course\flow-start.html:140
-#: .\relate\templates\sign-out-confirmation.html:8
-msgid "Cancel"
-msgstr "放弃"
-
 #. Translators: student should confirm to start another session.
-#: .\course\templates\course\flow-confirm-completion.html:76
-#: .\course\templates\course\flow-start.html:146
 msgid "I am sure"
 msgstr "我确认"
 
-#: .\course\templates\course\flow-page-interaction-email.txt:1
 #, python-format
 msgid ""
 "Hi there,\n"
@@ -4322,187 +3446,146 @@ msgstr ""
 "%(review_uri)s\n"
 "\n"
 
-#: .\course\templates\course\flow-page.html:28
-#: .\course\templates\course\flow-page.html:33
+msgid "Viewing session for partipant"
+msgstr "正在查看session的学员为: "
+
+msgid "(unspecified participant)"
+msgstr "(未确定的参与者)"
+
 msgctxt "Previous page/item in a flow"
 msgid "Previous page"
 msgstr "上一页"
 
-#: .\course\templates\course\flow-page.html:39
-#: .\course\templates\course\flow-page.html:44
 msgctxt "Next page/item in a flow"
 msgid "Next page"
 msgstr "下一页"
 
-#: .\course\templates\course\flow-page.html:53
 msgid "Boomark this page"
 msgstr "收藏页面"
 
-#: .\course\templates\course\flow-page.html:72
 msgid "Send an email about this page to course staff"
 msgstr "向课务人员发送关于本页面的答疑邮件."
 
-#: .\course\templates\course\flow-page.html:87
 msgid "Page Menu"
 msgstr "Page菜单"
 
-#: .\course\templates\course\flow-page.html:93
 msgid "Return to flow start page"
 msgstr "回到Flow起始页面"
 
-#: .\course\templates\course\flow-page.html:116
 msgid "View in grading interface"
 msgstr "在评分界面中查看"
 
-#: .\course\templates\course\flow-page.html:134
+msgid "Re-allow changes to page"
+msgstr "重新允许修改回答"
+
 msgid "Submission history for this page"
 msgstr "本页面的提交历史"
 
-#: .\course\templates\course\flow-page.html:151
-#: .\course\templates\course\grade-flow-page.html:39
 msgid "(current)"
 msgstr "(当前的)"
 
-#: .\course\templates\course\flow-page.html:154
 msgid "(submitted)"
 msgstr "(已提交的)"
 
-#: .\course\templates\course\flow-page.html:177
 msgid "Go to end"
 msgstr "跳转至最末"
 
-#: .\course\templates\course\flow-page.html:182
-msgid "Submit assignment"
-msgstr "提交作业"
+#, python-format
+msgid "Submit %(flow_title)s"
+msgstr "提交%(flow_title)s"
 
-#: .\course\templates\course\flow-page.html:184
-#: .\course\templates\course\flow-page.html:190
 msgid "Finish"
 msgstr "结束"
 
-#: .\course\templates\course\flow-page.html:188
-#: .\course\templates\course\flow-start.html:27
-#: .\course\templates\course\gradebook-single.html:141
 msgid "Result"
 msgstr "结果"
 
 #. Translators: the string is followed by "what will happen" at deadline.
-#: .\course\templates\course\flow-page.html:216
 msgid "At deadline:"
 msgstr "当截止时："
 
-#: .\course\templates\course\flow-page.html:294
 msgid "Session duration:"
-msgstr "session的时间长度:"
+msgstr "本Session持续时长:"
 
-#: .\course\templates\course\flow-page.html:296
 msgid "minutes"
 msgstr "分钟"
 
-#: .\course\templates\course\flow-page.html:299
 msgid "Time factor:"
 msgstr "时间乘数:"
 
-#: .\course\templates\course\flow-page.html:314
 #, python-format
 msgid "%(max_points)s point"
 msgid_plural "%(max_points)s points"
 msgstr[0] "%(max_points)s分"
 msgstr[1] "%(max_points)s分"
 
-#: .\course\templates\course\flow-page.html:338
+msgid "Optional question"
+msgstr "不计分问题"
+
 msgid "(You may still change your answer after you submit it.)"
 msgstr "(您仍然可以在提交<b>本问题</b>后修改回答)"
 
-#: .\course\templates\course\flow-page.html:417
 msgid "You have unsaved changes on this page."
 msgstr "您在本页还有未保存的修订. "
 
-#: .\course\templates\course\flow-page.html:488
 msgid "Saved."
 msgstr "已保存"
 
-#: .\course\templates\course\flow-page.html:495
 msgid "Error--not saved."
 msgstr "错误--未保存."
 
-#: .\course\templates\course\flow-session-state.html:3
 msgid "unfinished"
 msgstr "未完成"
 
-#: .\course\templates\course\flow-session-state.html:5
 msgid "finished"
 msgstr "已完成"
 
-#: .\course\templates\course\flow-start.html:19
 msgid "Past sessions"
 msgstr "过往的session"
 
-#: .\course\templates\course\flow-start.html:25
-#: .\course\templates\course\gradebook-single.html:159
 msgid "Grading rules"
 msgstr "评分规则"
 
-#: .\course\templates\course\flow-start.html:26
-#: .\course\templates\course\gradebook-by-opp.html:28
-#: .\course\templates\course\gradebook-single.html:29
-#: .\course\templates\course\gradebook-single.html:140
 msgid "Due"
 msgstr "截止"
 
-#: .\course\templates\course\flow-start.html:28
-#: .\course\templates\course\gradebook-opp-list.html:24
-#: .\course\templates\course\gradebook-single.html:146
-#: .\course\templates\course\participation-table.html:7
 msgid "Actions"
 msgstr "操作"
 
-#: .\course\templates\course\flow-start.html:43
 msgid "(no description)"
 msgstr "(无描述)"
 
-#: .\course\templates\course\flow-start.html:54
 #, python-format
 msgid "<b>%(points)s</b> out of %(max_points)s (<b>%(percentage)s%%</b>)"
 msgstr "%(max_points)s分中的<b>%(points)s分</b> (<b>%(percentage)s%%</b>)"
 
-#: .\course\templates\course\flow-start.html:62
-#: .\course\templates\course\gradebook-single.html:207
 msgid "(none)"
 msgstr "(无)"
 
-#: .\course\templates\course\flow-start.html:65
 msgid "(not shown)"
 msgstr "(未显示)"
 
-#: .\course\templates\course\flow-start.html:73
 msgid "Resume"
 msgstr "继续"
 
-#: .\course\templates\course\flow-start.html:75
 msgid "Review"
 msgstr "回顾"
 
-#: .\course\templates\course\flow-start.html:95
 msgid "If you start a new session, the following rules will apply:"
 msgstr "如果您开始一个新的session, 以下的规则将会生效："
 
-#: .\course\templates\course\flow-start.html:99
 #, python-format
 msgid "Your session will be a '<b>%(description)s</b>'."
 msgstr "您的session将采取\"<b>%(description)s</b>\"的评分规则. "
 
-#: .\course\templates\course\flow-start.html:106
 #, python-format
 msgid "Your session will be due on <b>%(due)s</b>."
 msgstr "您的session将在<b>%(due)s</b>过期."
 
-#: .\course\templates\course\flow-start.html:112
 #, python-format
 msgid "You will receive <b>%(credit_percent)s%% credit</b> for your work."
 msgstr "您的得分将为应得分数的<b>%(credit_percent)s%%</b>. "
 
-#: .\course\templates\course\flow-start.html:119
 #, python-format
 msgid ""
 "This is not your first session. If you start another one, for your overall "
@@ -4513,25 +3596,20 @@ msgstr ""
 "您所有的session中采取\"<b>%(grade_aggregation_strategy_descr)s</b>\"累积策"
 "略. "
 
-#: .\course\templates\course\flow-start.html:134
-#: .\course\templates\course\flow-start.html:177
 msgid "Start"
 msgstr "开始"
 
-#: .\course\templates\course\flow-start.html:138
 msgid "I understand that starting a new session could lower my overall grade."
 msgstr "我已经知道开始一个新的session将有可能降低我的总体评分. "
 
-#: .\course\templates\course\flow-start.html:199
 msgid ""
-"You do not have any existing sessions and are not allowed to start a new one."
-msgstr "您没有可以开始的session，不允许开始一个新session. "
+"You do not have any existing/viewable sessions and are not allowed to start "
+"a new one."
+msgstr "您没有已经开始或可以查看的session，也不能开始一个新session. "
 
-#: .\course\templates\course\flow-start.html:206
 msgid "Check the following:"
 msgstr "检查以下项目："
 
-#: .\course\templates\course\flow-start.html:212
 #, python-format
 msgid ""
 "You're not currently signed in. Access to the resource is restricted, and "
@@ -4543,12 +3621,9 @@ msgstr ""
 "旦您登录了网站，请通过 <b><a href=\"%(relate-home)s\">主页</a></b> 返回课程页"
 "面，然后尝试您的上一次操作。"
 
-#: .\course\templates\course\flow-start.html:223
 msgid "Has the deadline for this assignment passed?"
 msgstr "作业的截止时间是否已经过了?"
 
-#: .\course\templates\course\flow-start.html:226
-#: .\relate\templates\403.html:27
 msgid ""
 "Complete your enrollment in your course. If you're not enrolled, a large "
 "\"Enroll now\" button will show up at the top of your course page. Click "
@@ -4557,8 +3632,6 @@ msgstr ""
 "请完成您的加入课程申请.  如果您还未加入, 在课程页面上有一个<b>“加入课程申"
 "请”</b>的按钮, 点击它, 并按指示步骤操作, 然后再重试您刚才的操作. "
 
-#: .\course\templates\course\flow-start.html:234
-#: .\relate\templates\403.html:34
 #, python-format
 msgid ""
 "If none of the above steps help, please navigate back to your course from "
@@ -4567,124 +3640,89 @@ msgstr ""
 "如果上面的步骤都无法完成，请从 <b><a href=\"%(relate-home)s\">主页</a></b> 浏"
 "览回您的课程页面，并联系课务人员。"
 
-#: .\course\templates\course\grade-flow-page.html:7
-#: .\course\templates\course\grade-flow-page.html:84
 msgid "Grading"
 msgstr "评分"
 
-#: .\course\templates\course\grade-flow-page.html:20
 msgid "Past submissions/grades"
 msgstr "过往的提交记录/评分记录"
 
-#: .\course\templates\course\grade-flow-page.html:33
 msgid "Submission:"
 msgstr "权限:"
 
-#: .\course\templates\course\grade-flow-page.html:34
 msgid "Grade:"
 msgstr "得分:"
 
-#: .\course\templates\course\grade-flow-page.html:42
 msgid "no grade"
 msgstr "无评分"
 
-#: .\course\templates\course\grade-flow-page.html:91
-#: .\course\templates\course\gradebook-by-opp.html:21
-#: .\course\templates\course\gradebook-participant.html:22
-#: .\course\templates\course\gradebook-single.html:13
 msgid "Property"
 msgstr "属性"
 
-#: .\course\templates\course\grade-flow-page.html:91
-#: .\course\templates\course\gradebook-by-opp.html:21
-#: .\course\templates\course\gradebook-participant.html:22
-#: .\course\templates\course\gradebook-single.html:13
 msgid "Value"
 msgstr "值"
 
 #. Translators: the grade information "for" a participant with fullname + (username)
-#: .\course\templates\course\grade-flow-page.html:101
 #, python-format
 msgid "for %(full_name)s (%(username)s)"
 msgstr "%(full_name)s (%(username)s)"
 
-#: .\course\templates\course\grade-flow-page.html:111
 msgid "Points awarded"
 msgstr "给予的分数"
 
-#: .\course\templates\course\grade-flow-page.html:118
 msgid "(unknown)"
 msgstr "(未知)"
 
 #. Translators: the unit name in grading
-#: .\course\templates\course\grade-flow-page.html:123
 msgid "point"
 msgid_plural "points"
 msgstr[0] "分"
 msgstr[1] "分"
 
-#: .\course\templates\course\grade-flow-page.html:130
-#: .\course\templates\course\grade-flow-page.html:150
 msgid "(n/a)"
 msgstr ""
 
-#: .\course\templates\course\grade-flow-page.html:135
 msgid "Graded"
 msgstr "已评分"
 
-#: .\course\templates\course\grade-flow-page.html:139
-#: .\course\templates\course\grading-statistics.html:22
 msgid "(autograded)"
 msgstr "(已自动评分)"
 
 #. Translators: the grade is awarded "by" some humman grader.
-#: .\course\templates\course\grade-flow-page.html:142
 #, python-format
 msgid "by %(grader_name)s"
 msgstr "评分人：%(grader_name)s"
 
-#: .\course\templates\course\grade-flow-page.html:147
 msgctxt "at (what time)"
 msgid "at"
 msgstr "于"
 
-#: .\course\templates\course\grade-flow-page.html:168 .\course\views.py:799
 msgid "Session"
 msgstr ""
 
-#: .\course\templates\course\grade-flow-page.html:173
 msgid "Start:"
 msgstr "开始:"
 
-#: .\course\templates\course\grade-flow-page.html:191
 msgid "Page number"
 msgstr "Page编号"
 
-#: .\course\templates\course\grade-flow-page.html:196
 msgid "View in flow"
 msgstr "在flow中查看"
 
-#: .\course\templates\course\grade-flow-page.html:214
 msgid "Correct Answer"
 msgstr "参考答案"
 
-#: .\course\templates\course\grade-flow-page.html:296
 msgid "Enter new feedback item:"
 msgstr "输入新的反馈项目:"
 
-#: .\course\templates\course\grade-flow-page.html:344
 msgid "Add phrase"
 msgstr "添加常用评语"
 
-#: .\course\templates\course\grade-flow-page.html:396
 msgid "Submit and next page"
 msgstr "提交并转到下一页"
 
-#: .\course\templates\course\grade-flow-page.html:401
 msgid "Submit and next session"
 msgstr "提交并转到下一个session"
 
-#: .\course\templates\course\grade-internal-notes-notify.txt:2
 #, python-format
 msgid ""
 "Hi there,\n"
@@ -4708,7 +3746,6 @@ msgstr ""
 "%(review_uri)s\n"
 "\n"
 
-#: .\course\templates\course\grade-notify.txt:2
 #, python-format
 msgid ""
 "\n"
@@ -4732,69 +3769,50 @@ msgstr ""
 "%(review_uri)s\n"
 "\n"
 
-#: .\course\templates\course\grade-notify.txt:11
 msgid "course staff"
 msgstr "课务"
 
-#: .\course\templates\course\gradebook-by-opp.html:25
-#: .\course\templates\course\gradebook-single.html:25
 msgid "Grading Opportunity ID"
 msgstr "得分机会ID"
 
-#: .\course\templates\course\gradebook-by-opp.html:35
-#: .\course\templates\course\gradebook-single.html:34
 msgid "Flow"
 msgstr ""
 
-#: .\course\templates\course\gradebook-by-opp.html:37
 msgid "(Start page)"
 msgstr "(开始页面)"
 
 #. Translators: "Counts" on the quantities of total session and finished sessions
-#: .\course\templates\course\gradebook-by-opp.html:42
 msgid "Counts"
 msgstr "计数"
 
-#: .\course\templates\course\gradebook-by-opp.html:44
 #, python-format
 msgid "%(total_sessions)s total sessions (%(finished_sessions)s finished)"
 msgstr "共%(total_sessions)s个session, (%(finished_sessions)s个已完成)"
 
-#: .\course\templates\course\gradebook-by-opp.html:51
 msgid "Operations"
 msgstr "操作"
 
-#: .\course\templates\course\gradebook-by-opp.html:54
 msgid "View analytics"
 msgstr "查看分析统计"
 
-#: .\course\templates\course\gradebook-by-opp.html:57
 msgid "View grader statistics"
 msgstr "查看得分统计"
 
-#: .\course\templates\course\gradebook-by-opp.html:62
 msgid "View page grades"
 msgstr "查看页面得分"
 
-#: .\course\templates\course\gradebook-by-opp.html:66
 msgid "Hide page grades"
 msgstr "隐藏页面得分"
 
-#: .\course\templates\course\gradebook-by-opp.html:70
 msgid "Download submissions"
 msgstr "下载提交的内容"
 
-#: .\course\templates\course\gradebook-by-opp.html:74
-#: .\course\templates\course\gradebook-opp-list.html:45
-#: .\course\templates\course\participation-table.html:24
 msgid "Edit"
 msgstr "编辑"
 
-#: .\course\templates\course\gradebook-by-opp.html:83
 msgid "Modify many sessions at once"
 msgstr "一次性修改若干个session"
 
-#: .\course\templates\course\gradebook-by-opp.html:87
 msgid ""
 "<p> \"Impose deadline (Expire sessions)\" will find all sessions for this "
 "flow that match the selected session tag and, depending on the session's "
@@ -4819,261 +3837,198 @@ msgstr ""
 "\", 并不会考察学员已提交的回答正确与否, 它只是使用已有的正确性信息重新计算该"
 "flow取得的分数, 这通常在修改了得分规则时使用.</p>"
 
-#: .\course\templates\course\gradebook-by-opp.html:124
 msgid "Session state"
 msgstr "session状态"
 
-#: .\course\templates\course\gradebook-by-opp.html:125
 msgid "Session grade"
 msgstr "session得分 "
 
-#: .\course\templates\course\gradebook-by-opp.html:173
 msgid "Rules tag"
 msgstr "规则tag"
 
-#: .\course\templates\course\gradebook-by-opp.html:180
 #, python-format
 msgid "%(points)s/%(max_points)s points"
 msgstr "%(points)s/%(max_points)s分"
 
-#: .\course\templates\course\gradebook-opp-list.html:18
 msgid "Add grading opportunity"
 msgstr "添加得分机会"
 
-#: .\course\templates\course\gradebook-opp-list.html:22
-#: .\course\templates\course\gradebook-participant.html:52
 msgid "Name of grading opportunity"
 msgstr "得分机会的名称"
 
-#: .\course\templates\course\gradebook-opp-list.html:29
 msgid "Shown to participants"
 msgstr "向学员显示"
 
-#: .\course\templates\course\gradebook-participant-list.html:17
 msgid "Add participant"
 msgstr "添加课程参与"
 
-#: .\course\templates\course\gradebook-participant.html:7
-#: .\course\templates\course\gradebook-participant.html:16
 msgid "My Grades"
 msgstr "我的成绩"
 
-#: .\course\templates\course\gradebook-participant.html:18
 msgid "Grades"
 msgstr "得分"
 
-#: .\course\templates\course\gradebook-participant.html:54
 msgid "Date"
 msgstr "日期"
 
-#: .\course\templates\course\gradebook-participant.html:76
-#: .\course\templates\course\gradebook-participant.html:77
 msgid "(not released)"
 msgstr "(未发布)"
 
-#: .\course\templates\course\gradebook-single.html:9
 msgid "Understand a grade"
 msgstr "成绩解读"
 
-#: .\course\templates\course\gradebook-single.html:40
 msgid "Flow start page"
 msgstr "Flow起始页面"
 
 #. Translators: averaged grade of a flow of all participants
-#: .\course\templates\course\gradebook-single.html:46
 msgid "Average grade"
 msgstr "所有参与者的平均分"
 
 #. Translators: average grade of a flow, format "10% (out of 5 grades)"
-#: .\course\templates\course\gradebook-single.html:50
 #, python-format
 msgid "%(avg_grade_percentage)s%% (out of %(avg_grade_population)s grades)"
 msgstr "%(avg_grade_percentage)s%% (共计%(avg_grade_population)s个评分)"
 
-#: .\course\templates\course\gradebook-single.html:55
 msgid "(no data)"
 msgstr "(暂无)"
 
-#: .\course\templates\course\gradebook-single.html:63
 msgid "Grade history"
 msgstr "得分记录"
 
-#: .\course\templates\course\gradebook-single.html:65
 msgid " (no grade data available)"
 msgstr "(尚无评分数据)"
 
 #. Translators: "what" stand for the state of a grade, e.g. "graded"
-#: .\course\templates\course\gradebook-single.html:71
 msgid "What"
 msgstr "评分情况"
 
-#: .\course\templates\course\gradebook-single.html:73
 msgid "Further Information"
 msgstr "更多信息"
 
-#: .\course\templates\course\gradebook-single.html:88
 #, python-format
 msgid "%(points)s/%(max_points)s points (%(percentage)s%%)"
 msgstr "%(points)s/%(max_points)s分 (%(percentage)s%%)"
 
-#: .\course\templates\course\gradebook-single.html:94
-#: .\course\templates\course\gradebook-single.html:253
 msgid "(no grade)"
 msgstr "(暂无)"
 
-#: .\course\templates\course\gradebook-single.html:105
 #, python-format
 msgid "(from flow session %(gchange_flow_session_id)s)"
 msgstr "(来自flow session %(gchange_flow_session_id)s)"
 
-#: .\course\templates\course\gradebook-single.html:143
 msgid "Pages"
 msgstr ""
 
 #. Translators: means "Started at", which followed by a time string
-#: .\course\templates\course\gradebook-single.html:171
 msgid "Started"
 msgstr "开始于"
 
 #. Translators: means "Completed at", which followed by a time string
-#: .\course\templates\course\gradebook-single.html:176
 msgid "Completed"
 msgstr "结束于"
 
 #. Translators: means "Last activity at", which followed by a time string
-#: .\course\templates\course\gradebook-single.html:180
 msgid "Last activity"
 msgstr "最后的操作"
 
-#: .\course\templates\course\gradebook-single.html:201
 #, python-format
 msgid "(grade not available) (%(max_points)s points achievable)"
 msgstr "(尚未评分) (最高可得到%(max_points)s分)"
 
-#: .\course\templates\course\gradebook-single.html:211
 msgid " Notes:"
 msgstr "注释："
 
-#: .\course\templates\course\gradebook-single.html:224
 msgid "Page"
 msgstr ""
 
-#: .\course\templates\course\gradebook-single.html:225
 msgid "Percent"
 msgstr "百分比"
 
-#: .\course\templates\course\gradebook-single.html:279
 msgid "Impose deadline"
 msgstr "实施截止"
 
-#: .\course\templates\course\gradebook-single.html:285
 msgid "End and grade"
 msgstr "结束session并评分"
 
-#: .\course\templates\course\gradebook-single.html:298
 msgid "Recalculate grade"
 msgstr "重新计算评分"
 
-#: .\course\templates\course\grading-statistics.html:5
 msgid "Grader Statistics"
 msgstr "评分统计"
 
-#: .\course\templates\course\grading-statistics.html:9
 msgid "Grader Statistics: "
 msgstr "评分统计"
 
-#: .\course\templates\course\grading-statistics.html:12
 msgid ""
 "(No information about grading work distribution for human-graded problems "
 "available.)"
 msgstr "(对于人工评分的问题，没有可用的评分分布信息.)"
 
-#: .\course\templates\course\grading-statistics.html:26
-#: .\course\templates\course\grading-statistics.html:38
 msgid "Total"
 msgstr "总计"
 
-#: .\course\templates\course\home.html:7
 #, python-format
 msgid " Welcome to %(RELATE)s "
 msgstr "欢迎来到%(RELATE)s "
 
-#: .\course\templates\course\home.html:8
 msgid "RELATE is an Environment for Learning And TEaching"
 msgstr ""
 
-#: .\course\templates\course\home.html:10
 msgid "Learn more"
 msgstr "了解更多"
 
-#: .\course\templates\course\home.html:21
 msgid "View"
 msgstr "查看"
 
-#: .\course\templates\course\home.html:27
 msgid "Past Courses"
 msgstr "以往的课程"
 
-#: .\course\templates\course\home.html:51
 #, python-format
 msgid "There are no courses hosted on this %(RELATE)s site."
 msgstr "本(%(RELATE)s)网站还没有挂载课程. "
 
-#: .\course\templates\course\home.html:54
 #, python-format
 msgid "<a href=\"%(relate-sign_in_by_user_pw)s\">Sign in</a> to get started."
 msgstr "<a href=\"%(relate-sign_in_by_user_pw)s\">登录</a> 以开始使用. "
 
-#: .\course\templates\course\home.html:61 .\course\versioning.py:346
 msgid "Set up new course"
 msgstr "设置新课程"
 
-#: .\course\templates\course\human-feedback-form.html:9
 msgid "Rubric"
 msgstr "评分标准(rubric)"
 
-#: .\course\templates\course\invalid-datespec-list.html:5
 msgid "Event validity check"
 msgstr "Event有效性检查"
 
-#: .\course\templates\course\invalid-datespec-list.html:8
 msgid ""
 "The following events were found in course content that are not present in "
 "the database:"
 msgstr "发现课程内容中以下的events并未列入数据库中："
 
-#: .\course\templates\course\invalid-datespec-list.html:26
 msgid "Unrecognized events were found."
 msgstr "发现无法识别的events. "
 
-#: .\course\templates\course\invalid-datespec-list.html:30
 msgid ""
 "Check the \"Calendar\" functions in the instructor menu to add the missing "
 "labels."
 msgstr "检查“任课老师”菜单中的“课程日程”功能以添加缺失的标签. "
 
-#: .\course\templates\course\invalid-datespec-list.html:39
 msgid "No unrecognized events were found."
 msgstr "没有可识别的events. "
 
-#: .\course\templates\course\keypair.html:5
 msgid "SSH Key Pair"
 msgstr ""
 
-#: .\course\templates\course\keypair.html:7
 msgid "Private key:"
 msgstr "私有密钥:"
 
-#: .\course\templates\course\keypair.html:8
 msgid ""
 "Copy and paste this block of text into the 'private key' field in RELATE."
 msgstr "将这块文本复制粘贴到网站的\"私有密钥\"字段中."
 
-#: .\course\templates\course\keypair.html:13
 msgid "Public key:"
 msgstr "公共密钥:"
 
-#: .\course\templates\course\keypair.html:14
 msgid ""
 "On Bitbucket, GitHub, or an other repository hosting site, add this snippet "
 "as an \"SSH Key\" to your user profile or as a \"Deployment key\" to your "
@@ -5082,27 +4037,21 @@ msgstr ""
 "在Bitbucket, Github或其它代码仓库托管网站，把这段代码设为你的用户\"SSH Key"
 "\"，或者作为你的仓库一个的\"Deployment key\"."
 
-#: .\course\templates\course\list-exams.html:5
 msgid "Available Exams"
 msgstr "进行中的测验"
 
-#: .\course\templates\course\list-exams.html:20
 msgid "Take exam"
 msgstr "参加测验"
 
-#: .\course\templates\course\list-exams.html:26
 msgid "(No exams available.)"
 msgstr "(尚无可用的测验)"
 
-#: .\course\templates\course\list-exams.html:28
 msgid "(No exams available. Please sign in to continue.)"
 msgstr "(尚无可用的测验. 请登录以继续.)"
 
-#: .\course\templates\course\login-by-email.html:7
 msgid "Sign in or create account"
 msgstr "登录 或 新建帐户"
 
-#: .\course\templates\course\login-by-email.html:12
 #, python-format
 msgid ""
 "If you cannot or would not like to sign in by email, <a href=\"%(relate-"
@@ -5114,7 +4063,6 @@ msgstr ""
 #. Translators: For courses which require specific email suffix for enrollment, translate the following literals
 #. with your customized email suffix.
 #.
-#: .\course\templates\course\login-by-email.html:24
 msgid ""
 "Please use the <em>official</em> email address associated with the "
 "institution at which this course is taking place. Some courses may require a "
@@ -5123,7 +4071,6 @@ msgstr ""
 "一些课程要求用特定的电子邮件后缀(例如“@scut.edu.cn”)用于申请课程, 请与课程管"
 "理人员确认. 如果是这样, 请使用指定的 <em>官方</em> 电子邮箱. "
 
-#: .\course\templates\course\login.html:12
 #, python-format
 msgid ""
 "If you cannot or would not like to sign in using a RELATE-specific user name "
@@ -5133,20 +4080,17 @@ msgstr ""
 "如果你不能或者不喜欢使用RELATE用户名密码方式登入，请<a href='%(relate-"
 "sign_in_choice)s%(next_uri)s'>尝试使用别的方式登录</a>."
 
-#: .\course\templates\course\login.html:21
 msgid ""
 "Note that the user name and password needed to use this form is <em>not</em> "
 "the user name and password you may have been assigned by your institution."
 msgstr ""
 "注意：这里设定的用户名和密码<em>并不是</em>你所属机构网站的登录用户名密码."
 
-#: .\course\templates\course\login.html:31
 #, python-format
 msgid ""
 "If you do not have an account, <a href='%(relate-sign_up)s'>sign up</a>."
 msgstr "如果您还没有帐号，请 <a href='%(relate-sign_up)s'>注册</a> . "
 
-#: .\course\templates\course\login.html:36
 #, python-format
 msgid ""
 "If you do not remember your password, <a href=\"%(relate-reset_password)s\"> "
@@ -5155,22 +4099,16 @@ msgstr ""
 "如果您不记得您的密码，请 <a href=\"%(relate-reset_password)s\">重置密码</"
 "a> . "
 
-#: .\course\templates\course\participation-table.html:9
 msgid "Status"
 msgstr "状态"
 
 #. Translators: "set-up" stands for set-up code for code question
-#: .\course\templates\course\prompt-code-question.html:10
 msgid "Problem set-up code"
 msgstr "问题设置代码"
 
-#: .\course\templates\course\prompt-code-question.html:11
-#: .\course\templates\course\prompt-code-question.html:40
-#: .\course\templates\course\prompt-code-question.html:69
 msgid "(click to view)"
 msgstr "(点击查看)"
 
-#: .\course\templates\course\prompt-code-question.html:18
 msgid ""
 "This is the code that is used to set up the problem and produce test data "
 "for your submission. It is reproduced here for your information, or if you "
@@ -5178,12 +4116,14 @@ msgid ""
 "copy/paste this code into the code box below. This code is run automatically "
 "'behind the scenes' before your submitted code."
 msgstr ""
+"这部分代码是用来设定问题以及产生您提交结果测试数据的代码。将其展示在这里是为"
+"了向您提供信息，或者您想在RELATE网站之外时使用这部分代码。请您 <strong>不要</"
+"strong> 把这部分代码 复制/粘贴 到下面的代码框中。当您提交代码时，这部分代码会"
+"自动在后台运行。"
 
-#: .\course\templates\course\prompt-code-question.html:39
 msgid "Testing code"
 msgstr "测试代码"
 
-#: .\course\templates\course\prompt-code-question.html:47
 msgid ""
 "This is the code that is used to generate feedback for your submission. It "
 "is reproduced here for your information, or if you would like to run your "
@@ -5191,45 +4131,38 @@ msgid ""
 "into the code box below. This code is run automatically 'behind the scenes' "
 "after your submitted code."
 msgstr ""
+"这部分代码是用来产生您提交的代码所得到的反馈信息。将其展示在这里是为了向您提"
+"供信息，或者您想在RELATE网站之外时使用这部分代码。请您 <strong>不要</strong> "
+"把这部分代码 复制/粘贴 到下面的代码框中。当您提交代码时，这部分代码会自动在后"
+"台运行。"
 
 #. Translators: starter code for code question
-#: .\course\templates\course\prompt-code-question.html:68
 msgid "Starter code"
 msgstr "起始代码"
 
-#: .\course\templates\course\query-participations.html:7
-#: .\course\templates\course\query-participations.html:15
 msgid "Query Participations"
 msgstr "查询课程参与"
 
-#: .\course\templates\course\query-participations.html:24
 msgid "No matches"
 msgstr "未找到匹配项"
 
-#: .\course\templates\course\sandbox-markup.html:12
 msgid "Markup Sandbox"
 msgstr "Markup沙箱"
 
 #. Translators: "[SB]" is abbreviation for "Sandbox"
-#: .\course\templates\course\sandbox-page.html:10
 #, python-format
 msgid "[SB] %(title)s"
 msgstr "[沙箱] %(title)s"
 
-#: .\course\templates\course\sandbox-page.html:14
-#: .\course\templates\course\sandbox-page.html:23
 msgid "Page Sandbox"
 msgstr "Page沙箱"
 
-#: .\course\templates\course\sandbox-page.html:35
 msgid "Warnings were encountered when validating the page:"
 msgstr "验证页面时遇到了如下的警告:"
 
-#: .\course\templates\course\sandbox-page.html:83
 msgid "(Page preview appears here)"
 msgstr "(在这里预览Page)"
 
-#: .\course\templates\course\sign-in-email.txt:2
 #, python-format
 msgid ""
 "\n"
@@ -5250,25 +4183,20 @@ msgstr ""
 "%(home_uri)s\n"
 "输入了您的电子邮件. 如果不是您操作的, 可忽略此邮件. \n"
 
-#: .\course\templates\course\static-page.html:6
 msgid "Jump to"
 msgstr "转到"
 
-#: .\course\templates\course\submit-notify.txt:1
 #, python-format
 msgid "Dear course staff of %(course_identifier)s,"
 msgstr "尊敬的%(course_identifier)s课务人员,"
 
-#: .\course\templates\course\submit-notify.txt:3
 #, python-format
 msgid "Participant '%(participant)s'"
 msgstr "学员 '%(participant)s'"
 
-#: .\course\templates\course\submit-notify.txt:3
 msgid "A participant"
 msgstr "一位学员"
 
-#: .\course\templates\course\submit-notify.txt:3
 #, python-format
 msgid ""
 " has just submitted his/her work on '%(flow_id)s'.\n"
@@ -5281,54 +4209,43 @@ msgstr ""
 "请点击以下链接来审阅：\n"
 "%(review_uri)s\n"
 
-#: .\course\templates\course\task-monitor.html:12
 msgid "Task Progress"
 msgstr "任务进程"
 
-#: .\course\templates\course\task-monitor.html:22
 msgid "Progress"
 msgstr "进程"
 
-#: .\course\templates\course\task-monitor.html:54
 msgid "The process failed and reported the following error:"
 msgstr "该过程进行失败，并报告了以下错误:"
 
-#: .\course\utils.py:488
 msgid "grading rule determination was unable to find a grading rule"
 msgstr "无法为评分找到规则"
 
-#: .\course\utils.py:540
 #, python-format
 msgid ""
 "Preview revision '%s' does not exist--showing active course content instead."
 msgstr "预览 '%s' 不存在 -- 所以这里显示课程的内容"
 
-#: .\course\utils.py:821
 msgid "Press F9 to toggle full-screen mode. "
 msgstr "按F9以打开/关闭全屏模式. "
 
-#: .\course\utils.py:822
 #, python-format
 msgid "Set editor mode in <a href='%s'>user profile</a>."
 msgstr "在 <a href='%s'>用户信息</a> 中设置编辑器模式. "
 
-#: .\course\utils.py:963
 msgid ""
 "Error: Columns to be imported contain non-ASCII characters. Please save your "
 "CSV file as utf-8 encoded and import again."
 msgstr ""
 "错误: 需导入的列中含有非ASCII字符. 请将CSV文件转换为utf8格式后再尝试导入."
 
-#: .\course\validation.py:70 .\course\validation.py:78
 msgid "invalid identifier"
 msgstr "无效的identifier"
 
-#: .\course\validation.py:96
 #, python-format
 msgid "invalid role '%(role)s'"
 msgstr "无效的角色 \"%(role)s\""
 
-#: .\course\validation.py:110
 #, python-format
 msgid ""
 "Name of facility not recognized: '%(fac_name)s'. Known facility names: '%"
@@ -5337,79 +4254,62 @@ msgstr ""
 "教学设施名称无法识别: '%(fac_name)s'. 已知的教学设施名包括: '%"
 "(known_fac_names)s'"
 
-#: .\course\validation.py:158
 #, python-format
 msgid "attribute '%(attr)s' missing"
 msgstr "缺少\"%(attr)s\"属性"
 
-#: .\course\validation.py:176
 #, python-format
 msgid ""
 "attribute '%(attr)s' has wrong type: got '%(name)s', expected '%(allowed)s'"
 msgstr "属性\"%(attr)s\"的类型错误: 设置为\"%(name)s\", 应该为\"%(allowed)s\""
 
-#: .\course\validation.py:191
 #, python-format
 msgid "extraneous attribute(s) '%(attr)s'"
 msgstr "冗余的外部属性 \"%(attr)s\""
 
-#: .\course\validation.py:312
 msgid "Uses deprecated 'start' attribute--use 'if_after' instead"
 msgstr "使用了已淘汰的(deprecated)\"start'属性 -- 建议改为使用'if_after\""
 
-#: .\course\validation.py:318
 msgid "Uses deprecated 'end' attribute--use 'if_before' instead"
 msgstr "使用了已淘汰的(deprecated)\"end'属性 -- 建议改为使用'if_before\""
 
-#: .\course\validation.py:324
 msgid "Uses deprecated 'roles' attribute--use 'if_has_role' instead"
 msgstr "使用了已淘汰的(deprecated)\"roles'属性 -- 建议改为使用'if_has_role\""
 
-#: .\course\validation.py:356
 msgid "no title present"
 msgstr ""
 
-#: .\course\validation.py:387
 msgid "must have either 'chunks' or 'content'"
 msgstr "必须有'chunks'或'content'"
 
-#: .\course\validation.py:414
 #, python-format
 msgid "chunk id '%(chunkid)s' not unique"
 msgstr "chunk id \"%(chunkid)s\" 应是唯一的"
 
-#: .\course\validation.py:431
 msgid "flow page has no ID"
 msgstr "flow page没有ID"
 
-#: .\course\validation.py:449
 msgid "could not instantiate flow page"
 msgstr "无法初始化flow page"
 
-#: .\course\validation.py:485
 #, python-format
 msgid "group '%(group_id)s': group is empty"
 msgstr "group \"%(group_id)s\": group 是空的"
 
-#: .\course\validation.py:492
 #, python-format
 msgid "group '%(group_id)s': max_page_count is not positive"
 msgstr "group \"%(group_id)s\": max_page_count 不是正数"
 
-#: .\course\validation.py:505
 #, python-format
 msgid "page id '%(page_desc_id)s' not unique"
 msgstr "page id \"%(page_desc_id)s\" 应是唯一的"
 
-#: .\course\validation.py:561
 msgid "attribute 'may_start_new_session' is not present"
 msgstr "没有找到\"may_start_new_session\"属性"
 
-#: .\course\validation.py:565
 msgid "attribute 'may_list_existing_sessions' is not present"
 msgstr "没有找到\"may_list_existing_sessions\"属性"
 
-#: .\course\validation.py:569
 msgid ""
 "Attribute 'lock_down_as_exam_session' is deprecated and non-functional. Use "
 "the access permission flag 'lock_down_as_exam_session' instead."
@@ -5417,52 +4317,49 @@ msgstr ""
 "属性'lock_down_as_exam_session'已经淘汰，请在access permission中使"
 "用'lock_down_as_exam_session'."
 
-#: .\course\validation.py:583 .\course\validation.py:643
-#: .\course\validation.py:749
 #, python-format
 msgid "invalid tag '%(tag)s'"
 msgstr "无效的 tag \"%(tag)s\""
 
-#: .\course\validation.py:592
 #, python-format
 msgid "invalid default expiration mode '%(expiremode)s'"
 msgstr "无效的过期模式默认值 \"%(expiremode)s\""
 
-#: .\course\validation.py:651
 #, python-format
 msgid "invalid expiration mode '%(expiremode)s'"
 msgstr "无效的过期模式 \"%(expiremode)s\""
 
-#: .\course\validation.py:668
 msgid ""
 "Rule specifies 'submit_answer' or 'end_session' permissions for non-in-"
 "progress flow. These permissions will be ignored."
 msgstr ""
+"在非进行中的flow的Rule中设置了'submit_answer'或'end_session'的权限，这些权限"
+"将被忽略."
 
-#: .\course\validation.py:715
 msgid ""
 "'grade_identifier' attribute found. This attribute is no longer allowed here "
 "and should be moved upward into the 'rules' block."
 msgstr ""
+"发现'grade_identifier'属性. 该属性不再允许在这里设置，应向上移到'rules'块中."
 
-#: .\course\validation.py:724
 msgid ""
 "'grade_aggregation_strategy' attribute found. This attribute is no longer "
 "allowed here and should be moved upward into the 'rules' block."
 msgstr ""
+"发现'grade_aggregation_strategy'属性. 该属性不再允许在这里设置，应向上移"
+"到'rules'块中."
 
-#: .\course\validation.py:760
 msgid "'generates_grade' is true, but no 'grade_identifier'is given."
-msgstr ""
+msgstr "'generates_grade'设为true, 但没有设置'grade_identifier'."
 
-#: .\course\validation.py:789
 msgid ""
 "'rules' block does not have a grade_identifier attribute. This attribute "
 "needs to be moved out of the lower-level 'grading' rules block and into the "
 "'rules' block itself."
 msgstr ""
+"'rules'块没有'grade_identifier'属性. 该属性应移出低一级的'grading'规则块，并"
+"移入'rule'块中."
 
-#: .\course\validation.py:828
 #, python-format
 msgid ""
 "flows that have a grade identifier ('%(identifier)s') must have grading "
@@ -5471,23 +4368,18 @@ msgstr ""
 "设置了grade identifier(%(identifier)s)的flow, 必须有"
 "grade_aggregation_strategy的评分规则"
 
-#: .\course\validation.py:844
 msgid "invalid grade aggregation strategy"
 msgstr "无效的多session评分累积策略"
 
-#: .\course\validation.py:855
 msgid "'grading' block is required if grade_identifier is not null/None."
-msgstr ""
+msgstr "当'grade_identifier'不是null或None时, 需要设置'grading'块."
 
-#: .\course\validation.py:866
 msgid "rules/grading: may not be an empty list"
-msgstr ""
+msgstr "rules/grading不能是一个空的list"
 
-#: .\course\validation.py:881
 msgid "rules/grading: last grading rule must be unconditional"
 msgstr "rules/grading: 最后一个grading rule必须是无条件的"
 
-#: .\course\validation.py:893
 msgid ""
 "Uses deprecated 'modify' permission--replace by 'submit_answer' and "
 "'end_session'"
@@ -5495,7 +4387,6 @@ msgstr ""
 "使用了已淘汰的(deprecated)权限\"modify\" -- 请改为"
 "\"submit_answer'和'end_session\""
 
-#: .\course\validation.py:899
 msgid ""
 "Uses deprecated 'see_answer' permission--replace by "
 "'see_answer_after_submission'"
@@ -5503,66 +4394,57 @@ msgstr ""
 "使用了已淘汰的(deprecated)权限\"see_answer\" -- 请改为"
 "\"see_answer_after_submission\""
 
-#: .\course\validation.py:906
 #, python-format
 msgid "invalid flow permission '%(permission)s'"
 msgstr "无效的flow权限 \"%(permission)s\""
 
-#: .\course\validation.py:946
 msgid "must have either 'groups' or 'pages'"
 msgstr "必须有'groups'或'pages'"
 
-#: .\course\validation.py:968
 #, python-format
 msgid "group %(group_index)d ('%(group_id)s'): 'pages' is not a list"
 msgstr "group %(group_index)d ('%(group_id)s'): 'page'不是一个list"
 
-#: .\course\validation.py:983
 #, python-format
 msgid "group %(group_index)d ('%(group_id)s'): no pages found"
 msgstr "group %(group_index)d ('%(group_id)s'): 找不到page"
 
-#: .\course\validation.py:991
 #, python-format
 msgid "%s: no pages found"
 msgstr "%s: 找不到page"
 
-#: .\course\validation.py:1004
 #, python-format
 msgid "group id '%(group_id)s' not unique"
 msgstr "group id \"%(group_id)s\" 应该是唯一的"
 
-#: .\course\validation.py:1026
 #, python-format
 msgid "notify_on_submit: item %d is not a string"
 msgstr "notify_on_submit: 项目%d不是一个字符串"
 
-#: .\course\validation.py:1032
 #, python-format
 msgid ""
 "Attribute '%s' is deprecated as part of a flow. Specify it as part of a "
 "grading rule instead."
 msgstr "'%s'已经不再作为flow的属性设置, 请在grading rule中设置它."
 
-#: .\course\validation.py:1165
 msgid "Access class 'public' is deprecated. Use 'unenrolled' instead."
 msgstr "Access类的'public'已经淘汰, 请使用'unenrolled'."
 
-#: .\course\validation.py:1170
 #, python-format
 msgid ""
 "%s: access classes 'public' and 'unenrolled' may not exist simultaneously."
 msgstr "%s: access类中不能同时有'public'和'unenrolled'."
 
-#: .\course\validation.py:1233
 msgid ""
 "{location}: existing grading opportunity with identifier "
 "'{grade_identifier}' refers to flow '{other_flow_id}', however flow code in "
 "this flow ('{new_flow_id}') specifies the same grade identifier. (Have you "
 "renamed the flow? If so, edit the grading opportunity to match.)"
 msgstr ""
+"{location}: 现有的以'{grade_identifier}'作为grade_identifier的评分机会指向的"
+"是flow '{other_flow_id}', 然而本flow('{new_flow_id}')中的代码设定使用了同一个"
+"grade_identifier. (您是否重命名了该flow? 如果是，请编辑评分机会以保持匹配.)"
 
-#: .\course\validation.py:1272
 #, python-format
 msgid ""
 "%(loc)s, group '%(group)s', page '%(page)s': page type ('%(type_new)s') "
@@ -5571,12 +4453,10 @@ msgstr ""
 "%(loc)s, group '%(group)s', page '%(page)s': page type ('%(type_new)s') 与数"
 "据库中使用的type不同 ('%(type_old)s')"
 
-#: .\course\validation.py:1303
 #, python-format
 msgid "Your course repository does not have an events file named '%s'."
 msgstr "您课程的仓库中并不包含一个名为'%s'的事件文件."
 
-#: .\course\validation.py:1346
 msgid ""
 "Your course repository has a 'media/' directory. Linking to media files "
 "using 'media:' is discouraged. Use the 'repo:' and 'repocur:' linkng schemes "
@@ -5585,159 +4465,125 @@ msgstr ""
 "你课程的仓库中有一个'media/'目录. 不建议使用'media:'来链接到媒体文件. 建议改"
 "为使用'repo:'和'repocur:'来链接到你的方案(schemes)."
 
-#: .\course\validation.py:1371
 msgid ""
 "invalid flow name. Flow names may only contain (roman) letters, numbers, "
 "dashes and underscores."
 msgstr "无效的flow名称. flow的名称只能有英文字母、数字、减号和下划线. "
 
-#: .\course\validation.py:1396
 msgid "flow uses the same grade_identifier as another flow"
 msgstr "本flow使用了与另一个flow相同的grade_identifier"
 
-#: .\course\validation.py:1435
 msgid ""
 "invalid page name. Page names may only contain alphanumeric characters (any "
 "language) and hyphens."
 msgstr "无效的page名称. page的名称只能有英文字母、数字、减号. "
 
-#: .\course\validation.py:1532
 msgid "WARNINGS: "
 msgstr "警告："
 
-#: .\course\versioning.py:214
 msgid "Validate and create"
 msgstr "验证并创建课程"
 
-#: .\course\versioning.py:219
 msgid "Git source must be specified"
 msgstr "必须设定git源"
 
-#: .\course\versioning.py:252
 msgid ""
 "No refs found in remote repository (i.e. no master branch, no HEAD). This "
 "looks very much like a blank repository. Please create course.yml in the "
 "remote repository before creating your course."
 msgstr ""
+"在远程仓库中未找到参照（即，无master分支，无HEAD). 这很可能是因为该仓库是一个"
+"空仓库. 在创建您的课程时，请在远程仓库中创建course.yml文件."
 
-#: .\course\versioning.py:295
 msgid "Course content validated, creation succeeded."
 msgstr "课程内容有效性验证完成, 创建成功. "
 
-#: .\course\versioning.py:321
 #, python-format
 msgid "Failed to delete unused repository directory '%s'."
 msgstr "无法删除未使用的代码仓库目录\"%s\"."
 
-#: .\course\versioning.py:333
 msgid "Course creation failed"
 msgstr "课程创建失败"
 
-#: .\course\versioning.py:382
 msgid "no git source URL specified"
 msgstr "未设定git源的URL"
 
-#: .\course\versioning.py:395
 msgid "fetch would discard commits, refusing"
 msgstr "fetch将会放弃修改, 拒绝fetch"
 
-#: .\course\versioning.py:399
 msgid "Fetch successful."
 msgstr "fetch成功. "
 
-#: .\course\versioning.py:411 .\course\versioning.py:460
 msgid "Preview ended."
 msgstr "预览已结束. "
 
-#: .\course\versioning.py:424
 #, python-format
 msgid "Course content did not validate successfully. (%s) Update not applied."
 msgstr "课程内容有效性验证不成功, (%s) 未应用更新. "
 
-#: .\course\versioning.py:431
 msgid "Course content validated successfully."
 msgstr "课程内容有效性验证成功. "
 
-#: .\course\versioning.py:435
 msgid "Course content validated OK, with warnings: "
 msgstr "课程内容有效性验证成功, 但有警告信息:"
 
-#: .\course\versioning.py:446
 msgid "Preview activated."
 msgstr "预览状态已激活. "
 
-#: .\course\versioning.py:463
 msgid "Update applied. "
 msgstr "更新已应用. "
 
-#: .\course\versioning.py:466 .\course\versioning.py:585 .\course\views.py:891
 msgid "invalid command"
 msgstr "无效的命令"
 
-#: .\course\versioning.py:505
 msgctxt "new git SHA for revision of course contents"
 msgid "New git SHA"
 msgstr "新的git SHA"
 
-#: .\course\versioning.py:508
 msgid "Prevent updating to a git revision prior to the current one"
 msgstr "防止更新到当前git修订版本之前的版本."
 
-#: .\course\versioning.py:516
 msgid "Fetch and update"
 msgstr "fetch并更新"
 
-#: .\course\versioning.py:520
 msgid "End preview"
 msgstr "结束预览"
 
-#: .\course\versioning.py:522
 msgid "Fetch and preview"
 msgstr "fetch并预览"
 
-#: .\course\versioning.py:525
 msgid "Fetch"
 msgstr ""
 
-#: .\course\versioning.py:540
 msgid "- not found -"
 msgstr "- 未找到 -"
 
-#: .\course\versioning.py:624
 msgid "Git Source URL"
 msgstr "Git源URL"
 
-#: .\course\versioning.py:629
 msgid "Public active git SHA"
 msgstr "公开运行的git SHA"
 
-#: .\course\versioning.py:638
 msgid "Current git HEAD"
 msgstr "当前的git HEAD"
 
-#: .\course\versioning.py:648 .\course\versioning.py:659
 msgid "Current preview git SHA"
 msgstr "当前预览的git SHA"
 
-#: .\course\versioning.py:661
 msgid "None"
 msgstr "无"
 
-#: .\course\versioning.py:673
 msgid "Update Course Revision"
 msgstr "更新对课程内容的修订"
 
-#: .\course\views.py:155 .\course\views.py:157
 msgid "course page is currently hidden"
 msgstr "课程页面当前被隐藏. "
 
-#: .\course\views.py:182
 msgid ""
 "Your enrollment request is pending. You will be notified once it has been "
 "acted upon."
 msgstr "您的加入课程申请处于等待状态, 如果该申请被受理, 您将会立即收到通知. "
 
-#: .\course\views.py:192
 #, python-format
 msgid ""
 "This course uses institutional ID for enrollment preapproval, please <a "
@@ -5747,7 +4593,6 @@ msgstr ""
 "本课程启用学号预批准课程申请，请在您的个人信息中<a href='%s' role='button' "
 "class='btn btn-md btn-primary'>填写学号&nbsp;&raquo;</a>."
 
-#: .\course\views.py:207
 msgid ""
 "Your institutional ID is not verified or preapproved. Please contact your "
 "course staff."
@@ -5755,145 +4600,110 @@ msgstr "您的学号没有得到预批准或者未获得认定，请联系您的
 
 #. Translators: "set" fake time.
 #. Translators: "set" fake facility.
-#: .\course\views.py:375 .\course\views.py:485
 msgid "Set"
 msgstr "设定"
 
 #. Translators: "unset" fake time.
 #. Translators: "unset" fake facility.
-#: .\course\views.py:378 .\course\views.py:488
 msgid "Unset"
 msgstr "恢复正常"
 
-#: .\course\views.py:417
-msgid "only staff may set fake time"
-msgstr "只有课务人员可以设置虚拟时间"
+msgid "may not set fake time"
+msgstr "不允许设置虚拟时间"
 
-#: .\course\views.py:441 .\relate\templates\base-page-top.html:41
-#: .\relate\templates\base.html:77
 msgid "Set fake time"
 msgstr "设置虚拟时间"
 
-#: .\course\views.py:466
 msgid "Facilities"
 msgstr "教学设施(facility)"
 
-#: .\course\views.py:467
 msgid "Facilities you wish to pretend to be in"
 msgstr "你想假装置身其中的教学设施"
 
-#: .\course\views.py:470
 msgid "Custom facilities"
 msgstr "自定义教学设施"
 
-#: .\course\views.py:472
 msgid ""
 "More (non-predefined) facility names, separated by commas, which would like "
 "to pretend to be in"
 msgstr "更多的(未定义的)用于假装置身其中的教学设施名称, 用逗号分隔"
 
-#: .\course\views.py:478
 msgid "Add fake facililities header"
 msgstr "添加虚拟教学设施header"
 
-#: .\course\views.py:479
 msgid ""
 "Add a page header to every page rendered while pretending to be in a "
 "facility, as a reminder that this pretending is in progress."
 msgstr "为所有虚拟教学设备的页面添加header，以提示目前正在虚拟过程中."
 
-#: .\course\views.py:493
-msgid "only staff may set fake facility"
-msgstr "只有课务人员可以设置虚拟教学设施"
-
-#: .\course\views.py:527
 msgid "Pretend to be in Facilities"
 msgstr "假装置身于教学设施中"
 
-#: .\course\views.py:556
 msgctxt "Duration for instant flow"
 msgid "Duration in minutes"
 msgstr "时长(分钟)"
 
-#: .\course\views.py:561
 msgctxt "Add an instant flow"
 msgid "Add"
 msgstr "添加"
 
-#: .\course\views.py:565
 msgctxt "Cancel all instant flow(s)"
 msgid "Cancel all"
 msgstr "全部取消"
 
-#: .\course\views.py:618
 msgid "Manage Instant Flow Requests"
 msgstr "管理即时Flow"
 
-#: .\course\views.py:641
 msgctxt "Start an activity"
 msgid "Go"
 msgstr "前往"
 
-#: .\course\views.py:670
 msgid "Test Flow"
 msgstr "测试flow"
 
-#: .\course\views.py:701
 msgid "Select participant for whom exception is to be granted."
 msgstr "选择需要给予破例的用户. "
 
-#: .\course\views.py:715 .\course\views.py:806
 msgctxt "Next step"
 msgid "Next"
 msgstr "下一步"
 
-#: .\course\views.py:722 .\course\views.py:815 .\course\views.py:1056
 msgid "may not grant exceptions"
 msgstr "不允许实施破例"
 
-#: .\course\views.py:742 .\course\views.py:928 .\course\views.py:1219
 msgid "Grant Exception"
 msgstr "给予破例"
 
 #. Translators: %s is the string of the start time of a session.
-#: .\course\views.py:751
 #, python-format
 msgid "started at %s"
 msgstr "开始于%s"
 
-#: .\course\views.py:770
 msgid ""
 "If you click 'Create session', this tag will be applied to the new session."
 msgstr "如果您点击\"创建session\", 这个tag将会应用到新的session. "
 
-#: .\course\views.py:772
 msgid "Access rules tag for new session"
 msgstr "新session的访问规则tag"
 
-#: .\course\views.py:778
 msgid "Create session (override rules)"
 msgstr "创建session(覆盖rules)"
 
-#: .\course\views.py:783
 msgid "Create session"
 msgstr "创建session"
 
-#: .\course\views.py:796
 msgid ""
 "The rules that currently apply to selected session will provide the default "
 "values for the rules on the next page."
 msgstr "选定session所采用的rule将为作为下一个page所采用rule的默认值. "
 
-#: .\course\views.py:824
 #, python-format
 msgid "Granting exception to '%(participation)s' for '%(flow_id)s'."
 msgstr "对%(participation)s的%(flow_id)s给予破例."
 
-#: .\course\views.py:845 .\course\views.py:849
 msgid "NONE"
 msgstr "无"
 
-#: .\course\views.py:861
 msgid ""
 "Creating a new session is (technically) not allowed by course rules. "
 "Clicking 'Create Session' anyway will override this rule."
@@ -5901,24 +4711,19 @@ msgstr ""
 "根据课程的设定, (从技术上)不允许创建一个新的session. 点击\"创建session\"将覆"
 "盖掉这个规则. "
 
-#: .\course\views.py:951
 msgid "Exception only applies to sessions with the above tag"
 msgstr "只有有以上tag的session才能采取破例措施. "
 
-#: .\course\views.py:963
 msgid "If set, an exception for the access rules will be created."
 msgstr "如果设定，将创建一个属于该access rule的例外. "
 
-#: .\course\views.py:965
 msgid "Create access rule exception"
 msgstr "创建access rule下的破例"
 
-#: .\course\views.py:972
 msgctxt "Time when access expires"
 msgid "Access expires"
 msgstr "访问到期时间"
 
-#: .\course\views.py:973
 msgid ""
 "At the specified time, the special access granted below will expire and "
 "revert to being the same as for the rest of the class. This field may be "
@@ -5931,23 +4736,18 @@ msgstr ""
 "date\"和'credit percent\"也不会过期, 并且始终保持有效, 除非被其它的破例措施覆"
 "盖. "
 
-#: .\course\views.py:991
 msgid "If set, an exception for the grading rules will be created."
 msgstr "如果设定，将创建一个属于该评分规则下的例外. "
 
-#: .\course\views.py:993
 msgid "Create grading rule exception"
 msgstr "创建评分规则的破例"
 
-#: .\course\views.py:995
 msgid "If set, the 'Due' field will be disregarded."
 msgstr "如果选定, 则“截止时间”的设定将不被考虑. "
 
-#: .\course\views.py:998
 msgid "Due same as access expiration"
 msgstr "访问到期，则截止"
 
-#: .\course\views.py:1003
 msgid ""
 "The due time shown to the student. Also, the time after which any session "
 "under these rules is subject to expiration."
@@ -5956,83 +4756,68 @@ msgstr ""
 "date shown to the student. Also, the time after which any session under "
 "these rules is subject to expiration. "
 
-#: .\course\views.py:1011
+msgid "Generates grade"
+msgstr "产生评分"
+
 msgid "Credit percent"
 msgstr "得分百分比"
 
-#: .\course\views.py:1014
 msgid "Bonus points"
 msgstr "加分"
 
-#: .\course\views.py:1017
 msgid "Maximum number of points (for percentage)"
 msgstr "最高得分(按百分比)"
 
-#: .\course\views.py:1020
 msgid "Maximum number of points (enforced cap)"
 msgstr "最高得分(按分数)"
 
-#: .\course\views.py:1037
 msgid "Save"
 msgstr "保存"
 
-#: .\course\views.py:1046
 msgid ""
 "Must specify access expiration if 'due same as access expiration' is set."
 msgstr ""
 "如果设定了与访问同时截止(due same as access expiration), 则必须确定访问截止时"
 "间(access expiration). "
 
-#: .\course\views.py:1115 .\course\views.py:1179
 msgid "newly created exception"
 msgstr "新创建的破例"
 
-#: .\course\views.py:1145
 msgid "Granted excecption"
 msgstr "已给予破例"
 
-#: .\course\views.py:1147
 msgid "credit"
 msgstr "应得分"
 
-#: .\course\views.py:1196
 #, python-format
 msgid "Exception granted to '%(participation)s' for '%(flow_id)s'."
 msgstr "已对%(participation)s的%(flow_id)s给予破例. "
 
-#: .\course\views.py:1222
 #, python-format
 msgid ""
 "Granting exception to '%(participation)s' for '%(flow_id)s' (session %"
 "(session)s)."
 msgstr "对%(participation)s的%(flow_id)s(%(session)s的session)给予破例."
 
-#: .\course\views.py:1239
 msgid "only staff may use this tool"
 msgstr "只有课务人员可以使用这个工具"
 
-#: .\course\views.py:1281
 #, python-format
 msgid "%(current)d out of %(total)d items processed."
 msgstr "%(current)d个(共计%(total)d个)已经处理."
 
-#: .\course\views.py:1341
 msgid "Edit Course"
 msgstr "编辑课程"
 
-#: .\relate\templates\403.html:5
 msgid "403 Forbidden"
 msgstr "403 禁止访问"
 
-#: .\relate\templates\403.html:7
 msgid "Access to the page you requested was denied."
 msgstr "访问此页面的请求被拒绝. "
 
-#: .\relate\templates\403.html:9
 msgid "Here are a few things you could try:"
 msgstr "您可以尝试以下操作："
 
-#: .\relate\templates\403.html:17
 #, python-format
 msgid ""
 "You're not currently signed in. Access to the resource is restricted, and "
@@ -6044,19 +4829,15 @@ msgstr ""
 "访问。如果您已经登录，请通过 <a href=\"%(relate-home)s\">主页</a> 返回课程页"
 "面，然后尝试您的上一次操作。"
 
-#: .\relate\templates\403.html:42
 msgid " Sorry, and thanks for your patience! "
 msgstr "抱歉, 同时感谢您的耐心！"
 
-#: .\relate\templates\404.html:5
 msgid "404 Not Found"
 msgstr "404 网页不存在"
 
-#: .\relate\templates\404.html:8
 msgid "Request URL"
 msgstr "已请求的URL"
 
-#: .\relate\templates\404.html:12
 msgid ""
 "Oops. Either the URL you entered was invalid, or you stumbled on a dead "
 "link. If it was the latter, please get in touch with your course staff to "
@@ -6065,22 +4846,18 @@ msgstr ""
 "噢！要么是您输入的URL无效, 要么您误入了一个死链接. 如果是后者, 请与课程管理人"
 "员联系, 并让他们知道您的什么操作导致了以上错误. "
 
-#: .\relate\templates\404.html:20 .\relate\templates\500.html:18
 #, python-format
 msgid ""
 "In the meantime, you may navigate back to  the <a href=\"%(relate-home)s"
 "\">home page</a>."
 msgstr "同时，您也可以导航回到 <a href=\"%(relate-home)s\">主页</a>. "
 
-#: .\relate\templates\404.html:27 .\relate\templates\500.html:25
 msgid "Sorry, and thanks for your patience!"
 msgstr "抱歉, 同时感谢您的耐心！"
 
-#: .\relate\templates\500.html:5
 msgid "500 Server Error"
 msgstr "500 服务器错误"
 
-#: .\relate\templates\500.html:8
 msgid ""
 "Oops. That shouldn't have happened. Technical details of the error have been "
 "recorded. Please get in touch with your course staff to let them know what "
@@ -6091,71 +4868,56 @@ msgstr ""
 "员联系, 并让他们知道您的什么操作导致了以上错误. 同时请提及您发送报告的时间, "
 "谢谢！"
 
-#: .\relate\templates\admin\base_site.html:6
 #, python-format
 msgid "%(RELATE)s Administration"
 msgstr "%(RELATE)s管理"
 
-#: .\relate\templates\base-page-top.html:35
 #, python-format
 msgid ""
 "You are currently seeing a preview of what the site would look like at %"
 "(fake_time)s."
 msgstr "您现在正在预览这个网站在时间为%(fake_time)s时的样子. "
 
-#: .\relate\templates\base-page-top.html:49
 #, python-format
 msgid ""
 "You are currently seeing a preview of what the site would look like from "
 "inside the facilities  <b>%(facilities)s</b>."
 msgstr "您现在正在预览这个网站在教学设施<b>%(facilities)s</b>打开的样子. "
 
-#: .\relate\templates\base-page-top.html:55 .\relate\templates\base.html:78
 msgid "Pretend to be in facilities"
 msgstr "假装置身于教学设施中"
 
-#: .\relate\templates\base-page-top.html:63
 msgid "Now impersonating"
 msgstr "正在模拟"
 
-#: .\relate\templates\base.html:66
 msgid "Staff"
 msgstr "高级管理"
 
-#: .\relate\templates\base.html:69
 msgid "Admin site"
 msgstr "管理网站"
 
-#: .\relate\templates\base.html:71
-msgid "Test/Troubleshoot"
-msgstr "测试/发现问题"
-
-#: .\relate\templates\base.html:85
 msgid "Issue exam tickets"
 msgstr "发布测验ticket"
 
-#: .\relate\templates\base.html:86
 msgid "Exam check-in"
 msgstr "登入测验"
 
-#: .\relate\templates\base.html:99
+msgid "Test/Troubleshoot"
+msgstr "测试/发现问题"
+
 #, python-format
 msgid "Signed in as %(username)s"
 msgstr "登录用户： %(username)s"
 
-#: .\relate\templates\base.html:106
 msgid "(impersonated)"
 msgstr "(正在模拟用户)"
 
-#: .\relate\templates\djangosaml2\wayf.html:5
 msgid "Institutional Login (SAML2)"
 msgstr "用机构密码登录(SAML2)"
 
-#: .\relate\templates\djangosaml2\wayf.html:6
 msgid "Please select your Identity Provider from the following list:"
 msgstr "请从以下列表选择你的ID提供者: "
 
-#: .\relate\templates\maintenance.html:8
 #, python-format
 msgid ""
 "%(RELATE)s is currently in maintenance mode. Sorry for the interruption, "
@@ -6164,43 +4926,32 @@ msgstr ""
 "%(RELATE)s网站目前正在维护. 我们对因此为你带来不便深表抱歉, 我们很快将会恢"
 "复. "
 
-#: .\relate\templates\sign-in-choice.html:5
 msgid "Sign in to RELATE"
 msgstr "登录RELATE"
 
-#: .\relate\templates\sign-in-choice.html:14
 msgid "Sign in using your institution's login"
 msgstr "使用你所属机构的登录方式"
 
-#: .\relate\templates\sign-in-choice.html:23
 msgid "Sign in using your email"
 msgstr "用您的电子邮件登录"
 
-#: .\relate\templates\sign-in-choice.html:32
 msgid "Sign up for an account"
 msgstr "注册新帐号"
 
-#: .\relate\templates\sign-in-choice.html:41
 msgid "Sign in using an exam ticket"
 msgstr "使用测验ticket登录"
 
-#: .\relate\templates\sign-in-choice.html:49
 msgid "Sign in with a RELATE-specific user name and password"
 msgstr "使用RELATE用户名密码登录"
 
-#: .\relate\templates\sign-out-confirmation.html:5
 msgid "You're already signed in"
 msgstr "您已经登录. "
 
-#: .\relate\templates\sign-out-confirmation.html:6
 msgid "Would you like to sign out and proceed with your previous operation?"
 msgstr "是否要登出，并继续之前的操作？"
 
-#: .\relate\templates\sign-out-confirmation.html:7
-#: .\relate\templates\user-profile-form.html:12
 msgid "Sign out"
 msgstr "退出登录"
 
-#: .\relate\templates\user-profile-form.html:7
 msgid "User Profile"
 msgstr "用户信息"


### PR DESCRIPTION
To reduce the meaningless position diff lines when positions of i18n literal changed.
e.g.

```
python manage.py makemessages -l de --no-location
```