### PR TITLE
Fix bug when feedback points are close enough to 1

### DIFF
--- a/course/page/code_runpy_backend.py
+++ b/course/page/code_runpy_backend.py
@@ -24,6 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
+import math
 import sys
 import traceback
 
@@ -299,6 +300,9 @@ def run_code(result, run_req):
         except Exception:
             package_exception(result, "test_error")
             return
+
+    if feedback.points is not None and math.isclose(feedback.points, 1):
+        feedback.points = 1
 
     if not (feedback.points is None or 0 <= feedback.points <= 1):
         raise ValueError("grade point value is invalid: %s"


### PR DESCRIPTION
We have a lot of multi-part homework questions. We initialize a score of 0, then add points for each part the student gets correct. For example:
```python
score = 0

if x is good:
    score += 0.3
if y is good:
    score += 0.3
if plot is good:
    score += 0.2
if plot has a title:
    score += 0.05
if plot has an xlabel:
    score += 0.05
if plot has a ylabel:
    score += 0.05
if plot has the correct axes:
    score += 0.05

feedback.set_points(score)
```
This test code looks innocuous enough, until you realize that `score` doesn't add up to 1, it adds up to 1.0000000000000002. This results in RELATE crashing with the following error message:
```
Traceback (most recent call last):
  File "/opt/runpy/runpy", line 89, in do_POST
    run_code(response, run_req)
  File "/opt/runpy/code_runpy_backend.py", line 303, in run_code
    % feedback.points)
ValueError: grade point value is invalid: 1.0000000000000002
```
To get around this, we've been adding the following code snippet to all of our test codes:
```python
import math

if math.isclose(score, 1):
    feedback.set_points(1)
else:
    feedback.set_points(score)
```
I figured it was time I got around to reporting and fixing this bug.

**Note:** I haven't actually tested this change. I have no idea how to test this.

This is one of many ways to solve the problem. Personally, I think it would be easier to accept any value greater than 1 as 1, so if the point total can go over 100%, let it. I wasn't sure if it would be better to catch the bug in this file, or in code_feedback.py. Personally, I would use a setter for the points attribute that checks these kind of things.