### PR TITLE
Optimize display of InlineMulti question.

### DIFF
--- a/course/templates/course/custom-crispy-inline-form.html
+++ b/course/templates/course/custom-crispy-inline-form.html
@@ -9,6 +9,13 @@
         input_element.removeAttr("style");
     }
 
+    {#  hack display html before first input box as span instead of p #}
+    $('.relate-interaction-container >  form.form-inline > p:nth-child(2)').each(function(){
+      if ($(this).is("p")){
+        $(this).replaceWith($('<span>' + this.innerHTML + '</span>'));
+      }
+    });
+
     $('[use-popover="true"]').each(function(){
 
         {# enable popovers #}


### PR DESCRIPTION
If there were literals before the first blank, those literal will be wrapped by `<p>`, displaying an indepedent paragraph, like this:

![image](https://user-images.githubusercontent.com/7379654/30784148-5cdce524-a182-11e7-9367-6dd81023ac62.png)

With this patch, it will check whether the first element is wrapped by `<p>`, if yes, modify the element to be wrapped by `<span>`, then :
![image](https://user-images.githubusercontent.com/7379654/30784154-6e746c12-a182-11e7-892f-29078784c761.png)

This patch is kind of dirty, because I think it's hard to do by hacking the form template, and actually I didn't find where to hack that.