### PR TITLE
More readable data type error messages

### DIFF
--- a/course/page/code_feedback.py
+++ b/course/page/code_feedback.py
@@ -92,7 +92,7 @@ class Feedback:
             return bad(
                     "'%s' does not have correct data type--"
                     "got: '%s', expected: '%s'" % (
-                        name, data.dtype.kind, ref.dtype.kind))
+                        name, data.dtype, ref.dtype))
 
         return True
 


### PR DESCRIPTION
Because this:
```
'data points' does not have correct data type--got: 'float64', expected: 'int64'
```
is much more readable than this:
```
'data points' does not have correct data type--got: 'f', expected: 'i'
```
This is also inline with the error message for `check_numpy_array_sanity`:
```
'data points' does not consist of floating point numbers--got: 'int64'
```