### PR TITLE
Update typing dependency.

### DIFF
--- a/course/content.py
+++ b/course/content.py
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
-from typing import cast, Union
+from typing import cast, Union, Text
 
 from django.conf import settings
 from django.utils.translation import ugettext as _
@@ -1147,11 +1147,7 @@ def parse_date_spec(
         return localize_if_needed(
                 datetime.datetime.combine(datespec, datetime.time.min))
 
-    try:
-        from typing import Text
-    except ImportError:
-        Text = None  # noqa
-    datespec_str = cast(Text, datespec).strip()  # type: ignore
+    datespec_str = cast(Text, datespec).strip()
 
     # {{{ parse postprocessors
 

--- a/course/utils.py
+++ b/course/utils.py
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
-from typing import cast
+from typing import cast, Text
 
 import six
 import datetime  # noqa
@@ -538,12 +538,7 @@ def get_session_grading_rule(
         max_points_enforced_cap = getattr_with_fallback(
                 (rule, flow_desc), "max_points_enforced_cap", None)
 
-        try:
-            from typing import Text  # noqa
-        except ImportError:
-            Text = None  # noqa
-
-        grade_aggregation_strategy = cast(Text, grade_aggregation_strategy)  # type: ignore  # noqa
+        grade_aggregation_strategy = cast(Text, grade_aggregation_strategy)
 
         return FlowSessionGradingRule(
                 grade_identifier=grade_identifier,

--- a/course/views.py
+++ b/course/views.py
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
-from typing import cast, List
+from typing import cast, List, Text
 
 import datetime
 
@@ -1155,11 +1155,7 @@ def grant_exception_stage_3(pctx, participation_id, flow_id, session_id):
 
             tags = []  # type: List[Text]
             if hasattr(flow_desc, "rules"):
-                try:
-                    from typing import Text  # noqa
-                except ImportError:
-                    Text = None  # noqa
-                tags = cast(List[Text], getattr(flow_desc.rules, "tags", []))  # type: ignore  # noqa
+                tags = cast(List[Text], getattr(flow_desc.rules, "tags", []))
 
             exception_created = False
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -92,7 +92,7 @@ git+https://github.com/inducer/bleach@prevent-attribute-value-filtering#egg=blea
 pytools
 
 # For mypy (static type checking) support
-typing
+typing>=3.6.1
 
 # For unittest by mock (only required for Py2)
 # mock


### PR DESCRIPTION
For Python 2.7, typing >= 3.6.1 is required.