### PR TITLE
Extend tests

### DIFF
--- a/course/page/code.py
+++ b/course/page/code.py
@@ -43,6 +43,9 @@ from course.page.base import (
         get_editor_interaction_mode)
 from course.constants import flow_permission
 
+# DEBUGGING SWITCH: False for 'spawn container', True for 'a faked container'
+USE_FAKED_CONTAINER = False
+
 
 # {{{ python code question
 
@@ -95,8 +98,7 @@ def request_python_run(run_req, run_timeout, image=None):
 
     docker_timeout = 15
 
-    # DEBUGGING SWITCH: 1 for 'spawn container', 0 for 'static container'
-    if 1:
+    if not USE_FAKED_CONTAINER:
         docker_url = getattr(settings, "RELATE_DOCKER_URL",
                 "unix://var/run/docker.sock")
         docker_tls = getattr(settings, "RELATE_DOCKER_TLS_CONFIG",

--- a/course/page/code.py
+++ b/course/page/code.py
@@ -43,8 +43,10 @@ from course.page.base import (
         get_editor_interaction_mode)
 from course.constants import flow_permission
 
-# DEBUGGING SWITCH: False for 'spawn container', True for 'a faked container'
-USE_FAKED_CONTAINER = False
+# DEBUGGING SWITCH:
+# True for 'spawn containers' (normal operation)
+# False for 'just connect to localhost:RUNPY_PORT' for runpy'
+SPAWN_CONTAINERS_FOR_RUNPY = False
 
 
 # {{{ python code question
@@ -98,7 +100,7 @@ def request_python_run(run_req, run_timeout, image=None):
 
     docker_timeout = 15
 
-    if not USE_FAKED_CONTAINER:
+    if SPAWN_CONTAINERS_FOR_RUNPY:
         docker_url = getattr(settings, "RELATE_DOCKER_URL",
                 "unix://var/run/docker.sock")
         docker_tls = getattr(settings, "RELATE_DOCKER_TLS_CONFIG",

--- a/course/page/text.py
+++ b/course/page/text.py
@@ -41,6 +41,8 @@ from course.page.base import (
 import re
 import sys
 
+CORRECT_ANSWER_PATTERN = string_concat(_("A correct answer is"), ": '%s'.")  # noqa
+
 
 class TextAnswerForm(StyledForm):
     # prevents form submission with codemirror's empty textarea
@@ -961,8 +963,6 @@ class TextQuestion(TextQuestionBase, PageBaseWithValue):
     def correct_answer(self, page_context, page_data, answer_data, grade_data):
         # FIXME: Could use 'best' match to answer
 
-        CA_PATTERN = string_concat(_("A correct answer is"), ": '%s'.")  # noqa
-
         for matcher in self.matchers:
             unspec_correct_answer_text = matcher.correct_answer_text()
             if unspec_correct_answer_text is not None:
@@ -970,7 +970,7 @@ class TextQuestion(TextQuestionBase, PageBaseWithValue):
 
         assert unspec_correct_answer_text
 
-        result = CA_PATTERN % unspec_correct_answer_text
+        result = CORRECT_ANSWER_PATTERN % unspec_correct_answer_text
 
         if hasattr(self.page_desc, "answer_explanation"):
             result += markup_to_html(page_context, self.page_desc.answer_explanation)

--- a/docker-image-run-py/runpy
+++ b/docker-image-run-py/runpy
@@ -29,7 +29,21 @@ import socketserver
 import json
 import sys
 import io
-from code_runpy_backend import Struct, run_code, package_exception
+try:
+    from code_runpy_backend import Struct, run_code, package_exception
+except ImportError:
+    try:
+        # When faking a container for unittest
+        from course.page.code_runpy_backend import (
+            Struct, run_code, package_exception)
+    except ImportError:
+        # When debugging, i.e., run "python runpy" command line
+        import os
+        sys.path.insert(0, os.path.abspath(
+            os.path.join(os.path.dirname(__file__), os.pardir)))
+        from course.page.code_runpy_backend import (
+            Struct, run_code, package_exception)
+
 from http.server import BaseHTTPRequestHandler
 
 PORT = 9941

--- a/tests/base_test_mixins.py
+++ b/tests/base_test_mixins.py
@@ -778,7 +778,7 @@ class FakedRunpyContainerMixin(object):
 
         super(FakedRunpyContainerMixin, cls).setUpClass()
         cls.faked_container_patch = mock.patch(
-            "course.page.code.USE_FAKED_CONTAINER", True)
+            "course.page.code.SPAWN_CONTAINERS_FOR_RUNPY", False)
         cls.faked_container_patch.start()
 
         python_executable = os.getenv("PY_EXE")

--- a/tests/base_test_mixins.py
+++ b/tests/base_test_mixins.py
@@ -763,7 +763,7 @@ class FallBackStorageMessageTestMixin(object):
             print("\n-------no message----------")
 
 
-class FakedRunpyContainerMixin(object):
+class SubprocessRunpyContainerMixin(object):
     """
     This mixin is used to fake a runpy container, only needed when
     the TestCase include test(s) for code questions
@@ -776,7 +776,7 @@ class FakedRunpyContainerMixin(object):
                            "PY3 only, since currently runpy docker only "
                            "provide PY3 envrionment")
 
-        super(FakedRunpyContainerMixin, cls).setUpClass()
+        super(SubprocessRunpyContainerMixin, cls).setUpClass()
         cls.faked_container_patch = mock.patch(
             "course.page.code.SPAWN_CONTAINERS_FOR_RUNPY", False)
         cls.faked_container_patch.start()
@@ -806,6 +806,6 @@ class FakedRunpyContainerMixin(object):
 
     @classmethod
     def tearDownClass(cls):  # noqa
-        super(FakedRunpyContainerMixin, cls).tearDownClass()
+        super(SubprocessRunpyContainerMixin, cls).tearDownClass()
         cls.faked_container_patch.stop()
         cls.faked_container_process.kill()

--- a/tests/base_test_mixins.py
+++ b/tests/base_test_mixins.py
@@ -22,14 +22,17 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
+import six
 import os
 from django.conf import settings
 from django.test import Client, override_settings
 from django.urls import reverse, resolve
 from django.contrib.auth import get_user_model
 from relate.utils import force_remove_path
-from course.models import Course, Participation, ParticipationRole, FlowSession
+from course.models import (
+    Course, Participation, ParticipationRole, FlowSession, FlowPageData)
 from course.constants import participation_status, user_status
+from .utils import mock
 
 CREATE_SUPERUSER_KWARGS = {
     "username": "test_admin",
@@ -136,7 +139,70 @@ NONE_PARTICIPATION_USER_CREATE_KWARG_LIST = [
 ]
 
 
-class SuperuserCreateMixin(object):
+class ResponseContextMixin(object):
+    """
+    Response context refers to "the template Context instance that was used
+    to render the template that produced the response content".
+    Ref: https://docs.djangoproject.com/en/dev/topics/testing/tools/#django.test.Response.context  # noqa
+    """
+    def get_response_context_value_by_name(self, response, context_name):
+        value = response.context.__getitem__(context_name)
+        self.assertIsNotNone(
+            value,
+            msg="%s does not exist in given response" % context_name)
+        return value
+
+    def assertResponseContextIsNone(self, resp, context_name):  # noqa
+        try:
+            value = self.get_response_context_value_by_name(resp, context_name)
+        except AssertionError:
+            # the context item doesn't exist
+            pass
+        else:
+            self.assertIsNone(value)
+
+    def assertResponseContextIsNotNone(self, resp, context_name):  # noqa
+        value = self.get_response_context_value_by_name(resp, context_name)
+        self.assertIsNotNone(value)
+
+    def assertResponseContextEqual(self, resp, context_name, expected_value):  # noqa
+        value = self.get_response_context_value_by_name(resp, context_name)
+        self.assertEqual(value, expected_value)
+
+    def assertResponseContextContains(self, resp,  # noqa
+                                      context_name, expected_value, html=False):
+        value = self.get_response_context_value_by_name(resp, context_name)
+        if not html:
+            self.assertIn(expected_value, value)
+        else:
+            self.assertInHTML(expected_value, value)
+
+    def assertResponseContextRegex(  # noqa
+            self, resp,  # noqa
+            context_name, expected_value_regex):
+        value = self.get_response_context_value_by_name(resp, context_name)
+        six.assertRegex(self, value, expected_value_regex)
+
+    def debug_print_response_context_value(self, resp, context_name):
+        try:
+            value = self.get_response_context_value_by_name(resp, context_name)
+            print("\n-----------context %s-------------"
+                  % context_name)
+            if isinstance(value, (list, tuple)):
+                from course.validation import ValidationWarning
+                for v in value:
+                    if isinstance(v, ValidationWarning):
+                        print(v.text)
+                    else:
+                        print(repr(v))
+            else:
+                print(value)
+            print("-----------context end-------------\n")
+        except AssertionError:
+            print("\n-------no value for context %s----------" % context_name)
+
+
+class SuperuserCreateMixin(ResponseContextMixin):
     create_superuser_kwargs = CREATE_SUPERUSER_KWARGS
 
     @classmethod
@@ -289,6 +355,76 @@ class CoursesTestMixinBase(SuperuserCreateMixin):
     def get_course_page_url(cls, course):
         return reverse("relate-course_page", args=[course.identifier])
 
+    def get_response_context_answer_feedback(self, response):
+        return self.get_response_context_value_by_name(response, "feedback")
+
+    def assertResponseContextAnswerFeedbackContainsFeedback(  # noqa
+                                        self, response, expected_feedback):
+        answer_feedback = self.get_response_context_answer_feedback(response)
+        self.assertTrue(hasattr(answer_feedback, "feedback"))
+        self.assertIn(expected_feedback, answer_feedback.feedback)
+
+    def assertResponseContextAnswerFeedbackCorrectnessEquals(  # noqa
+                                        self, response, expected_correctness):
+        answer_feedback = self.get_response_context_answer_feedback(response)
+        if expected_correctness is None:
+            try:
+                self.assertTrue(hasattr(answer_feedback, "correctness"))
+            except AssertionError:
+                pass
+            else:
+                self.assertIsNone(answer_feedback.correctness)
+        else:
+            from decimal import Decimal
+            self.assertEqual(answer_feedback.correctness,
+                                    Decimal(str(expected_correctness)))
+
+    def get_logged_in_user(self):
+        try:
+            logged_in_user_id = self.c.session['_auth_user_id']
+            from django.contrib.auth import get_user_model
+            logged_in_user = get_user_model().objects.get(
+                pk=int(logged_in_user_id))
+        except KeyError:
+            logged_in_user = None
+        return logged_in_user
+
+    def temporarily_switch_to_user(self, switch_to):
+        _self = self
+
+        from functools import wraps
+
+        class ClientUserSwitcher(object):
+            def __init__(self, switch_to):
+                self.client = _self.c
+                self.switch_to = switch_to
+                self.logged_in_user = _self.get_logged_in_user()
+
+            def __enter__(self):
+                if self.logged_in_user == self.switch_to:
+                    return
+                if self.switch_to is None:
+                    self.client.logout()
+                    return
+                self.client.force_login(self.switch_to)
+
+            def __exit__(self, exc_type, exc_val, exc_tb):
+                if self.logged_in_user == self.switch_to:
+                    return
+                if self.logged_in_user is None:
+                    self.client.logout()
+                    return
+                self.client.force_login(self.logged_in_user)
+
+            def __call__(self, func):
+                @wraps(func)
+                def wrapper(*args, **kw):
+                    with self:
+                        return func(*args, **kw)
+                return wrapper
+
+        return ClientUserSwitcher(switch_to)
+
 
 class SingleCourseTestMixin(CoursesTestMixinBase):
     courses_setup_list = SINGLE_COURSE_SETUP_LIST
@@ -340,18 +476,33 @@ class SingleCourseTestMixin(CoursesTestMixinBase):
     def tearDownClass(cls):
         super(SingleCourseTestMixin, cls).tearDownClass()
 
+    def get_page_data(self, flow_session_id, page_id):
+        return FlowPageData.objects.get(
+            flow_session_id=flow_session_id, page_id=page_id)
+
+    def get_response_body(self, response):
+        return self.get_response_context_value_by_name(response, "body")
+
+    def get_page_response_correct_answer(self, response):
+        return self.get_response_context_value_by_name(response, "correct_answer")
+
+    def get_page_response_feedback(self, response):
+        return self.get_response_context_value_by_name(response, "feedback")
+
 
 class SingleCoursePageTestMixin(SingleCourseTestMixin):
+    # todo: this should be be subclassed from CoursesTestMixinBase
+    # or it is hard for cross-course page tests
+
     @property
     def flow_id(self):
         raise NotImplementedError
 
-    @classmethod
-    def start_quiz(cls, flow_id):
+    def start_quiz(self, flow_id):
         existing_quiz_count = FlowSession.objects.all().count()
-        params = {"course_identifier": cls.course.identifier,
+        params = {"course_identifier": self.course.identifier,
                   "flow_id": flow_id}
-        resp = cls.c.post(reverse("relate-view_start_flow", kwargs=params))
+        resp = self.c.post(reverse("relate-view_start_flow", kwargs=params))
         assert resp.status_code == 302
         new_quiz_count = FlowSession.objects.all().count()
         assert new_quiz_count == existing_quiz_count + 1
@@ -359,43 +510,84 @@ class SingleCoursePageTestMixin(SingleCourseTestMixin):
         # Yep, no regax!
         _, _, kwargs = resolve(resp.url)
         # Should be in correct course
-        assert kwargs["course_identifier"] == cls.course.identifier
+        assert kwargs["course_identifier"] == self.course.identifier
         # Should redirect us to welcome page
         assert int(kwargs["ordinal"]) == 0
-        cls.page_params = kwargs
+        self.page_params = kwargs
 
-    @classmethod
-    def end_quiz(cls):
+    def end_quiz(self):
         from copy import deepcopy
-        page_params = deepcopy(cls.page_params)
+        page_params = deepcopy(self.page_params)
         del page_params["ordinal"]
-        resp = cls.c.post(reverse("relate-finish_flow_session_view",
-                                  kwargs=page_params), {'submit': ['']})
+        resp = self.c.post(reverse("relate-finish_flow_session_view",
+                                   kwargs=page_params), {'submit': ['']})
         return resp
 
-    @classmethod
-    def get_ordinal_via_page_id(cls, page_id):
+    def get_ordinal_via_page_id(self, page_id):
         from course.models import FlowPageData
         flow_page_data = FlowPageData.objects.get(
-            flow_session__id=cls.page_params["flow_session_id"],
+            flow_session__id=self.page_params["flow_session_id"],
             page_id=page_id
         )
         return flow_page_data.ordinal
 
-    @classmethod
-    def client_post_answer_by_page_id(cls, page_id, answer_data):
-        page_ordinal = cls.get_ordinal_via_page_id(page_id)
-        return cls.client_post_answer_by_ordinal(page_ordinal, answer_data)
+    def get_page_url_by_ordinal(self, page_ordinal):
+        page_params = self.get_page_params_by_ordinal(page_ordinal)
+        return reverse("relate-view_flow_page", kwargs=page_params)
 
-    @classmethod
-    def client_post_answer_by_ordinal(cls, page_ordinal, answer_data):
+    def get_page_grading_url_by_ordinal(self, page_ordinal, flow_session_id=None):
+        page_params = self.get_page_params_by_ordinal(page_ordinal)
+        del page_params["ordinal"]
+        page_params["page_ordinal"] = page_ordinal
+        if flow_session_id:
+            page_params["flow_session_id"] = flow_session_id
+        return reverse("relate-grade_flow_page", kwargs=page_params)
+
+    def get_page_url_by_page_id(self, page_id):
+        page_ordinal = self.get_ordinal_via_page_id(page_id)
+        return self.get_page_url_by_ordinal(page_ordinal)
+
+    def get_page_grading_url_by_page_id(self, page_id, flow_session_id=None):
+        page_ordinal = self.get_ordinal_via_page_id(page_id)
+        return self.get_page_grading_url_by_ordinal(page_ordinal, flow_session_id)
+
+    def post_answer_by_page_id(self, page_id, answer_data):
+        page_ordinal = self.get_ordinal_via_page_id(page_id)
+        return self.post_answer_by_ordinal(page_ordinal, answer_data)
+
+    def post_grade_by_page_id(self, page_id, grade_data, flow_session_id=None,
+                              force_login_instructor=True):
+        post_data = {"submit": [""]}
+        post_data.update(grade_data)
+
+        force_login_user = self.get_logged_in_user()
+        if force_login_instructor:
+            force_login_user = self.instructor_participation.user
+
+        with self.temporarily_switch_to_user(force_login_user):
+            response = self.c.post(
+                self.get_page_grading_url_by_page_id(
+                    page_id, flow_session_id=flow_session_id),
+                data=post_data,
+                follow=True)
+
+        return response
+
+    def get_page_params_by_ordinal(self, page_ordinal):
         from copy import deepcopy
-        page_params = deepcopy(cls.page_params)
+        page_params = deepcopy(self.page_params)
         page_params.update({"ordinal": str(page_ordinal)})
+        return page_params
+
+    def get_page_params_by_page_id(self, page_id):
+        page_ordianl = self.get_ordinal_via_page_id(page_id)
+        return self.get_page_params_by_ordinal(page_ordianl)
+
+    def post_answer_by_ordinal(self, page_ordinal, answer_data):
         submit_data = answer_data
         submit_data.update({"submit": ["Submit final answer"]})
-        resp = cls.c.post(
-            reverse("relate-view_flow_page", kwargs=page_params),
+        resp = self.c.post(
+            self.get_page_url_by_ordinal(page_ordinal),
             submit_data)
         return resp
 
@@ -437,13 +629,55 @@ class SingleCoursePageTestMixin(SingleCourseTestMixin):
         self.assertEqual(len(result), expected_count)
 
     def assertGradeHistoryItemsCount(  # noqa
-            self, page_ordinal, expected_count, flow_session_id=None):
+            self, page_ordinal, expected_count, flow_session_id=None,
+            force_login_instructor=True):
         if flow_session_id is None:
             flow_session_id = FlowSession.objects.all().last().pk
-        resp = self.get_page_grade_history(flow_session_id, page_ordinal)
+
+        if force_login_instructor:
+            switch_to = self.instructor_participation.user
+        else:
+            switch_to = self.get_logged_in_user()
+
+        with self.temporarily_switch_to_user(switch_to):
+            resp = self.get_page_grade_history(flow_session_id, page_ordinal)
+
         import json
         result = json.loads(resp.content.decode())["result"]
         self.assertEqual(len(result), expected_count)
+
+    def get_update_course_url(self):
+        return reverse("relate-update_course", args=[self.course.identifier])
+
+    def update_course_content(self, commit_sha,
+                              fetch_update=False,
+                              prevent_discarding_revisions=True,
+                              force_login_instructor=True):
+
+        try:
+            commit_sha = commit_sha.decode()
+        except Exception:
+            pass
+
+        data = {"new_sha": [commit_sha],
+                }
+
+        if not prevent_discarding_revisions:
+            data["prevent_discarding_revisions"] = ["on"]
+
+        if not fetch_update:
+            data["update"] = ["Update"]
+        else:
+            data["fetch_update"] = ["Fetch and update"]
+
+        force_login_user = None
+        if force_login_instructor:
+            force_login_user = self.instructor_participation.user
+
+        with self.temporarily_switch_to_user(force_login_user):
+            response = self.c.post(self.get_update_course_url(), data)
+
+        return response
 
 
 class FallBackStorageMessageTestMixin(object):
@@ -453,22 +687,24 @@ class FallBackStorageMessageTestMixin(object):
     storage = 'django.contrib.messages.storage.fallback.FallbackStorage'
 
     def setUp(self):  # noqa
+        super(FallBackStorageMessageTestMixin, self).setUp()
         self.settings_override = override_settings(MESSAGE_STORAGE=self.storage)
         self.settings_override.enable()
 
     def tearDown(self):  # noqa
         self.settings_override.disable()
 
-    def get_storage_from_response(self, response):
-        return response.context['messages']
-
     def get_listed_storage_from_response(self, response):
-        return list(self.get_storage_from_response(response))
+        return list(self.get_response_context_value_by_name(response, 'messages'))
 
     def clear_message_response_storage(self, response):
         # this should only be used for debug, because we are using private method
         # which might change
-        storage = self.get_storage_from_response(response)
+        try:
+            storage = self.get_response_context_value_by_name(response, 'messages')
+        except AssertionError:
+            # message doesn't exist in response context
+            return
         if hasattr(storage, '_loaded_data'):
             storage._loaded_data = []
         elif hasattr(storage, '_loaded_message'):
@@ -485,7 +721,19 @@ class FallBackStorageMessageTestMixin(object):
 
     def assertResponseMessagesEqual(self, response, expected_messages):  # noqa
         storage = self.get_listed_storage_from_response(response)
+        if not isinstance(expected_messages, list):
+            expected_messages = [expected_messages]
+        self.assertEqual(len([m for m in storage]), len(expected_messages))
         self.assertEqual([m.message for m in storage], expected_messages)
+
+    def assertResponseMessagesEqualRegex(self, response, expected_message_regexs):  # noqa
+        storage = self.get_listed_storage_from_response(response)
+        if not isinstance(expected_message_regexs, list):
+            expected_message_regexs = [expected_message_regexs]
+        self.assertEqual(len([m for m in storage]), len(expected_message_regexs))
+        messages = [m.message for m in storage]
+        for idx, m in enumerate(messages):
+            six.assertRegex(self, m, expected_message_regexs[idx])
 
     def assertResponseMessagesContains(self, response, expected_messages):  # noqa
         storage = self.get_listed_storage_from_response(response)
@@ -513,3 +761,51 @@ class FallBackStorageMessageTestMixin(object):
             print("-----------message end-------------\n")
         except KeyError:
             print("\n-------no message----------")
+
+
+class FakedRunpyContainerMixin(object):
+    """
+    This mixin is used to fake a runpy container, only needed when
+    the TestCase include test(s) for code questions
+    """
+    @classmethod
+    def setUpClass(cls):  # noqa
+        if six.PY2:
+            from unittest import SkipTest
+            raise SkipTest("In process fake container is configured for "
+                           "PY3 only, since currently runpy docker only "
+                           "provide PY3 envrionment")
+
+        super(FakedRunpyContainerMixin, cls).setUpClass()
+        cls.faked_container_patch = mock.patch(
+            "course.page.code.USE_FAKED_CONTAINER", True)
+        cls.faked_container_patch.start()
+
+        python_executable = os.getenv("PY_EXE")
+
+        if not python_executable:
+            import sys
+            python_executable = sys.executable
+
+        import subprocess
+        args = [python_executable,
+                os.path.abspath(
+                    os.path.join(
+                        os.path.dirname(__file__), os.pardir,
+                        "docker-image-run-py", "runpy")),
+                ]
+        cls.faked_container_process = subprocess.Popen(
+            args,
+            stdout=subprocess.DEVNULL,
+
+            # because runpy prints to stderr
+            stderr=subprocess.DEVNULL
+        )
+
+        cls.faked_container_patch.start()
+
+    @classmethod
+    def tearDownClass(cls):  # noqa
+        super(FakedRunpyContainerMixin, cls).tearDownClass()
+        cls.faked_container_patch.stop()
+        cls.faked_container_process.kill()

--- a/tests/test_enrollment.py
+++ b/tests/test_enrollment.py
@@ -216,8 +216,8 @@ class EnrollmentRequestTest(
     course_attributes_extra = {"enrollment_approval_required": True}
 
     def test_enroll_request_non_participation(self):
-        self.c.force_login(self.non_participation_user1)
-        resp = self.c.post(self.enroll_request_url, follow=True)
+        with self.temporarily_switch_to_user(self.non_participation_user1):
+            resp = self.c.post(self.enroll_request_url, follow=True)
         self.assertResponseMessagesCount(resp, 2)
         self.assertResponseMessagesEqual(
             resp, [MESSAGE_ENROLLMENT_SENT_TEXT,
@@ -230,7 +230,8 @@ class EnrollmentRequestTest(
             1)
 
         # Second and after visits to course page should display only 1 messages
-        resp = self.c.get(self.course_page_url)
+        with self.temporarily_switch_to_user(self.non_participation_user1):
+            resp = self.c.get(self.course_page_url)
         self.assertResponseMessagesCount(resp, 1)
         self.assertResponseMessagesEqual(
             resp, [MESSAGE_ENROLL_REQUEST_PENDING_TEXT])
@@ -240,8 +241,8 @@ class EnrollmentRequestTest(
                          EMAIL_NEW_ENROLLMENT_REQUEST_TITLE_PATTERN
                          % self.course.identifier)
 
-        self.c.force_login(self.non_participation_user2)
-        resp = self.c.post(self.enroll_request_url, follow=True)
+        with self.temporarily_switch_to_user(self.non_participation_user2):
+            resp = self.c.post(self.enroll_request_url, follow=True)
         self.assertRedirects(resp, self.course_page_url)
         self.assertEqual(len(mail.outbox), 2)
         self.assertEqual(
@@ -252,10 +253,10 @@ class EnrollmentRequestTest(
                 side_effect=course_get_object_or_404_sf_enroll_apprv_not_required)
     def test_enroll_request_non_participation_not_require_approval(
             self, mocked_get_object_or_404):
-        self.c.force_login(self.non_participation_user1)
         expected_active_participation_count = (
             self.get_participation_count_by_status(participation_status.active) + 1)
-        resp = self.c.post(self.enroll_request_url, follow=True)
+        with self.temporarily_switch_to_user(self.non_participation_user1):
+            resp = self.c.post(self.enroll_request_url, follow=True)
         self.assertResponseMessagesCount(resp, 1)
         self.assertResponseMessagesEqual(
             resp, [MESSAGE_SUCCESSFULLY_ENROLLED_TEXT])
@@ -272,7 +273,8 @@ class EnrollmentRequestTest(
                          % self.course.identifier)
 
         # Second and after visits to course page should display no messages
-        resp = self.c.get(self.course_page_url)
+        with self.temporarily_switch_to_user(self.non_participation_user1):
+            resp = self.c.get(self.course_page_url)
         self.assertResponseMessagesCount(resp, 0)
         self.assertEqual(
             self.get_participation_count_by_status(participation_status.active),
@@ -283,10 +285,10 @@ class EnrollmentRequestTest(
                 side_effect=course_get_object_or_404_sf_not_accepts_enrollment)
     def test_enroll_request_non_participation_course_not_accept_enrollment(
             self, mocked_get_object_or_404):
-        self.c.force_login(self.non_participation_user1)
         expected_active_participation_count = (
             self.get_participation_count_by_status(participation_status.active))
-        resp = self.c.post(self.enroll_request_url, follow=True)
+        with self.temporarily_switch_to_user(self.non_participation_user1):
+            resp = self.c.post(self.enroll_request_url, follow=True)
         self.assertResponseMessagesCount(resp, 1)
         self.assertResponseMessagesEqual(
             resp, [MESSAGE_NOT_ACCEPTING_ENROLLMENTS_TEXT])
@@ -302,15 +304,16 @@ class EnrollmentRequestTest(
         )
 
         # Second and after visits to course page should display no messages
-        resp = self.c.get(self.course_page_url)
+        with self.temporarily_switch_to_user(self.non_participation_user1):
+            resp = self.c.get(self.course_page_url)
         self.assertResponseMessagesCount(resp, 0)
 
     # https://github.com/inducer/relate/issues/370
     def test_pending_user_re_enroll_request_failure(self):
         self.create_participation(self.course, self.non_participation_user1,
                                   status=participation_status.requested)
-        self.c.force_login(self.non_participation_user1)
-        resp = self.c.post(self.enroll_request_url, follow=True)
+        with self.temporarily_switch_to_user(self.non_participation_user1):
+            resp = self.c.post(self.enroll_request_url, follow=True)
 
         # Second enroll request won't send more emails,
         self.assertEqual(len(mail.outbox), 0)
@@ -327,8 +330,9 @@ class EnrollmentRequestTest(
     def test_denied_user_enroll_request_failure(self):
         self.create_participation(self.course, self.non_participation_user1,
                                   status=participation_status.denied)
-        self.c.force_login(self.non_participation_user1)
-        resp = self.c.post(self.enroll_request_url, follow=True)
+        with self.temporarily_switch_to_user(self.non_participation_user1):
+            resp = self.c.post(self.enroll_request_url, follow=True)
+
         self.assertEqual(len(mail.outbox), 0)
         self.assertResponseMessagesCount(resp, 1)
         self.assertResponseMessagesEqual(
@@ -340,8 +344,9 @@ class EnrollmentRequestTest(
     def test_dropped_user_re_enroll_request_failure(self):
         self.create_participation(self.course, self.non_participation_user1,
                                   status=participation_status.dropped)
-        self.c.force_login(self.non_participation_user1)
-        resp = self.c.post(self.enroll_request_url, follow=True)
+        with self.temporarily_switch_to_user(self.non_participation_user1):
+            resp = self.c.post(self.enroll_request_url, follow=True)
+
         self.assertEqual(len(mail.outbox), 0)
         self.assertResponseMessagesCount(resp, 1)
         self.assertResponseMessagesEqual(
@@ -352,8 +357,8 @@ class EnrollmentRequestTest(
 
     #  https://github.com/inducer/relate/issues/369
     def test_unconfirmed_user_enroll_request(self):
-        self.c.force_login(self.non_participation_user4)
-        resp = self.c.post(self.enroll_request_url, follow=True)
+        with self.temporarily_switch_to_user(self.non_participation_user4):
+            resp = self.c.post(self.enroll_request_url, follow=True)
         self.assertResponseMessagesCount(resp, 1)
         self.assertResponseMessagesEqual(
             resp,
@@ -365,8 +370,8 @@ class EnrollmentRequestTest(
             0)
 
     def test_enroll_request_fail_re_enroll(self):
-        self.c.force_login(self.student_participation.user)
-        resp = self.c.post(self.enroll_request_url, follow=True)
+        with self.temporarily_switch_to_user(self.student_participation.user):
+            resp = self.c.post(self.enroll_request_url, follow=True)
         self.assertResponseMessagesCount(resp, 1)
         self.assertResponseMessagesEqual(
             resp, [MESSAGE_CANNOT_REENROLL_TEXT])
@@ -374,9 +379,9 @@ class EnrollmentRequestTest(
         self.assertEqual(len(mail.outbox), 0)
 
     def test_enroll_by_get(self):
-        self.c.force_login(self.non_participation_user1)
-        self.c.get(self.enroll_request_url)
-        resp = self.c.get(self.course_page_url)
+        with self.temporarily_switch_to_user(self.non_participation_user1):
+            self.c.get(self.enroll_request_url)
+            resp = self.c.get(self.course_page_url)
         self.assertResponseMessagesCount(resp, 1)
         self.assertResponseMessagesEqual(
             resp, [MESSAGE_ENROLL_ONLY_ACCEPT_POST_REQUEST_TEXT])
@@ -384,9 +389,9 @@ class EnrollmentRequestTest(
         self.assertEqual(len(mail.outbox), 0)
 
         # for participations, this show MESSAGE_CANNOT_REENROLL_TEXT
-        self.c.force_login(self.student_participation.user)
-        self.c.get(self.enroll_request_url)
-        resp = self.c.get(self.course_page_url)
+        with self.temporarily_switch_to_user(self.student_participation.user):
+            self.c.get(self.enroll_request_url)
+            resp = self.c.get(self.course_page_url)
         self.assertResponseMessagesCount(resp, 1)
         self.assertResponseMessagesEqual(
             resp, [MESSAGE_CANNOT_REENROLL_TEXT])
@@ -394,8 +399,9 @@ class EnrollmentRequestTest(
         self.assertEqual(len(mail.outbox), 0)
 
     def test_edit_participation_view_get_for_requested(self):
-        self.c.force_login(self.non_participation_user1)
-        self.c.post(self.enroll_request_url, follow=True)
+        with self.temporarily_switch_to_user(self.non_participation_user1):
+            self.c.post(self.enroll_request_url, follow=True)
+
         self.assertEqual(
             self.get_participation_count_by_status(participation_status.requested),
             1)
@@ -404,27 +410,34 @@ class EnrollmentRequestTest(
         )
         my_participation_edit_url = (
             self.get_participation_edit_url(my_participation.pk))
-        resp = self.c.get(my_participation_edit_url)
+
+        with self.temporarily_switch_to_user(self.non_participation_user1):
+            resp = self.c.get(my_participation_edit_url)
+
         self.assertEqual(resp.status_code, 403)
 
-        self.c.force_login(self.non_participation_user2)
-        resp = self.c.get(my_participation_edit_url)
+        with self.temporarily_switch_to_user(self.non_participation_user2):
+            resp = self.c.get(my_participation_edit_url)
+
         self.assertEqual(resp.status_code, 403)
 
-        self.c.force_login(self.student_participation.user)
-        resp = self.c.get(my_participation_edit_url)
+        with self.temporarily_switch_to_user(self.student_participation.user):
+            resp = self.c.get(my_participation_edit_url)
+
         self.assertEqual(resp.status_code, 403)
 
         # only instructor may view edit participation page
-        self.c.force_login(self.instructor_participation.user)
-        resp = self.c.get(my_participation_edit_url)
+        with self.temporarily_switch_to_user(self.instructor_participation.user):
+            resp = self.c.get(my_participation_edit_url)
+
         self.assertEqual(resp.status_code, 200)
         self.assertContains(resp, "submit-id-submit")
         self.assertContains(resp, "submit-id-approve")
         self.assertContains(resp, "submit-id-deny")
 
-        self.c.force_login(self.ta_participation.user)
-        resp = self.c.get(my_participation_edit_url)
+        with self.temporarily_switch_to_user(self.ta_participation.user):
+            resp = self.c.get(my_participation_edit_url)
+
         self.assertEqual(resp.status_code, 200)
         self.assertContains(resp, "submit-id-submit")
         self.assertContains(resp, "submit-id-approve")
@@ -436,23 +449,27 @@ class EnrollmentRequestTest(
         resp = self.c.get(my_participation_edit_url)
         self.assertEqual(resp.status_code, 403)
 
-        self.c.force_login(self.non_participation_user1)
-        resp = self.c.get(my_participation_edit_url)
+        with self.temporarily_switch_to_user(self.non_participation_user1):
+            resp = self.c.get(my_participation_edit_url)
+
         self.assertEqual(resp.status_code, 403)
 
-        self.c.force_login(self.student_participation.user)
-        resp = self.c.get(my_participation_edit_url)
+        with self.temporarily_switch_to_user(self.student_participation.user):
+            resp = self.c.get(my_participation_edit_url)
+
         self.assertEqual(resp.status_code, 403)
 
         # only instructor may view edit participation page
-        self.c.force_login(self.instructor_participation.user)
-        resp = self.c.get(my_participation_edit_url)
+        with self.temporarily_switch_to_user(self.instructor_participation.user):
+            resp = self.c.get(my_participation_edit_url)
+
         self.assertEqual(resp.status_code, 200)
         self.assertContains(resp, "submit-id-submit")
         self.assertContains(resp, "submit-id-drop")
 
-        self.c.force_login(self.ta_participation.user)
-        resp = self.c.get(my_participation_edit_url)
+        with self.temporarily_switch_to_user(self.ta_participation.user):
+            resp = self.c.get(my_participation_edit_url)
+
         self.assertEqual(resp.status_code, 200)
         self.assertContains(resp, "submit-id-submit")
         self.assertContains(resp, "submit-id-drop")
@@ -467,8 +484,9 @@ class EnrollRequireEmailSuffixTest(LocmemBackendTestsMixin,
     @mock.patch("course.enrollment.get_object_or_404",
                 side_effect=course_get_object_or_404_sf_not_email_suffix1)
     def test_email_suffix_matched(self, mocked_email_suffix):
-        self.c.force_login(self.non_participation_user1)
-        resp = self.c.post(self.enroll_request_url, follow=True)
+        with self.temporarily_switch_to_user(self.non_participation_user1):
+            resp = self.c.post(self.enroll_request_url, follow=True)
+
         self.assertResponseMessagesCount(resp, 2)
         self.assertResponseMessagesEqual(
             resp, [MESSAGE_ENROLLMENT_SENT_TEXT,
@@ -484,8 +502,9 @@ class EnrollRequireEmailSuffixTest(LocmemBackendTestsMixin,
     @mock.patch("course.enrollment.get_object_or_404",
                 side_effect=course_get_object_or_404_sf_not_email_suffix1)
     def test_email_suffix_not_matched(self, mocked_email_suffix):
-        self.c.force_login(self.non_participation_user2)
-        resp = self.c.post(self.enroll_request_url, follow=True)
+        with self.temporarily_switch_to_user(self.non_participation_user2):
+            resp = self.c.post(self.enroll_request_url, follow=True)
+
         self.assertResponseMessagesCount(resp, 1)
         self.assertResponseMessagesEqual(
             resp,
@@ -500,8 +519,9 @@ class EnrollRequireEmailSuffixTest(LocmemBackendTestsMixin,
     @mock.patch("course.enrollment.get_object_or_404",
                 side_effect=course_get_object_or_404_sf_not_email_suffix1)
     def test_email_suffix_matched_unconfirmed(self, mocked_email_suffix):
-        self.c.force_login(self.non_participation_user3)
-        resp = self.c.post(self.enroll_request_url, follow=True)
+        with self.temporarily_switch_to_user(self.non_participation_user3):
+            resp = self.c.post(self.enroll_request_url, follow=True)
+
         self.assertResponseMessagesCount(resp, 1)
         self.assertResponseMessagesEqual(
             resp,
@@ -516,8 +536,9 @@ class EnrollRequireEmailSuffixTest(LocmemBackendTestsMixin,
     @mock.patch("course.enrollment.get_object_or_404",
                 side_effect=course_get_object_or_404_sf_not_email_suffix1)
     def test_email_suffix_not_matched_unconfirmed(self, mocked_email_suffix):
-        self.c.force_login(self.non_participation_user4)
-        resp = self.c.post(self.enroll_request_url, follow=True)
+        with self.temporarily_switch_to_user(self.non_participation_user4):
+            resp = self.c.post(self.enroll_request_url, follow=True)
+
         self.assertResponseMessagesCount(resp, 1)
         self.assertResponseMessagesEqual(
             resp,
@@ -534,8 +555,8 @@ class EnrollRequireEmailSuffixTest(LocmemBackendTestsMixin,
     @mock.patch("course.enrollment.get_object_or_404",
                 side_effect=course_get_object_or_404_sf_not_email_suffix2)
     def test_email_suffix_domain_matched(self, mocked_email_suffix):
-        self.c.force_login(self.non_participation_user1)
-        resp = self.c.post(self.enroll_request_url, follow=True)
+        with self.temporarily_switch_to_user(self.non_participation_user1):
+            resp = self.c.post(self.enroll_request_url, follow=True)
         self.assertResponseMessagesCount(resp, 2)
         self.assertResponseMessagesEqual(
             resp, [MESSAGE_ENROLLMENT_SENT_TEXT,
@@ -551,8 +572,9 @@ class EnrollRequireEmailSuffixTest(LocmemBackendTestsMixin,
     @mock.patch("course.enrollment.get_object_or_404",
                 side_effect=course_get_object_or_404_sf_not_email_suffix2)
     def test_email_suffix_domain_not_matched(self, mocked_email_suffix):
-        self.c.force_login(self.non_participation_user2)
-        resp = self.c.post(self.enroll_request_url, follow=True)
+        with self.temporarily_switch_to_user(self.non_participation_user2):
+            resp = self.c.post(self.enroll_request_url, follow=True)
+
         self.assertResponseMessagesCount(resp, 1)
         self.assertResponseMessagesEqual(
             resp,
@@ -567,8 +589,9 @@ class EnrollRequireEmailSuffixTest(LocmemBackendTestsMixin,
     @mock.patch("course.enrollment.get_object_or_404",
                 side_effect=course_get_object_or_404_sf_not_email_suffix2)
     def test_email_suffix_domain_matched_unconfirmed(self, mocked_email_suffix):
-        self.c.force_login(self.non_participation_user3)
-        resp = self.c.post(self.enroll_request_url, follow=True)
+        with self.temporarily_switch_to_user(self.non_participation_user3):
+            resp = self.c.post(self.enroll_request_url, follow=True)
+
         self.assertResponseMessagesCount(resp, 1)
         self.assertResponseMessagesEqual(
             resp,
@@ -591,8 +614,9 @@ class EnrollRequireEmailSuffixTest(LocmemBackendTestsMixin,
             "last_name": "User5",
             "status": user_status.active
         })
-        self.c.force_login(test_user5)
-        resp = self.c.post(self.enroll_request_url, follow=True)
+        with self.temporarily_switch_to_user(test_user5):
+            resp = self.c.post(self.enroll_request_url, follow=True)
+
         self.assertResponseMessagesCount(resp, 2)
         self.assertResponseMessagesEqual(
             resp, [MESSAGE_ENROLLMENT_SENT_TEXT,
@@ -645,8 +669,10 @@ class EnrollmentDecisionTest(EnrollmentDecisionTestMixin, TestCase):
         self.assertEqual(
             self.get_participation_count_by_status(participation_status.requested),
             1)
-        self.c.force_login(self.instructor_participation.user)
-        resp = self.c.post(self.my_participation_edit_url, self.approve_post_data)
+        with self.temporarily_switch_to_user(self.instructor_participation.user):
+            resp = self.c.post(self.my_participation_edit_url,
+                               self.approve_post_data)
+
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(
             self.get_participation_count_by_status(participation_status.requested),
@@ -660,8 +686,10 @@ class EnrollmentDecisionTest(EnrollmentDecisionTestMixin, TestCase):
             0)
 
     def test_edit_participation_view_enroll_decision_approve_no_permission1(self):
-        self.c.force_login(self.student_participation.user)
-        resp = self.c.post(self.my_participation_edit_url, self.approve_post_data)
+        with self.temporarily_switch_to_user(self.student_participation.user):
+            resp = self.c.post(self.my_participation_edit_url,
+                               self.approve_post_data)
+
         self.assertEqual(resp.status_code, 403)
         self.assertEqual(len(mail.outbox), 0)
         self.assertEqual(
@@ -669,8 +697,10 @@ class EnrollmentDecisionTest(EnrollmentDecisionTestMixin, TestCase):
             1)
 
     def test_edit_participation_view_enroll_decision_approve_no_permission2(self):
-        self.c.force_login(self.non_participation_user1)
-        resp = self.c.post(self.my_participation_edit_url, self.approve_post_data)
+        with self.temporarily_switch_to_user(self.non_participation_user1):
+            resp = self.c.post(self.my_participation_edit_url,
+                               self.approve_post_data)
+
         self.assertEqual(resp.status_code, 403)
         self.assertEqual(len(mail.outbox), 0)
         self.assertEqual(
@@ -678,8 +708,9 @@ class EnrollmentDecisionTest(EnrollmentDecisionTestMixin, TestCase):
             1)
 
     def test_edit_participation_view_enroll_decision_deny(self):
-        self.c.force_login(self.instructor_participation.user)
-        resp = self.c.post(self.my_participation_edit_url, self.deny_post_data)
+        with self.temporarily_switch_to_user(self.instructor_participation.user):
+            resp = self.c.post(self.my_participation_edit_url, self.deny_post_data)
+
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(
             self.get_participation_count_by_status(participation_status.requested),
@@ -696,10 +727,10 @@ class EnrollmentDecisionTest(EnrollmentDecisionTestMixin, TestCase):
             1)
 
     def test_edit_participation_view_enroll_decision_drop(self):
-        self.c.force_login(self.instructor_participation.user)
         self.create_participation(self.course, self.non_participation_user3,
                                   status=participation_status.active)
-        resp = self.c.post(self.my_participation_edit_url, self.drop_post_data)
+        with self.temporarily_switch_to_user(self.instructor_participation.user):
+            resp = self.c.post(self.my_participation_edit_url, self.drop_post_data)
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(
             self.get_participation_count_by_status(participation_status.dropped),
@@ -789,7 +820,6 @@ class EnrollmentDecisionTest(EnrollmentDecisionTestMixin, TestCase):
         self.assertEqual(len(mail.outbox), 0)
 
     def test_edit_participation_view_add_new_invalid_choice(self):
-        self.c.force_login(self.instructor_participation.user)
         form_data = {"user": [str(self.student_participation.user.pk)],
                      "time_factor": 0.5,
                      "roles": self.student_role_post_data, "notes": [""],
@@ -797,15 +827,18 @@ class EnrollmentDecisionTest(EnrollmentDecisionTestMixin, TestCase):
                      }
         add_post_data = {"submit": [""]}
         add_post_data.update(form_data)
-        resp = self.c.post(self.add_new_url, add_post_data, follow=True)
+        with self.temporarily_switch_to_user(self.instructor_participation.user):
+            resp = self.c.post(self.add_new_url, add_post_data, follow=True)
+
         from django.forms.models import ModelChoiceField
         self.assertFormError(
             resp, 'form', 'user',
             ModelChoiceField.default_error_messages['invalid_choice'])
 
     def test_edit_participation_view_enroll_decision_deny_no_permission1(self):
-        self.c.force_login(self.student_participation.user)
-        resp = self.c.post(self.my_participation_edit_url, self.deny_post_data)
+        with self.temporarily_switch_to_user(self.student_participation.user):
+            resp = self.c.post(self.my_participation_edit_url, self.deny_post_data)
+
         self.assertEqual(resp.status_code, 403)
         self.assertEqual(len(mail.outbox), 0)
         self.assertEqual(
@@ -816,8 +849,9 @@ class EnrollmentDecisionTest(EnrollmentDecisionTestMixin, TestCase):
             0)
 
     def test_edit_participation_view_enroll_decision_deny_no_permission2(self):
-        self.c.force_login(self.non_participation_user1)
-        resp = self.c.post(self.my_participation_edit_url, self.deny_post_data)
+        with self.temporarily_switch_to_user(self.non_participation_user1):
+            resp = self.c.post(self.my_participation_edit_url, self.deny_post_data)
+
         self.assertEqual(resp.status_code, 403)
         self.assertEqual(len(mail.outbox), 0)
         self.assertEqual(
@@ -863,8 +897,8 @@ class EnrollmentPreapprovalTestMixin(LocmemBackendTestsMixin,
             course=self.course, identifier="student"))
         return [str(role.pk)]
 
-    def post_preapprovel(self, user, preapproval_type, preapproval_data=None):
-        self.c.force_login(user)
+    def post_preapprovel(self, preapproval_type, preapproval_data=None,
+                         force_loggin_instructor=True):
         if preapproval_data is None:
             if preapproval_type == "email":
                 preapproval_data = self.preapprove_data_emails
@@ -880,9 +914,12 @@ class EnrollmentPreapprovalTestMixin(LocmemBackendTestsMixin,
             "roles": self.student_role_post_data,
             "submit": [""]
         }
-        resp = self.c.post(self.preapproval_url, data, follow=True)
-        self.c.logout()
-        return resp
+        if not force_loggin_instructor:
+            approver = self.get_logged_in_user()
+        else:
+            approver = self.instructor_participation.user
+        with self.temporarily_switch_to_user(approver):
+            return self.c.post(self.preapproval_url, data, follow=True)
 
     def get_preapproval_count(self):
         return ParticipationPreapproval.objects.all().count()
@@ -894,13 +931,13 @@ class EnrollmentPreapprovalTest(EnrollmentPreapprovalTestMixin, TestCase):
         "preapproval_require_verified_inst_id": True}
 
     def test_preapproval_url_get(self):
-        self.c.force_login(self.instructor_participation.user)
-        resp = self.c.get(self.preapproval_url)
+        with self.temporarily_switch_to_user(self.instructor_participation.user):
+            resp = self.c.get(self.preapproval_url)
+
         self.assertTrue(resp.status_code, 200)
 
     def test_preapproval_create_email_type(self):
         resp = self.post_preapprovel(
-            self.instructor_participation.user,
             "email",
             self.preapprove_data_emails)
         self.assertEqual(
@@ -917,7 +954,6 @@ class EnrollmentPreapprovalTest(EnrollmentPreapprovalTestMixin, TestCase):
 
         # repost same data
         resp = self.post_preapprovel(
-            self.instructor_participation.user,
             "email",
             self.preapprove_data_emails)
         self.assertEqual(
@@ -934,7 +970,7 @@ class EnrollmentPreapprovalTest(EnrollmentPreapprovalTestMixin, TestCase):
 
     def test_preapproval_create_institutional_id_type(self):
         resp = self.post_preapprovel(
-            self.instructor_participation.user, "institutional_id",
+            "institutional_id",
             self.preapprove_data_institutional_ids)
         self.assertEqual(
             self.get_preapproval_count(),
@@ -951,7 +987,7 @@ class EnrollmentPreapprovalTest(EnrollmentPreapprovalTestMixin, TestCase):
 
         # repost same data
         resp = self.post_preapprovel(
-            self.instructor_participation.user, "institutional_id",
+            "institutional_id",
             self.preapprove_data_institutional_ids)
         self.assertEqual(
             self.get_preapproval_count(),
@@ -967,28 +1003,29 @@ class EnrollmentPreapprovalTest(EnrollmentPreapprovalTestMixin, TestCase):
         )
 
     def test_preapproval_create_permission_error(self):
-        self.c.force_login(self.student_participation.user)
-        resp = self.c.get(self.preapproval_url)
-        self.assertEqual(resp.status_code, 403)
-        resp = self.post_preapprovel(
-            self.student_participation.user,
-            "email",
-            self.preapprove_data_emails)
-        self.assertEqual(
-            self.get_preapproval_count(), 0)
-        self.assertEqual(resp.status_code, 403)
+        with self.temporarily_switch_to_user(self.student_participation.user):
+            resp = self.c.get(self.preapproval_url)
+            self.assertEqual(resp.status_code, 403)
+            resp = self.post_preapprovel(
+                "email",
+                self.preapprove_data_emails,
+                force_loggin_instructor=False
+            )
+            self.assertEqual(
+                self.get_preapproval_count(), 0)
+            self.assertEqual(resp.status_code, 403)
 
     def test_preapproval_email_type_approve_pendings(self):
         enroll_request_users = [self.non_participation_user1]
         for u in enroll_request_users:
-            self.c.force_login(u)
-            self.c.post(self.enroll_request_url, follow=True)
-            self.c.logout()
+            with self.temporarily_switch_to_user(u):
+                self.c.post(self.enroll_request_url, follow=True)
+
         self.flush_mailbox()
         expected_participation_count = (
             self.get_participation_count_by_status(participation_status.active) + 1)
         resp = self.post_preapprovel(
-            self.instructor_participation.user, "email",
+            "email",
             self.preapprove_data_emails)
         self.assertEqual(
             self.get_participation_count_by_status(
@@ -1011,9 +1048,9 @@ class EnrollmentPreapprovalTest(EnrollmentPreapprovalTestMixin, TestCase):
         enroll_request_users = [
             self.non_participation_user1, self.non_participation_user2]
         for u in enroll_request_users:
-            self.c.force_login(u)
-            self.c.post(self.enroll_request_url, follow=True)
-            self.c.logout()
+            with self.temporarily_switch_to_user(u):
+                self.c.post(self.enroll_request_url, follow=True)
+
         self.flush_mailbox()
         n_expected_newly_enrolled_users = (
             len([u for u in enroll_request_users if u.institutional_id_verified]))
@@ -1022,7 +1059,7 @@ class EnrollmentPreapprovalTest(EnrollmentPreapprovalTestMixin, TestCase):
             + n_expected_newly_enrolled_users
         )
         resp = self.post_preapprovel(
-            self.instructor_participation.user, "institutional_id",
+            "institutional_id",
             self.preapprove_data_institutional_ids)
         self.assertEqual(
             self.get_participation_count_by_status(
@@ -1055,9 +1092,9 @@ class EnrollmentPreapprovalInstIdNotRequireVerifiedTest(
         enroll_request_users = [
             self.non_participation_user1, self.non_participation_user2]
         for u in enroll_request_users:
-            self.c.force_login(u)
-            self.c.post(self.enroll_request_url, follow=True)
-            self.c.logout()
+            with self.temporarily_switch_to_user(u):
+                self.c.post(self.enroll_request_url, follow=True)
+
         self.flush_mailbox()
         n_expected_newly_enrolled_users = len(enroll_request_users)
         expected_participation_count = (
@@ -1065,7 +1102,7 @@ class EnrollmentPreapprovalInstIdNotRequireVerifiedTest(
             + n_expected_newly_enrolled_users
         )
         resp = self.post_preapprovel(
-            self.instructor_participation.user, "institutional_id",
+            "institutional_id",
             self.preapprove_data_institutional_ids)
         self.assertEqual(
             self.get_participation_count_by_status(
@@ -1116,9 +1153,9 @@ class EnrollmentRequestEmailConnectionsTest(
                 ENROLLMENT_EMAIL_FROM=self.enrollment_email_from):
 
             expected_from_email = settings.ENROLLMENT_EMAIL_FROM
+            with self.temporarily_switch_to_user(self.non_participation_user1):
+                self.c.post(self.enroll_request_url, follow=True)
 
-            self.c.force_login(self.non_participation_user1)
-            self.c.post(self.enroll_request_url, follow=True)
             msg = mail.outbox[0]
             self.assertEqual(msg.from_email, expected_from_email)
 
@@ -1132,8 +1169,9 @@ class EnrollmentRequestEmailConnectionsTest(
 
             expected_from_email = settings.ROBOT_EMAIL_FROM
 
-            self.c.force_login(self.non_participation_user1)
-            self.c.post(self.enroll_request_url, follow=True)
+            with self.temporarily_switch_to_user(self.non_participation_user1):
+                self.c.post(self.enroll_request_url, follow=True)
+
             msg = mail.outbox[0]
             self.assertEqual(msg.from_email, expected_from_email)
 
@@ -1151,8 +1189,9 @@ class EnrollmentDecisionEmailConnectionsTest(
 
             expected_from_email = settings.ENROLLMENT_EMAIL_FROM
 
-            self.c.force_login(self.instructor_participation.user)
-            self.c.post(self.my_participation_edit_url, self.approve_post_data)
+            with self.temporarily_switch_to_user(
+                    self.instructor_participation.user):
+                self.c.post(self.my_participation_edit_url, self.approve_post_data)
 
             msg = mail.outbox[0]
             self.assertEqual(msg.from_email, expected_from_email)
@@ -1166,8 +1205,9 @@ class EnrollmentDecisionEmailConnectionsTest(
 
             expected_from_email = self.course.from_email
 
-            self.c.force_login(self.instructor_participation.user)
-            self.c.post(self.my_participation_edit_url, self.approve_post_data)
+            with self.temporarily_switch_to_user(
+                    self.instructor_participation.user):
+                self.c.post(self.my_participation_edit_url, self.approve_post_data)
 
             msg = mail.outbox[0]
             self.assertEqual(msg.from_email, expected_from_email)
@@ -1185,8 +1225,10 @@ class EnrollmentDecisionEmailConnectionsTest(
 
             expected_from_email = settings.ROBOT_EMAIL_FROM
 
-            self.c.force_login(self.instructor_participation.user)
-            self.c.post(self.my_participation_edit_url, self.approve_post_data)
+            with self.temporarily_switch_to_user(
+                    self.instructor_participation.user):
+                self.c.post(self.my_participation_edit_url, self.approve_post_data)
+
             msg = mail.outbox[0]
             self.assertEqual(msg.from_email, expected_from_email)
 
@@ -1201,8 +1243,9 @@ class EnrollmentDecisionEmailConnectionsTest(
 
             expected_from_email = self.course.from_email
 
-            self.c.force_login(self.instructor_participation.user)
-            self.c.post(self.my_participation_edit_url, self.approve_post_data)
+            with self.temporarily_switch_to_user(
+                    self.instructor_participation.user):
+                self.c.post(self.my_participation_edit_url, self.approve_post_data)
             msg = mail.outbox[0]
             self.assertEqual(msg.from_email, expected_from_email)
     # }}}

--- a/tests/test_pages.py
+++ b/tests/test_pages.py
@@ -31,7 +31,7 @@ from django.contrib.auth import get_user_model
 from course.models import FlowPageVisit, Course, FlowSession
 from .base_test_mixins import (
     SingleCoursePageTestMixin, FallBackStorageMessageTestMixin,
-    FakedRunpyContainerMixin)
+    SubprocessRunpyContainerMixin)
 from .utils import LocmemBackendTestsMixin
 
 QUIZ_FLOW_ID = "quiz-test"
@@ -572,7 +572,7 @@ class SingleCourseQuizPageGradeInterfaceTest(LocmemBackendTestsMixin,
 
 class SingleCourseQuizPageCodeQuestionTest(
             SingleCoursePageTestMixin, FallBackStorageMessageTestMixin,
-            FakedRunpyContainerMixin, TestCase):
+            SubprocessRunpyContainerMixin, TestCase):
     flow_id = QUIZ_FLOW_ID
 
     def setUp(self):  # noqa


### PR DESCRIPTION
Allow (and use) static container to test code questions, along with some refactoring of unittest methods.

This is preparing for the future `GeneratedQuestions` or `VariantGeneratingQuestion` as discussed in #243.