### PR TITLE
Ensure I18N literals were marked correctly via CI.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -67,6 +67,9 @@ install:
 before_test:
   - "%CMD_IN_ENV% pip install coverage"
 
+  # Make sure i18n literals marked correctly
+  - "python manage.py makemessages --no-location"
+
 test_script:
   # Run the project tests
   - "%CMD_IN_ENV% coverage run manage.py test tests/"

--- a/run-tests-for-ci.sh
+++ b/run-tests-for-ci.sh
@@ -64,6 +64,9 @@ $PIP install -r req.txt
 
 cp local_settings.example.py local_settings.py
 
+# Make sure i18n literals marked correctly
+${PY_EXE} manage.py makemessages --no-location
+
 $PIP install codecov
 coverage run manage.py test tests/
 coverage report -m


### PR DESCRIPTION
If I18N literals marked incorrect, CI tests will fail.