### PR TITLE
Configuration for email-only signin.

### DIFF
--- a/course/auth.py
+++ b/course/auth.py
@@ -352,6 +352,11 @@ def sign_in_by_user_pw(request, redirect_field_name=REDIRECT_FIELD_NAME):
     """
     Displays the login form and handles the login action.
     """
+    if not settings.RELATE_SIGN_IN_BY_USERNAME_ENABLED:
+        messages.add_message(request, messages.ERROR,
+                _("Username-based sign-in is not being used"))
+        return redirect("relate-sign_in_choice")
+
     redirect_to = request.POST.get(redirect_field_name,
                                    request.GET.get(redirect_field_name, ''))
 

--- a/course/templates/course/login-by-email.html
+++ b/course/templates/course/login-by-email.html
@@ -6,6 +6,7 @@
 {% block content %}
   <h1>{% trans "Sign in or create account" %}</h1>
 
+  {% if relate_sign_in_by_exam_tickets_enabled or relate_sign_in_by_username_enabled %}
   <div class="alert alert-info">
     <i class="fa fa-chevron-left"></i>
     {% url "relate-sign_in_choice" as relate-sign_in_choice %}
@@ -14,6 +15,7 @@
       <a href="{{ relate-sign_in_choice }}">please choose a different method to sign in</a>.
     {% endblocktrans %}
   </div>
+  {% endif %}
 
   <div class="alert alert-warning">
     <i class="fa fa-warning"></i>

--- a/local_settings.example.py
+++ b/local_settings.example.py
@@ -85,7 +85,7 @@ ADMINS = (
     )
 
 # If your email service do not allow nonauthorized sender, uncomment the following
-# statement and change the configurations above accordingly, noticing that all 
+# statement and change the configurations above accordingly, noticing that all
 # emails will be sent using the EMAIL_ settings above.
 #RELATE_EMAIL_SMTP_ALLOW_NONAUTHORIZED_SENDER = False
 
@@ -168,6 +168,7 @@ RELATE_SESSION_RESTART_COOLDOWN_SECONDS = 10
 # {{{ sign-in methods
 
 RELATE_SIGN_IN_BY_EMAIL_ENABLED = True
+RELATE_SIGN_IN_BY_USERNAME_ENABLED = True
 RELATE_REGISTRATION_ENABLED = False
 RELATE_SIGN_IN_BY_EXAM_TICKETS_ENABLED = True
 

--- a/relate/templates/sign-in-choice.html
+++ b/relate/templates/sign-in-choice.html
@@ -41,6 +41,7 @@
           {% trans "Sign in using an exam ticket" %} &raquo;</a>
       </li>
     {% endif %}
+    {% if relate_sign_in_by_username_enabled %}
     <li>
       <a
         class="btn btn-primary"
@@ -48,5 +49,6 @@
         role="button"><i class="fa fa-key"></i>
         {% trans "Sign in with a RELATE-specific user name and password" %} &raquo;</a>
     </li>
+    {% endif %}
   </ul>
 {% endblock %}

--- a/relate/utils.py
+++ b/relate/utils.py
@@ -139,6 +139,8 @@ def settings_context_processor(request):
         "student_sign_in_view": "relate-sign_in_choice",
         "relate_sign_in_by_email_enabled":
         settings.RELATE_SIGN_IN_BY_EMAIL_ENABLED,
+        "relate_sign_in_by_username_enabled":
+        settings.RELATE_SIGN_IN_BY_USERNAME_ENABLED,
         "relate_registration_enabled":
         settings.RELATE_REGISTRATION_ENABLED,
         "relate_sign_in_by_exam_tickets_enabled":


### PR DESCRIPTION
We want a setup where users can _only_ use the email sign-in. This pull request mimics the other logic sign-in logic:

1. Add a `RELATE_SIGN_IN_BY_USERNAME_ENABLED` setting (default: True) which can be used to disable username sign-in in the app (but not /admin/).
2. Since there is not a guaranteed second sign-in method, check before showing the alert about alternate methods.

There may be some other logic that I'm missing (or a good reason to not disable the username sign-in). Happy to update and/or scrap depending on your thoughts.