### PR TITLE
Ensure uniqueness of user email.

### DIFF
--- a/accounts/models.py
+++ b/accounts/models.py
@@ -236,7 +236,7 @@ class User(AbstractBaseUser, PermissionsMixin):
 
         # This is for backward compatibility.
         # Because user instances are frequently updated when auth_login,
-        # reset_password. Without this, all user won't be able to login.
+        # reset_password. Without this, no user will be able to login.
         if ((update_fields is not None and "email" in update_fields)
                 or self.pk is None):
             self.clean()

--- a/accounts/models.py
+++ b/accounts/models.py
@@ -220,7 +220,30 @@ class User(AbstractBaseUser, PermissionsMixin):
 
         return _("user")
 
+    def clean(self):
+        super(User, self).clean()
+        qset = self.__class__.objects.filter(email__iexact=self.email)
+        if self.pk is not None:
+            # In case editing an existing user object
+            qset = qset.exclude(pk=self.pk)
+        if qset.exists():
+            from django.core.exceptions import ValidationError
+            raise ValidationError(
+                {"email": _("That email address is already in use.")})
+
     def save(self, *args, **kwargs):
+        update_fields = kwargs.get("update_fields")
+
+        # This is for backward compatibility.
+        # Because user instances are frequently updated when auth_login,
+        # reset_password. Without this, all user won't be able to login.
+        if ((update_fields is not None and "email" in update_fields)
+                or self.pk is None):
+            self.clean()
+
+        if self.institutional_id is not None:
+            self.institutional_id = self.institutional_id.strip()
+
         # works around https://code.djangoproject.com/ticket/4136#comment:33
         self.institutional_id = self.institutional_id or None
         super(User, self).save(*args, **kwargs)

--- a/course/auth.py
+++ b/course/auth.py
@@ -611,7 +611,7 @@ def reset_password(request, field="email"):
                         _("Failed to send an email: multiple users were "
                           "unexpectedly using that same "
                           "email address. Please "
-                          "contact site staffs."))
+                          "contact site staff."))
             else:
                 if user is None:
                     FIELD_DICT = {  # noqa

--- a/course/auth.py
+++ b/course/auth.py
@@ -32,7 +32,7 @@ from django.shortcuts import (  # noqa
 from django.contrib import messages
 import django.forms as forms
 from django.core.exceptions import (PermissionDenied, SuspiciousOperation,
-        ObjectDoesNotExist)
+        ObjectDoesNotExist, MultipleObjectsReturned)
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Submit, Layout, Div, Button
 from django.conf import settings
@@ -482,14 +482,6 @@ def sign_up(request):
                 messages.add_message(request, messages.ERROR,
                         _("A user with that username already exists."))
 
-            elif get_user_model().objects.filter(
-                    email__iexact=form.cleaned_data["email"]).count():
-                messages.add_message(request, messages.ERROR,
-                        _("That email address is already in use. "
-                        "Would you like to "
-                        "<a href='%s'>reset your password</a> instead?")
-                        % reverse(
-                            "relate-reset_password")),
             else:
                 email = form.cleaned_data["email"]
                 user = get_user_model()(
@@ -534,6 +526,16 @@ def sign_up(request):
                         "the link."))
 
                 return redirect("relate-home")
+        else:
+            if ("email" in form.errors
+                    and "That email address is already in use."
+                    in form.errors["email"]):
+                messages.add_message(request, messages.ERROR,
+                        _("That email address is already in use. "
+                        "Would you like to "
+                        "<a href='%s'>reset your password</a> instead?")
+                        % reverse(
+                            "relate-reset_password"))
 
     else:
         form = SignUpForm()
@@ -583,80 +585,95 @@ def reset_password(request, field="email"):
     ResetPasswordForm = globals()["ResetPasswordFormBy" + field.title()]  # noqa
     if request.method == 'POST':
         form = ResetPasswordForm(request.POST)
+        user = None
         if form.is_valid():
+            exist_users_with_same_email = False
             if field == "instid":
                 inst_id = form.cleaned_data["instid"]
                 try:
                     user = get_user_model().objects.get(
                             institutional_id__iexact=inst_id)
                 except ObjectDoesNotExist:
-                    user = None
+                    pass
 
             if field == "email":
                 email = form.cleaned_data["email"]
                 try:
                     user = get_user_model().objects.get(email__iexact=email)
                 except ObjectDoesNotExist:
-                    user = None
+                    pass
+                except MultipleObjectsReturned:
+                    exist_users_with_same_email = True
 
-            if user is None:
-                FIELD_DICT = {  # noqa
-                        "email": _("email address"),
-                        "instid": _("institutional ID")
-                        }
+            if exist_users_with_same_email:
+                # This is for backward compatibility.
                 messages.add_message(request, messages.ERROR,
-                        _("That %(field)s doesn't have an "
-                            "associated user account. Are you "
-                            "sure you've registered?")
-                        % {"field": FIELD_DICT[field]})
+                        _("Failed to send an email: multiple users were "
+                          "unexpectedly using that same "
+                          "email address. Please "
+                          "contact site staffs."))
             else:
-                if not user.email:
-                    # happens when a user have an inst_id but have no email.
+                if user is None:
+                    FIELD_DICT = {  # noqa
+                            "email": _("email address"),
+                            "instid": _("institutional ID")
+                            }
                     messages.add_message(request, messages.ERROR,
-                            _("The account with that institution ID "
-                                "doesn't have an associated email."))
+                            _("That %(field)s doesn't have an "
+                                "associated user account. Are you "
+                                "sure you've registered?")
+                            % {"field": FIELD_DICT[field]})
                 else:
-                    email = user.email
-                    user.sign_in_key = make_sign_in_key(user)
-                    user.save()
+                    if not user.email:
+                        # happens when a user have an inst_id but have no email.
+                        # This is almost impossible, because the email field of
+                        # User should meet NOT NULL constraint.
+                        messages.add_message(request, messages.ERROR,
+                                _("The account with that institution ID "
+                                    "doesn't have an associated email."))
+                    else:
+                        email = user.email
+                        user.sign_in_key = make_sign_in_key(user)
+                        user.save()
 
-                    from relate.utils import render_email_template
-                    message = render_email_template("course/sign-in-email.txt", {
-                        "user": user,
-                        "sign_in_uri": request.build_absolute_uri(
-                            reverse(
-                                "relate-reset_password_stage2",
-                                args=(user.id, user.sign_in_key,))),
-                        "home_uri": request.build_absolute_uri(
-                            reverse("relate-home"))
-                        })
-                    from django.core.mail import EmailMessage
-                    msg = EmailMessage(
-                            string_concat("[%s] " % _(get_site_name()),
-                                          _("Password reset")),
-                            message,
-                            getattr(settings, "NO_REPLY_EMAIL_FROM",
-                                    settings.ROBOT_EMAIL_FROM),
-                            [email])
+                        from relate.utils import render_email_template
+                        message = render_email_template(
+                            "course/sign-in-email.txt", {
+                                "user": user,
+                                "sign_in_uri": request.build_absolute_uri(
+                                    reverse(
+                                        "relate-reset_password_stage2",
+                                        args=(user.id, user.sign_in_key,))),
+                                "home_uri": request.build_absolute_uri(
+                                    reverse("relate-home"))
+                            })
+                        from django.core.mail import EmailMessage
+                        msg = EmailMessage(
+                                string_concat("[%s] " % _(get_site_name()),
+                                              _("Password reset")),
+                                message,
+                                getattr(settings, "NO_REPLY_EMAIL_FROM",
+                                        settings.ROBOT_EMAIL_FROM),
+                                [email])
 
-                    from relate.utils import get_outbound_mail_connection
-                    msg.connection = (
-                            get_outbound_mail_connection("no_reply")
-                            if hasattr(settings, "NO_REPLY_EMAIL_FROM")
-                            else get_outbound_mail_connection("robot"))
-                    msg.send()
+                        from relate.utils import get_outbound_mail_connection
+                        msg.connection = (
+                                get_outbound_mail_connection("no_reply")
+                                if hasattr(settings, "NO_REPLY_EMAIL_FROM")
+                                else get_outbound_mail_connection("robot"))
+                        msg.send()
 
-                    if field == "instid":
+                        if field == "instid":
+                            messages.add_message(request, messages.INFO,
+                                _("The email address associated with that "
+                                  "account is %s.")
+                                % masked_email(email))
+
                         messages.add_message(request, messages.INFO,
-                            _("The email address associated with that "
-                                "account is %s.")
-                            % masked_email(email))
+                                _("Email sent. Please check your email and "
+                                  "click the link."))
 
-                    messages.add_message(request, messages.INFO,
-                            _("Email sent. Please check your email and "
-                            "click the link."))
-
-                    return redirect("relate-home")
+                        return redirect("relate-home")
     else:
         form = ResetPasswordForm()
 

--- a/tests/base_test_mixins.py
+++ b/tests/base_test_mixins.py
@@ -335,6 +335,19 @@ class SuperuserCreateMixin(ResponseContextMixin):
         return self.c.post(
             self.get_stop_impersonate_view_url(), data, follow=follow)
 
+    def get_reset_password_url(self, use_instid=False):
+        kwargs = {}
+        if use_instid:
+            kwargs["field"] = "instid"
+        return reverse("relate-reset_password", kwargs=kwargs)
+
+    def get_reset_password(self, use_instid=False):
+        return self.c.get(self.get_reset_password_url(use_instid))
+
+    def post_reset_password(self, data, use_instid=False):
+        return self.c.post(self.get_reset_password_url(use_instid),
+                           data=data)
+
     def get_fake_time_url(self):
         return reverse("relate-set_fake_time")
 
@@ -393,6 +406,13 @@ class SuperuserCreateMixin(ResponseContextMixin):
     def assertSessionPretendFacilitiesIsNone(self, session):  # noqa
         pretended = session.get("relate_pretend_facilities", None)
         self.assertIsNone(pretended)
+
+    def assertFormErrorLoose(self, response, error):  # noqa
+        """Assert that error is found in response.context['form'] errors"""
+        import itertools
+        form_errors = list(
+            itertools.chain(*response.context['form'].errors.values()))
+        self.assertIn(str(error), form_errors)
 
 
 # {{{ defined here so that they can be used by in classmethod and instance method

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -49,6 +49,9 @@ class UserFactory(factory.django.DjangoModelFactory):
         model = get_user_model()
 
     username = factory.Sequence(lambda n: "testuser_%03d" % n)
+    email = factory.Sequence(lambda n: "test_factory_%03d@exmaple.com" % n)
+    status = constants.user_status.active
+    password = factory.Sequence(lambda n: "password_%03d" % n)
 
 
 class CourseFactory(factory.django.DjangoModelFactory):

--- a/tests/test_accounts/test_models.py
+++ b/tests/test_accounts/test_models.py
@@ -1,0 +1,71 @@
+from __future__ import division
+
+__copyright__ = "Copyright (C) 2018 Dong Zhuang"
+
+__license__ = """
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"""
+
+from django.core.exceptions import ValidationError
+from django.db.utils import IntegrityError
+from django.test import TestCase
+from django.contrib.auth import get_user_model
+
+from tests.factories import UserFactory
+
+
+class UserModelTest(TestCase):
+    """
+    Different from tests.test_auth, this is testing db operation.
+    """
+    def test_email_uniqueness(self):
+        UserFactory.create(email="test@example.com")
+        with self.assertRaises(ValidationError) as error:
+            UserFactory.create(email="test@example.com")
+        self.assertEqual(
+            error.exception.messages,
+            ["That email address is already in use."])
+
+    def test_email_uniqueness_case_insensitive(self):
+        UserFactory.create(email="test@example.com")
+        with self.assertRaises(ValidationError) as error:
+            UserFactory.create(email="Test@example.com")
+        self.assertEqual(
+            error.exception.messages,
+            ["That email address is already in use."])
+
+    def test_institutional_uniqueness(self):
+        UserFactory.create(institutional_id="1234")
+        with self.assertRaises(IntegrityError):
+            UserFactory.create(institutional_id="1234")
+
+    def test_save_institutional_id_none(self):
+        user = UserFactory.create(institutional_id="1234")
+        users = get_user_model().objects.all()
+        self.assertTrue(users.count(), 1)
+        self.assertEqual(users[0].institutional_id, "1234")
+
+        user.institutional_id = "  "
+        user.save()
+        self.assertIsNone(get_user_model().objects.first().institutional_id)
+
+    def test_user_must_have_email(self):
+        UserFactory.create()
+        with self.assertRaises(IntegrityError):
+            UserFactory.create(email=None)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1556,7 +1556,7 @@ class ResetPasswordStageOneTest(CoursesTestMixinBase, LocmemBackendTestsMixin,
                     "Failed to send an email: multiple users were "
                     "unexpectedly using that same "
                     "email address. Please "
-                    "contact site staffs.")
+                    "contact site staff.")
                 resp = self.post_reset_password(
                     data={"email": "some_email@example.com"})
                 self.assertTrue(resp.status_code, 200)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -23,7 +23,6 @@ THE SOFTWARE.
 """
 
 import six
-import itertools
 from six.moves.urllib.parse import ParseResult, quote, urlparse
 from djangosaml2.urls import urlpatterns as djsaml2_urlpatterns
 from django.test import TestCase, override_settings, RequestFactory
@@ -46,6 +45,7 @@ from tests.base_test_mixins import (
 
 from tests.utils import (
     LocmemBackendTestsMixin, load_url_pattern_names, reload_urlconf, mock)
+from tests.factories import UserFactory
 
 # settings names
 EDITABLE_INST_ID_BEFORE_VERI = "RELATE_EDITABLE_INST_ID_BEFORE_VERIFICATION"
@@ -418,12 +418,6 @@ class AuthTestMixin(object):
 
     def assertSessionHasNoUserLoggedIn(self):  # noqa
         self.assertNotIn(SESSION_KEY, self.c.session)
-
-    def assertFormErrorLoose(self, response, error):  # noqa
-        """Assert that error is found in response.context['form'] errors"""
-        form_errors = list(
-            itertools.chain(*response.context['form'].errors.values()))
-        self.assertIn(str(error), form_errors)
 
     def concatenate_redirect_url(self, url, redirect_to=None):
         if not redirect_to:
@@ -1480,5 +1474,127 @@ class UserProfileTest(CoursesTestMixinBase, AuthTestMixin,
             self.assertTrue(resp.status_code, 200)
             self.assertIn(expected_msg,
                           mock_add_msg.call_args[0])
+
+
+class ResetPasswordStageOneTest(CoursesTestMixinBase, LocmemBackendTestsMixin,
+                                TestCase):
+    @classmethod
+    def setUpTestData(cls):  # noqa
+        super(ResetPasswordStageOneTest, cls).setUpTestData()
+        cls.user_email = "a_very_looooooong_email@somehost.com"
+        cls.user_inst_id = "1234"
+        cls.user = UserFactory.create(email=cls.user_email,
+                                      institutional_id=cls.user_inst_id)
+
+    def setUp(self):
+        super(ResetPasswordStageOneTest, self).setUp()
+        self.registration_override_setting = override_settings(
+            RELATE_REGISTRATION_ENABLED=True)
+        self.registration_override_setting.enable()
+        self.addCleanup(self.registration_override_setting.disable)
+        self.user.refresh_from_db()
+        self.c.logout()
+
+    def test_reset_get(self):
+        resp = self.get_reset_password()
+        self.assertEqual(resp.status_code, 200)
+        resp = self.get_reset_password(use_instid=True)
+        self.assertEqual(resp.status_code, 200)
+
+    @override_settings(RELATE_REGISTRATION_ENABLED=False)
+    def test_reset_with_registration_disabled(self):
+        resp = self.get_reset_password()
+        self.assertEqual(resp.status_code, 400)
+
+        resp = self.get_reset_password(use_instid=True)
+        self.assertEqual(resp.status_code, 400)
+
+        resp = self.post_reset_password(data={})
+        self.assertEqual(resp.status_code, 400)
+
+        resp = self.post_reset_password(use_instid=True, data={})
+        self.assertEqual(resp.status_code, 400)
+
+    def test_reset_form_invalid(self):
+        resp = self.post_reset_password(
+            data={"email": "some/email"})
+        self.assertTrue(resp.status_code, 200)
+        self.assertFormErrorLoose(resp, "Enter a valid email address.")
+        self.assertEqual(len(mail.outbox), 0)
+
+    def test_reset_by_email_non_exist(self):
+        with mock.patch("course.auth.messages.add_message") as mock_add_msg:
+            expected_msg = (
+                "That %s doesn't have an "
+                "associated user account. Are you "
+                "sure you've registered?" % "email address")
+            resp = self.post_reset_password(
+                data={"email": "some_email@example.com"})
+            self.assertTrue(resp.status_code, 200)
+            self.assertIn(expected_msg, mock_add_msg.call_args[0])
+        self.assertEqual(len(mail.outbox), 0)
+
+    def test_reset_by_instid_non_exist(self):
+        with mock.patch("course.auth.messages.add_message") as mock_add_msg:
+            expected_msg = (
+                "That %s doesn't have an "
+                "associated user account. Are you "
+                "sure you've registered?" % "institutional ID")
+            resp = self.post_reset_password(
+                data={"instid": "2345"}, use_instid=True)
+            self.assertTrue(resp.status_code, 200)
+            self.assertIn(expected_msg, mock_add_msg.call_args[0])
+        self.assertEqual(len(mail.outbox), 0)
+        self.assertEqual(resp.status_code, 200)
+
+    def test_reset_by_email_have_multiple_user_with_same_email(self):
+        with mock.patch("accounts.models.User.objects.get") as mock_get_user:
+            from django.core.exceptions import MultipleObjectsReturned
+            mock_get_user.side_effect = MultipleObjectsReturned()
+            with mock.patch("course.auth.messages.add_message") as mock_add_msg:
+                expected_msg = (
+                    "Failed to send an email: multiple users were "
+                    "unexpectedly using that same "
+                    "email address. Please "
+                    "contact site staffs.")
+                resp = self.post_reset_password(
+                    data={"email": "some_email@example.com"})
+                self.assertTrue(resp.status_code, 200)
+                self.assertIn(expected_msg, mock_add_msg.call_args[0])
+            self.assertEqual(len(mail.outbox), 0)
+
+    def test_reset_by_email_post_success(self):
+        with mock.patch("course.auth.messages.add_message") as mock_add_msg:
+            expected_msg = (
+                "Email sent. Please check your email and "
+                "click the link."
+            )
+            resp = self.post_reset_password(data={"email": self.user_email})
+            self.assertTrue(resp.status_code, 200)
+            self.assertEqual(mock_add_msg.call_count, 1)
+            self.assertIn(expected_msg, mock_add_msg.call_args[0])
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertTemplateUsed("course/sign-in-email.txt", count=1)
+
+    def test_reset_by_istid_post_success(self):
+        from course.auth import masked_email
+        masked = masked_email(self.user_email)
+        self.assertNotEqual(masked, self.user_email)
+
+        with mock.patch("course.auth.messages.add_message") as mock_add_msg, \
+                mock.patch("course.auth.masked_email") as mock_mask_email:
+            expected_msg = (
+                "Email sent. Please check your email and "
+                "click the link."
+            )
+            resp = self.post_reset_password(data={"instid": self.user_inst_id},
+                                            use_instid=True)
+            self.assertTrue(resp.status_code, 200)
+            self.assertEqual(mock_add_msg.call_count, 2)
+            self.assertEqual(mock_mask_email.call_count, 1)
+            self.assertIn(expected_msg, mock_add_msg.call_args[0])
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertTemplateUsed("course/sign-in-email.txt", count=1)
+
 
 # vim: foldmethod=marker


### PR DESCRIPTION
Without this, staff can save multiple users with the same email in admin. Then reset password through email will result in 500 for those users.