### PR TITLE
display existing exceptions

### DIFF
--- a/course/templates/course/exception-table.html
+++ b/course/templates/course/exception-table.html
@@ -25,27 +25,3 @@
   </table>
 </div>
 {% endif %}
-
-<!-- <table class="table table-striped">
-	<thead>
-    <th class="datacol">{% trans "participant" %}</th>
-    <th class="datacol">{% trans "flow id" %}</th>
-    <th class="datacol">{% trans "kind" %}</th>
-    <th class="datacol">{% trans "expiration" %}</th>
-    <th class="datacol">{% trans "creation time" %}</th>
-    <th class="datacol">{% trans "rules" %}</th>
-
-  </thead>
-	<tbody>
-    {% for participant in participants %}
-    <tr>
-    	<td class="datacol">{{ participant.participation }}</td>
-    	<td class="datacol">{{ participant.flow_id }}</td>
-    	<td class="datacol">{{ participant.kind }}</td>
-    	<td class="datacol">{{ participant.expiration }}</td>
-    	<td class="datacol">{{ participant.creation_time }}</td>
-        <td class="datacol">{{ participant.rule }}</td>
-    </tr>
-    {% endfor %}
-  </tbody>
-</table> -->

--- a/course/templates/course/exception-table.html
+++ b/course/templates/course/exception-table.html
@@ -1,0 +1,51 @@
+{% load i18n %}
+{% if permissions %}
+<h3>{% trans "Existing Excptions" %}</h3>
+<h4>{% trans "Permissions" %}</h4>
+<ul class="list-group row">
+  {% for p in permissions %}
+  <li class="list-group-item col-xs-6">{{ p }}</li>
+  {% endfor %}
+</ul>
+{% endif %}
+
+{% if gradings %}
+
+<h4>{% trans "Gradings" %}</h4>
+<div>
+  <table class="table table-striped">
+    <tbody>
+      {% for g in gradings %}
+      <tr>
+        <td class="datacol">{{ g.0 }}</td>
+        <td class="datacol">{{ g.1 }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% endif %}
+
+<!-- <table class="table table-striped">
+	<thead>
+    <th class="datacol">{% trans "participant" %}</th>
+    <th class="datacol">{% trans "flow id" %}</th>
+    <th class="datacol">{% trans "kind" %}</th>
+    <th class="datacol">{% trans "expiration" %}</th>
+    <th class="datacol">{% trans "creation time" %}</th>
+    <th class="datacol">{% trans "rules" %}</th>
+
+  </thead>
+	<tbody>
+    {% for participant in participants %}
+    <tr>
+    	<td class="datacol">{{ participant.participation }}</td>
+    	<td class="datacol">{{ participant.flow_id }}</td>
+    	<td class="datacol">{{ participant.kind }}</td>
+    	<td class="datacol">{{ participant.expiration }}</td>
+    	<td class="datacol">{{ participant.creation_time }}</td>
+        <td class="datacol">{{ participant.rule }}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table> -->

--- a/course/templates/course/exception-table.html
+++ b/course/templates/course/exception-table.html
@@ -1,6 +1,6 @@
 {% load i18n %}
+<h3>{% trans "Existing Exceptions" %}</h3>
 {% if permissions %}
-<h3>{% trans "Existing Excptions" %}</h3>
 <h4>{% trans "Permissions" %}</h4>
 <ul class="list-group row">
   {% for p in permissions %}

--- a/course/views.py
+++ b/course/views.py
@@ -747,7 +747,6 @@ class ExceptionStage1Form(StyledForm):
 
 @course_view
 def grant_exception(pctx):
-    print(type(pctx))
     if not pctx.has_permission(pperm.grant_exception):
         raise PermissionDenied(_("may not grant exceptions"))
 
@@ -756,19 +755,16 @@ def grant_exception(pctx):
 
     request = pctx.request
     if request.method == "POST":
-        print("post grant exception")
         form = ExceptionStage1Form(pctx.course, flow_ids, request.POST)
 
 
         if form.is_valid():
-            print("go to stage 2")
             return redirect("relate-grant_exception_stage_2",
                     pctx.course.identifier,
                     form.cleaned_data["participation"].id,
                     form.cleaned_data["flow_id"])
 
     else:
-        print("not post")
         form = ExceptionStage1Form(pctx.course, flow_ids)
 
     return render_course_page(pctx, "course/generic-course-form.html", {
@@ -846,7 +842,6 @@ given the participation and flow_id, find the latest exception record
 and build an exception table according to this record
 '''
 def exception_table(participation, flow_id):
-    print(participation, flow_id)
     try:
         last_exception = FlowRuleException.objects.filter(                    
                             participation=participation,
@@ -889,7 +884,6 @@ def exception_table(participation, flow_id):
     template = loader.get_template('course/exception-table.html')
     context = Context({ 'permissions': permissions, 'gradings': gradings })
     rendered = template.render(context)
-    print(rendered)
     excpt_table = string_concat(
                     "<div class='well'>",
                     "{}",
@@ -980,7 +974,6 @@ def grant_exception_stage_2(pctx, participation_id, flow_id):
     exception_form = None
     request = pctx.request
     if request.method == "POST":
-        print("post exception stage 2")
         exception_form = ExceptionStage2Form(find_sessions(), request.POST)
         create_session_form = CreateSessionForm(
                 session_tag_choices, default_tag, create_session_is_override,
@@ -1010,9 +1003,6 @@ def grant_exception_stage_2(pctx, participation_id, flow_id):
             exception_form = None
 
         elif exception_form.is_valid() and "next" in request.POST:  # type: ignore
-
-            print("render stage 3 course page")
-
             return redirect(
                     "relate-grant_exception_stage_3",
                     pctx.course.identifier,
@@ -1025,8 +1015,6 @@ def grant_exception_stage_2(pctx, participation_id, flow_id):
 
     if exception_form is None:
         exception_form = ExceptionStage2Form(find_sessions())
-
-    print("render stage 2 course page")
 
     return render_course_page(pctx, "course/generic-course-form.html", {
         "forms": [exception_form, create_session_form],

--- a/course/views.py
+++ b/course/views.py
@@ -757,7 +757,6 @@ def grant_exception(pctx):
     if request.method == "POST":
         form = ExceptionStage1Form(pctx.course, flow_ids, request.POST)
 
-
         if form.is_valid():
             return redirect("relate-grant_exception_stage_2",
                     pctx.course.identifier,

--- a/course/views.py
+++ b/course/views.py
@@ -840,7 +840,6 @@ class ExceptionStage2Form(StyledForm):
                             pgettext("Next step", "Next"),
                             " &raquo;"))))
 
-###################{{    
 
 '''
 given the participation and flow_id, find the latest exception record
@@ -898,7 +897,7 @@ def exception_table(participation, flow_id):
                     ).format(rendered)
 
     return excpt_table
-###################}}
+
 
 @course_view
 def grant_exception_stage_2(pctx, participation_id, flow_id):
@@ -921,12 +920,13 @@ def grant_exception_stage_2(pctx, participation_id, flow_id):
                 'participation': participation,
                 'flow_id': flow_id})
 
-
-########################
+    # {{{ create the exception table and append to form_text 
+    
     form_text = string_concat(
                     form_text,
                     exception_table(participation, flow_id))
-########################
+
+    # }}}
 
     from course.content import get_flow_desc
     try:


### PR DESCRIPTION
In the grant exception stage 2 page, display the latest exceptions granted.

The exceptions granted in stage 3 page have two types: permissions and gradings. 
I added a function that retrieves latest exceptions record and handles the two types (one can grant only one type or both types of exception in one time).
I added an html template to display the all the exceptions.