### PR TITLE
Pin dulwich version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ pytz
 pyyaml
 
 # dulwich
-dulwich>=0.18.2
+dulwich>=0.18.2,<0.19.0
 ecdsa
 paramiko
 


### PR DESCRIPTION
My requirements update somewhat changed the dependency resolution, and as a result it now uses dulwich 0.19 which contains [this](https://github.com/dulwich/dulwich/commit/8395a4e84b4245c534f418d8c957d83e071c12cc) breaking change, complaining that redundant kwargs are given.

We should adopt Dulwich's ParamikoSSHVendor, but anyway here's a hotfix.