### PR TITLE
Ensure test failure when I18N literals formatted improperly.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -61,9 +61,6 @@ install:
 before_test:
   - "%CMD_IN_ENV% pip install coverage factory_boy"
 
-  # Make sure i18n literals marked correctly
-  - "python manage.py makemessages --no-location"
-
 test_script:
   # Run the project tests
   - "%CMD_IN_ENV% coverage run manage.py test tests/"

--- a/run-tests-for-ci.sh
+++ b/run-tests-for-ci.sh
@@ -65,7 +65,14 @@ $PIP install -r req.txt
 cp local_settings.example.py local_settings.py
 
 # Make sure i18n literals marked correctly
-${PY_EXE} manage.py makemessages --no-location
+${PY_EXE} manage.py makemessages --no-location --ignore=req.txt > output.txt
+
+if [[ -n $(grep "msgid" output.txt) ]]; then
+    echo "Command 'python manage.py makemessages' failed with the following info:"
+    echo ""
+    grep --color -E '^|warning: ' output.txt
+    exit 1;
+fi
 
 $PIP install codecov factory_boy
 coverage run manage.py test tests/


### PR DESCRIPTION
1. Instead of logging a warning message, exit build/test with failure.
1. Removed makemessages process for Appveyor CI (it's hard to grep the output from the execution result).