### PR TITLE
Avoid failure when student passes non-callable as function

### DIFF
--- a/course/page/code_feedback.py
+++ b/course/page/code_feedback.py
@@ -171,6 +171,14 @@ class Feedback:
             return f(*args, **kwargs)
         except Exception as e:
             if callable(f):
+                try:
+                    callable_name = f.__name__
+                except Exception as e_name:
+                    callable_name = (
+                                "<unable to retrieve name; encountered %s: %s>"
+                                % (
+                                    type(e_name).__name__,
+                                    str(e_name)))
                 from traceback import format_exc
                 self.add_feedback(
                         "<p>"
@@ -180,7 +188,7 @@ class Feedback:
                         "</p>"
                         "<pre>%s</pre>"
                         % (
-                            f.__name__,
+                            callable_name,
                             "".join(format_exc())))
             else:
                 self.add_feedback(

--- a/course/page/code_feedback.py
+++ b/course/page/code_feedback.py
@@ -170,17 +170,25 @@ class Feedback:
         try:
             return f(*args, **kwargs)
         except Exception as e:
-            from traceback import format_exc
-            self.add_feedback(
-                    "<p>"
-                    "The callable '%s' supplied in your code failed with "
-                    "an exception while it was being called by the grading "
-                    "code:"
-                    "</p>"
-                    "<pre>%s</pre>"
-                    % (
-                        f.__name__,
-                        "".join(format_exc())))
+            if callable(f):
+                from traceback import format_exc
+                self.add_feedback(
+                        "<p>"
+                        "The callable '%s' supplied in your code failed with "
+                        "an exception while it was being called by the grading "
+                        "code:"
+                        "</p>"
+                        "<pre>%s</pre>"
+                        % (
+                            f.__name__,
+                            "".join(format_exc())))
+            else:
+                self.add_feedback(
+                        "<p>"
+                        "Your code was supposed to supply a function or "
+                        "callable, but the variable you supplied was not "
+                        "callable."
+                        "</p>")
 
             self.set_points(0)
             raise GradingComplete()


### PR DESCRIPTION
When students pass a non-function as `f` and we use `feedback.call_user(f)`, the grading code fails when trying to get `f.__name__`.  This patch resolves the issue by checking whether `f` is a `callable`.

One thing to note:  `callable()` was removed in Python 3.0 and 3.1, but brought back in later versions.  If you do not want to use `callable()`, you could accomplish the same thing with 

`import collections`
`isinstance(f, collections.Callable)`

I have *not* been able to test this on a running RELATE instance, so please look it over closely.