### PR TITLE
Revert "Add another nuisance error message"

### DIFF
--- a/course/page/code.py
+++ b/course/page/code.py
@@ -280,10 +280,6 @@ def is_nuisance_failure(result):
         if "[Errno 113] No route to host" in result["traceback"]:
             return True
 
-        if "requests.exceptions.ReadTimeout: HTTPSConnectionPool" \
-                in result["traceback"]:
-            return True
-
     return False
 
 

--- a/tests/test_pages/test_code.py
+++ b/tests/test_pages/test_code.py
@@ -1331,13 +1331,6 @@ class IsNuisanceFailureTest(unittest.TestCase):
                       "\n[Errno 113] No route to host: \nfoo"}
         self.assertTrue(is_nuisance_failure(result))
 
-    def test_read_timeout_https(self):
-        result = {"result": "uncaught_error",
-                  "traceback":
-                      "\nrequests.exceptions.ReadTimeout: "
-                      "HTTPSConnectionPool: \nfoo"}
-        self.assertTrue(is_nuisance_failure(result))
-
 
 class CodeQuestionWithHumanTextFeedbackSpecialCase(
         SingleCoursePageTestMixin, SubprocessRunpyContainerMixin, TestCase):


### PR DESCRIPTION
This reverts commit afe8001a325088a124964d9744aa18c6ad7d7a2f. The filtered message potentially was not spurious after all, indicating a real failure. (whose impact for the UIUC instance was masked by docker swarm redistribution)