### PR TITLE
Update python-memcached

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -78,7 +78,7 @@ git+https://github.com/knaperek/djangosaml2.git
 # Note: djangosaml2 uses a non-Py3 version of python-memcached directly.  #
 # Override that. Also: Don't be tempted to use this for Django caching--it's
 # broken.
-python-memcached==1.58
+python-memcached==1.59
 
 # }}}
 


### PR DESCRIPTION
Fixing this failure

```
Collecting python-memcached==1.58 (from -r requirements.txt (line 81))
  Using cached python-memcached-1.58.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/var/folders/yx/tn9fxy1s4qz1vf2cbb5fwlw00000gn/T/pip-build-l3yvlcg7/python-memcached/setup.py", line 8, in <module>
        version=get_module_constant('memcache', '__version__'),
      File "/Users/senthil/py/virtualenvironments/relateenv/lib/python3.6/site-packages/setuptools/depends.py", line 164, in get_module_constant
        return extract_constant(code, symbol, default)
      File "/Users/senthil/py/virtualenvironments/relateenv/lib/python3.6/site-packages/setuptools/depends.py", line 195, in extract_constant
        const = code.co_consts[arg]
    IndexError: tuple index out of range

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /private/var/folders/yx/tn9fxy1s4qz1vf2cbb5fwlw00000gn/T/pip-build-l3yvlcg7/python-memcached/
```