### PR TITLE
Render events via Ajax.

### DIFF
--- a/course/calendar.py
+++ b/course/calendar.py
@@ -26,27 +26,29 @@ THE SOFTWARE.
 
 import six
 from six.moves import range
+import datetime
+from bootstrap3_datetime.widgets import DateTimePicker
+from crispy_forms.layout import Submit
 
 from django.utils.translation import (
         ugettext_lazy as _, pgettext_lazy)
 from django.contrib.auth.decorators import login_required
-from course.utils import course_view, render_course_page
 from django.core.exceptions import (
     PermissionDenied, ObjectDoesNotExist, ValidationError)
 from django.db import transaction
 from django.contrib import messages  # noqa
+from django.http import JsonResponse
 import django.forms as forms
 
-from crispy_forms.layout import Submit
+from relate.utils import (
+    StyledForm, as_local_time, string_concat)
 
-import datetime
-from bootstrap3_datetime.widgets import DateTimePicker
-
-from relate.utils import StyledForm, as_local_time, string_concat
+from course.views import get_now_or_fake_time
 from course.constants import (
         participation_permission as pperm,
         )
 from course.models import Event
+from course.utils import course_view, render_course_page
 
 
 class ListTextWidget(forms.TextInput):
@@ -367,9 +369,17 @@ def view_calendar(pctx):
     if not pctx.has_permission(pperm.view_calendar):
         raise PermissionDenied(_("may not view calendar"))
 
-    from course.views import get_now_or_fake_time
     now = get_now_or_fake_time(pctx.request)
+    default_date = now.date()
+    if pctx.course.end_date is not None and default_date > pctx.course.end_date:
+        default_date = pctx.course.end_date
 
+    return render_course_page(pctx, "course/calendar.html", {
+        "default_date": default_date.isoformat(),
+    })
+
+
+def _get_events(pctx):
     events_json = []
 
     from course.content import (
@@ -379,6 +389,8 @@ def view_calendar(pctx):
                 pctx.course.events_file, pctx.course_commit_sha)
     except ObjectDoesNotExist:
         event_descr = {}
+
+    now = get_now_or_fake_time(pctx.request)
 
     event_kinds_desc = event_descr.get("event_kinds", {})
     event_info_desc = event_descr.get("events", {})
@@ -472,16 +484,30 @@ def view_calendar(pctx):
 
         events_json.append(event_json)
 
-    default_date = now.date()
-    if pctx.course.end_date is not None and default_date > pctx.course.end_date:
-        default_date = pctx.course.end_date
+    from django.template.loader import render_to_string
+    events_info_html = render_to_string(
+        "course/events_info.html",
+        context={"event_info_list": event_info_list},
+        request=pctx.request)
 
-    from json import dumps
-    return render_course_page(pctx, "course/calendar.html", {
-        "events_json": dumps(events_json),
-        "event_info_list": event_info_list,
-        "default_date": default_date.isoformat(),
-    })
+    return events_info_html, events_json
+
+
+@course_view
+def fetch_events(pctx):
+    if not pctx.has_permission(pperm.view_calendar):
+        raise PermissionDenied(_("may not view calendar"))
+
+    request = pctx.request
+    if not (request.is_ajax() and request.method == "GET"):
+        raise PermissionDenied(_("only AJAX GET is allowed"))
+
+    events_info_html, events_json = _get_events(pctx)
+
+    return JsonResponse(
+        {"events_json": events_json,
+         "events_info_html": events_info_html},
+        safe=False)
 
 # }}}
 

--- a/course/templates/course/calendar.html
+++ b/course/templates/course/calendar.html
@@ -4,61 +4,98 @@
 {% load static %}
 
 {% block title %}
-  {{ course.number}}
+  {{ course.number }}
   {% trans "Calendar" %} - {{ relate_site_name }}
 {% endblock %}
 
-{%block head_assets_extra %}
-  <link rel='stylesheet' href='{% static "fullcalendar/dist/fullcalendar.css" %}' />
+{% block head_assets_extra %}
+  <link rel='stylesheet' href='{% static "fullcalendar/dist/fullcalendar.css" %}?version=3.9.0'/>
   <script src='{% static "moment/moment.js" %}'></script>
-  <script src='{% static "fullcalendar/dist/fullcalendar.js" %}'></script>
+  <script src='{% static "fullcalendar/dist/fullcalendar.min.js" %}?version=3.9.0'></script>
   {# load calendar with local language #}
   {% get_current_language as LANGUAGE_CODE %}
   {% if LANGUAGE_CODE != "en" %}
-    <script src='{% static "fullcalendar/dist/lang/" %}{{ LANGUAGE_CODE |js_lang_fallback:"fullcalendar" }}.js'></script>
+    <script src='{% static "fullcalendar/dist/locale/" %}{{ LANGUAGE_CODE |js_lang_fallback:"fullcalendar" }}.js?version=3.9.0'></script>
   {% endif %}
+  {% if pperm.edit_events %}
+    <script src='{% static "blueimp-tmpl/js/tmpl.min.js" %}'></script>
+  {% endif %}
+
+  <style>
+    .spinner {
+      background: rgba(0, 0, 0, .2) url({% static "images/busy.gif" %}) no-repeat center center;
+      width: 100%;
+      height: 100%;
+      position: fixed;
+      top: 0;
+      left: 0;
+      z-index: 999;
+    }
+  </style>
+
 {% endblock %}
 
+
 {% block content %}
-  <h1>{{ course.number}} {% trans "Calendar" %}</h1>
+  <h1>{{ course.number }} {% trans "Calendar" %}</h1>
+  <div id="course-cal" style="margin-top:3em"></div>
+  <div id="cover"></div>
+  <b class="relate-calendar-notes">{% trans "Note" %}:</b>
+  {% trans "Some calendar entries are clickable and link to entries below." %}
 
-  <div id="coursecal" style="margin-top:3em"></div>
+  <div id="relate-event-info" style="margin-top:3ex"></div>
+{% endblock %}
 
-
+{% block page_bottom_javascript_extra %}
   <script type="text/javascript">
-    $(document).ready(function() {
-        $('#coursecal').fullCalendar({
+    (function(){
+      var $courseCal = $('#course-cal'),
+        $relateEventInfo = $('#relate-event-info');
+
+      var fetchUrl = '{% url "relate-fetch_events" course.identifier %}';
+
+      $(document).ready(function () {
+        $courseCal.fullCalendar({
           header: {
             left: 'prev,next today',
             center: 'title',
-            right: 'month,agendaWeek,agendaDay'
+            right: 'month,agendaWeek,agendaDay,listMonth'
           },
+          contentHeight: "auto",
           defaultDate: '{{ default_date }}',
+          defaultView: $(window).width() < 765 ? 'listMonth': 'month',
           timezone: "local",
+          nowIndicator: true,
+          views: {
+            month: {
+              displayEventEnd: $(window).width() < 765 ? false: true
+            }
+          },
+          minTime: "06:00:00",
+          maxTime: "24:00:00",
+          loading: function(isLoading, view){
+            if (isLoading)
+              $("#cover").addClass('spinner');
+            else $("#cover").removeClass('spinner');
+          },
+          events: function (start, end, timezone, callback) {
+            $.ajax({
+              url: fetchUrl,
+              success: function (result) {
+                $relateEventInfo.empty().html(result.events_info_html);
 
-          events: {{ events_json|safe }}
-        })
-    });
+                {# use events_json as eventSource #}
+                callback(result.events_json);
+                }
+              })
+            },
+        });
+      });
+    })();
+
   </script>
 
-{% blocktrans trimmed %}
-  <b>Note:</b> Some calendar entries are clickable and link to entries
-  below.
-{% endblocktrans %}
 
-  <div style="margin-top:3ex">
-  {% for event_info in event_info_list %}
-    <div id="event-{{ event_info.id }}" class="panel panel-default relate-calendar-event">
-      <div class="panel-heading">
-        <b>{{ event_info.human_title }}</b>
-        ({{ event_info.start_time }}{% if event_info.end_time %} - {{ event_info.end_time }}{% endif %})
-      </div>
-      <div class="panel-body">
-        {{ event_info.description|safe }}
-      </div>
-    </div>
-  {% endfor%}
-  </div>
-
+  {{ block.super }}
 {% endblock %}
 

--- a/course/templates/course/calendar.html
+++ b/course/templates/course/calendar.html
@@ -21,17 +21,19 @@
     <script src='{% static "blueimp-tmpl/js/tmpl.min.js" %}'></script>
   {% endif %}
 
-  <style>
-    .spinner {
-      background: rgba(0, 0, 0, .2) url({% static "images/busy.gif" %}) no-repeat center center;
-      width: 100%;
-      height: 100%;
-      position: fixed;
-      top: 0;
-      left: 0;
-      z-index: 999;
-    }
-  </style>
+  {% if pperm.edit_events %}
+    <style>
+      .spinner {
+        background: rgba(0, 0, 0, .2) url({% static "images/busy.gif" %}) no-repeat center center;
+        width: 100%;
+        height: 100%;
+        position: fixed;
+        top: 0;
+        left: 0;
+        z-index: 999;
+      }
+    </style>
+  {% endif %}
 
 {% endblock %}
 
@@ -39,11 +41,13 @@
 {% block content %}
   <h1>{{ course.number }} {% trans "Calendar" %}</h1>
   <div id="course-cal" style="margin-top:3em"></div>
-  <div id="cover"></div>
+  {% if pperm.edit_events %}
+    <div id="cover"></div>
+  {% endif %}
   <b class="relate-calendar-notes">{% trans "Note" %}:</b>
   {% trans "Some calendar entries are clickable and link to entries below." %}
 
-  <div id="relate-event-info" style="margin-top:3ex"></div>
+  <div id="relate-event-info" style="margin-top:3ex">{{ events_info_html|safe }}</div>
 {% endblock %}
 
 {% block page_bottom_javascript_extra %}
@@ -51,8 +55,6 @@
     (function(){
       var $courseCal = $('#course-cal'),
         $relateEventInfo = $('#relate-event-info');
-
-      var fetchUrl = '{% url "relate-fetch_events" course.identifier %}';
 
       $(document).ready(function () {
         $courseCal.fullCalendar({
@@ -78,7 +80,11 @@
               $("#cover").addClass('spinner');
             else $("#cover").removeClass('spinner');
           },
+        {% if not pperm.edit_events %}
+          events: {{ events_json|safe }},
+        {% else %}
           events: function (start, end, timezone, callback) {
+            var fetchUrl = '{% url "relate-fetch_events" course.identifier %}';
             $.ajax({
               url: fetchUrl,
               success: function (result) {
@@ -89,12 +95,12 @@
                 }
               })
             },
+        {% endif %}
         });
       });
     })();
 
   </script>
-
 
   {{ block.super }}
 {% endblock %}

--- a/course/templates/course/events_info.html
+++ b/course/templates/course/events_info.html
@@ -1,0 +1,12 @@
+{% for event_info in event_info_list %}
+    <div id="event-{{ event_info.id }}" class="panel panel-default relate-calendar-event">
+      <div class="panel-heading">
+        <b>{{ event_info.human_title }}</b>
+        ({{ event_info.start_time }}{% if event_info.end_time %} -
+        {{ event_info.end_time }}{% endif %})
+      </div>
+      <div class="panel-body">
+        {{ event_info.description|safe }}
+      </div>
+    </div>
+{% endfor %}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "datatables.net-fixedcolumns-bs": "^3.2.4",
     "datatables-i18n": "git+https://github.com/dzhuang/datatables-i18n.git",
     "font-awesome": "^4.7.0",
-    "fullcalendar": "^2.9.1",
+    "fullcalendar": "^3.9.0",
     "jquery": "^3.3.1",
     "jquery-ui-dist": "^1.12.1",
     "jstree": "^3.3.5",

--- a/relate/urls.py
+++ b/relate/urls.py
@@ -345,6 +345,11 @@ urlpatterns = [
         "/calendar/$",
         course.calendar.view_calendar,
         name="relate-view_calendar"),
+    url(r"^course"
+        "/" + COURSE_ID_REGEX +
+        "/calendar/fetch/$",
+        course.calendar.fetch_events,
+        name="relate-fetch_events"),
 
     # }}}
 

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -27,6 +27,7 @@ import json
 import datetime
 
 from django.test import TestCase
+from django.urls import reverse
 from django.utils.timezone import now, timedelta
 from django.core.exceptions import ValidationError
 
@@ -568,21 +569,19 @@ class RenumberEventsTest(SingleCourseTestMixin,
         self.assertAddMessageCalledWith("Events renumbered.")
 
 
-class ViewCalendarTest(SingleCourseTestMixin, HackRepoMixin, TestCase):
-    """test course.calendar.view_calendar"""
+class CalendarTestMixin(SingleCourseTestMixin, HackRepoMixin):
 
     default_faked_now = datetime.datetime(2019, 1, 1, tzinfo=pytz.UTC)
     default_event_time = default_faked_now - timedelta(hours=12)
     default_event_kind = "lecture"
 
     def setUp(self):
-        super(ViewCalendarTest, self).setUp()
+        super(CalendarTestMixin, self).setUp()
         fake_get_now_or_fake_time = mock.patch(
-            "course.views.get_now_or_fake_time")
+            "course.calendar.get_now_or_fake_time")
         self.mock_get_now_or_fake_time = fake_get_now_or_fake_time.start()
         self.mock_get_now_or_fake_time.return_value = now()
         self.addCleanup(fake_get_now_or_fake_time.stop)
-
         self.addCleanup(factories.EventFactory.reset_sequence)
 
     def get_course_calender_view(self, course_identifier=None):
@@ -594,6 +593,10 @@ class ViewCalendarTest(SingleCourseTestMixin, HackRepoMixin, TestCase):
         self.course.events_file = "events.yml"
         self.course.save()
 
+
+class ViewCalendarTest(CalendarTestMixin, TestCase):
+    force_login_student_for_each_test = True
+
     def test_no_pperm(self):
         with mock.patch(
                 "course.utils.CoursePageContext.has_permission"
@@ -602,14 +605,104 @@ class ViewCalendarTest(SingleCourseTestMixin, HackRepoMixin, TestCase):
             resp = self.get_course_calender_view()
             self.assertEqual(resp.status_code, 403)
 
-    def test_neither_events_nor_event_file(self):
-        self.mock_get_now_or_fake_time.return_value = self.default_faked_now
+    def test_success(self):
         resp = self.get_course_calender_view()
         self.assertEqual(resp.status_code, 200)
-        self.assertResponseContextEqual(resp, "events_json", '[]')
-        self.assertResponseContextEqual(resp, "event_info_list", [])
+
+    def test_default_time(self):
+        if self.course.end_date is not None:
+            self.course.end_date = (
+                    self.default_faked_now.date() + timedelta(days=100))
+            self.course.save()
+
+        self.mock_get_now_or_fake_time.return_value = self.default_faked_now
+
+        resp = self.get_course_calender_view()
+        self.assertEqual(resp.status_code, 200)
         self.assertResponseContextEqual(
             resp, "default_date", self.default_faked_now.date().isoformat())
+
+    def test_default_time_after_course_ended(self):
+        self.mock_get_now_or_fake_time.return_value = self.default_faked_now
+
+        self.course.end_date = self.default_faked_now.date() - timedelta(days=100)
+        self.course.save()
+        self.assertTrue(self.course.end_date < self.default_faked_now.date())
+
+        resp = self.get_course_calender_view()
+        self.assertEqual(resp.status_code, 200)
+
+        # Calendar's default_date will be course.end_date
+        self.assertResponseContextEqual(
+            resp, "default_date", self.course.end_date.isoformat())
+
+
+class FetchEventsTest(CalendarTestMixin, TestCase):
+    """test course.calendar.fetch_events"""
+    force_login_student_for_each_test = True
+
+    def setUp(self):
+        super(FetchEventsTest, self).setUp()
+        fake_render_to_string = mock.patch("django.template.loader.render_to_string")
+        self.mock_render_to_string = fake_render_to_string.start()
+
+        # Note: in this way, the events_info_html in the fetch_event response
+        # will always be empty, we test the events_info_html by check the kwargs
+        # when calling render_to_string
+        self.mock_render_to_string.return_value = ""
+        self.addCleanup(fake_render_to_string.stop)
+
+    def get_event_info_list_rendered(self):
+        """get the event_info_list rendered from mocked render_to_string call"""
+        self.assertTrue(self.mock_render_to_string.call_count > 0)
+        return self.mock_render_to_string.call_args[1]["context"]["event_info_list"]
+
+    def fetch_events_url(self, course_identifier=None):
+        course_identifier = course_identifier or self.get_default_course_identifier()
+        return reverse("relate-fetch_events", args=[course_identifier])
+
+    def get_fetch_events(self, course_identifier=None, using_ajax=True):
+        course_identifier = course_identifier or self.get_default_course_identifier()
+        kwargs = {}
+        if using_ajax:
+            kwargs["HTTP_X_REQUESTED_WITH"] = 'XMLHttpRequest'
+        return self.c.get(
+            self.fetch_events_url(course_identifier), **kwargs)
+
+    def test_no_pperm(self):
+        with mock.patch(
+                "course.utils.CoursePageContext.has_permission"
+        ) as mock_has_pperm:
+            mock_has_pperm.return_value = False
+            resp = self.get_fetch_events()
+            self.assertEqual(resp.status_code, 403)
+
+    def test_not_ajax(self):
+        resp = self.get_fetch_events(using_ajax=False)
+        self.assertEqual(resp.status_code, 403)
+
+    def test_ajax_post(self):
+        resp = self.c.post(self.fetch_events_url(), data={},
+                           HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        self.assertEqual(resp.status_code, 403)
+
+    def test_post(self):
+        resp = self.c.post(self.fetch_events_url(), data={})
+        self.assertEqual(resp.status_code, 403)
+
+    def test_fetch_success(self):
+        resp = self.get_fetch_events()
+        self.assertEqual(resp.status_code, 200)
+
+    def test_neither_events_nor_event_file(self):
+        self.mock_get_now_or_fake_time.return_value = self.default_faked_now
+        resp = self.get_fetch_events()
+        self.assertEqual(resp.status_code, 200)
+
+        resp_dict = json.loads(resp.content.decode())
+        self.assertEqual(resp_dict["events_json"], [])
+        event_info_list = self.get_event_info_list_rendered()
+        self.assertEqual(event_info_list, [])
 
     def test_no_event_file(self):
         factories.EventFactory(
@@ -619,10 +712,11 @@ class ViewCalendarTest(SingleCourseTestMixin, HackRepoMixin, TestCase):
             kind=self.default_event_kind, course=self.course,
             time=self.default_event_time + timedelta(hours=1))
 
-        resp = self.get_course_calender_view()
+        resp = self.get_fetch_events()
         self.assertEqual(resp.status_code, 200)
 
-        events_json = json.loads(resp.context["events_json"])
+        resp_dict = json.loads(resp.content.decode())
+        events_json = resp_dict["events_json"]
         self.assertEqual(len(events_json), 2)
         self.assertDictEqual(
             events_json[0],
@@ -636,7 +730,8 @@ class ViewCalendarTest(SingleCourseTestMixin, HackRepoMixin, TestCase):
              'allDay': False,
              'title': 'lecture 1'})
 
-        self.assertResponseContextEqual(resp, "event_info_list", [])
+        event_info_list = self.get_event_info_list_rendered()
+        self.assertEqual(event_info_list, [])
 
     def test_hidden_event_not_shown(self):
         factories.EventFactory(
@@ -647,27 +742,33 @@ class ViewCalendarTest(SingleCourseTestMixin, HackRepoMixin, TestCase):
             shown_in_calendar=False,
             time=self.default_event_time + timedelta(hours=1))
 
-        resp = self.get_course_calender_view()
+        resp = self.get_fetch_events()
         self.assertEqual(resp.status_code, 200)
 
-        events_json = json.loads(resp.context["events_json"])
+        resp_dict = json.loads(resp.content.decode())
+        events_json = resp_dict["events_json"]
+
         self.assertEqual(len(events_json), 1)
         self.assertDictEqual(
             events_json[0],
             {'id': 1, 'start': self.default_event_time.isoformat(),
              'allDay': False,
              'title': 'lecture 0'})
-        self.assertResponseContextEqual(resp, "event_info_list", [])
+
+        event_info_list = self.get_event_info_list_rendered()
+        self.assertEqual(event_info_list, [])
 
     def test_event_has_end_time(self):
         factories.EventFactory(
             kind=self.default_event_kind, course=self.course,
             time=self.default_event_time,
             end_time=self.default_event_time + timedelta(hours=1))
-        resp = self.get_course_calender_view()
+        resp = self.get_fetch_events()
         self.assertEqual(resp.status_code, 200)
 
-        events_json = json.loads(resp.context["events_json"])
+        resp_dict = json.loads(resp.content.decode())
+        events_json = resp_dict["events_json"]
+
         self.assertEqual(len(events_json), 1)
         event_json = events_json[0]
         self.assertDictEqual(
@@ -678,42 +779,21 @@ class ViewCalendarTest(SingleCourseTestMixin, HackRepoMixin, TestCase):
              'end': (self.default_event_time + timedelta(hours=1)).isoformat(),
              })
 
-        self.assertResponseContextEqual(resp, "event_info_list", [])
-
-    def test_event_course_finished(self):
-        self.mock_get_now_or_fake_time.return_value = self.default_faked_now
-        self.course.end_date = (self.default_faked_now - timedelta(weeks=1)).date()
-        self.course.save()
-
-        resp = self.get_course_calender_view()
-        self.assertEqual(resp.status_code, 200)
-
-        self.assertResponseContextEqual(resp, "events_json", '[]')
-        self.assertResponseContextEqual(resp, "event_info_list", [])
-        self.assertResponseContextEqual(
-            resp, "default_date", self.course.end_date.isoformat())
-
-    def test_event_course_not_finished(self):
-        self.mock_get_now_or_fake_time.return_value = self.default_faked_now
-        self.course.end_date = (self.default_faked_now + timedelta(weeks=1)).date()
-        self.course.save()
-
-        resp = self.get_course_calender_view()
-        self.assertEqual(resp.status_code, 200)
-
-        self.assertResponseContextEqual(resp, "events_json", '[]')
-        self.assertResponseContextEqual(resp, "event_info_list", [])
-        self.assertResponseContextEqual(
-            resp, "default_date", self.default_faked_now.date().isoformat())
+        event_info_list = self.get_event_info_list_rendered()
+        self.assertEqual(event_info_list, [])
 
     def test_events_file_no_events(self):
         # make sure it works
         self.switch_to_fake_commit_sha()
 
-        resp = self.get_course_calender_view()
+        resp = self.get_fetch_events()
 
-        self.assertResponseContextEqual(resp, "events_json", '[]')
-        self.assertResponseContextEqual(resp, "event_info_list", [])
+        resp_dict = json.loads(resp.content.decode())
+        events_json = resp_dict["events_json"]
+        self.assertEqual(events_json, [])
+
+        event_info_list = self.get_event_info_list_rendered()
+        self.assertEqual(event_info_list, [])
 
     def test_events_file_with_events_test1(self):
         self.switch_to_fake_commit_sha()
@@ -729,9 +809,11 @@ class ViewCalendarTest(SingleCourseTestMixin, HackRepoMixin, TestCase):
             kind=self.default_event_kind, course=self.course,
             time=self.default_event_time, ordinal=2)
 
-        resp = self.get_course_calender_view()
+        resp = self.get_fetch_events()
 
-        events_json = json.loads(resp.context["events_json"])
+        resp_dict = json.loads(resp.content.decode())
+        events_json = resp_dict["events_json"]
+
         self.assertEqual(len(events_json), 2)
         self.assertDictEqual(
             events_json[0],
@@ -749,7 +831,7 @@ class ViewCalendarTest(SingleCourseTestMixin, HackRepoMixin, TestCase):
              'url': '#event-1'
              })
 
-        event_info_list = resp.context["event_info_list"]
+        event_info_list = self.get_event_info_list_rendered()
 
         # lecture 2 doesn't create an EventInfo object
         self.assertEqual(len(event_info_list), 1)
@@ -793,9 +875,11 @@ class ViewCalendarTest(SingleCourseTestMixin, HackRepoMixin, TestCase):
             time=test_start_time,
             ordinal=None)
 
-        resp = self.get_course_calender_view()
+        resp = self.get_fetch_events()
 
-        events_json = json.loads(resp.context["events_json"])
+        resp_dict = json.loads(resp.content.decode())
+        events_json = resp_dict["events_json"]
+
         self.assertEqual(len(events_json), 3)
 
         self.assertDictEqual(
@@ -817,7 +901,7 @@ class ViewCalendarTest(SingleCourseTestMixin, HackRepoMixin, TestCase):
              'allDay': True,
              'title': 'test'})
 
-        event_info_list = resp.context["event_info_list"]
+        event_info_list = self.get_event_info_list_rendered()
 
         # only lecture 2 create an EventInfo object
         self.assertEqual(len(event_info_list), 1)
@@ -841,8 +925,9 @@ class ViewCalendarTest(SingleCourseTestMixin, HackRepoMixin, TestCase):
                 lecture3_start_time + timedelta(minutes=5))
 
         # no EventInfo object
-        resp = self.get_course_calender_view()
-        self.assertResponseContextEqual(resp, "event_info_list", [])
+        resp = self.get_fetch_events()
+        event_info_list = self.get_event_info_list_rendered()
+        self.assertEqual(event_info_list, [])
 
     def test_events_file_with_events_test3(self):
         self.switch_to_fake_commit_sha()
@@ -854,9 +939,11 @@ class ViewCalendarTest(SingleCourseTestMixin, HackRepoMixin, TestCase):
             time=self.default_event_time,
             end_time=exam_end_time)
 
-        resp = self.get_course_calender_view()
+        resp = self.get_fetch_events()
 
-        events_json = json.loads(resp.context["events_json"])
+        resp_dict = json.loads(resp.content.decode())
+        events_json = resp_dict["events_json"]
+
         self.assertEqual(len(events_json), 1)
 
         self.assertDictEqual(
@@ -868,7 +955,8 @@ class ViewCalendarTest(SingleCourseTestMixin, HackRepoMixin, TestCase):
              'color': 'red',
              'end': exam_end_time.isoformat()})
 
-        self.assertResponseContextEqual(resp, "event_info_list", [])
+        event_info_list = self.get_event_info_list_rendered()
+        self.assertEqual(event_info_list, [])
 
     def test_all_day_event(self):
         self.switch_to_fake_commit_sha()
@@ -890,9 +978,11 @@ class ViewCalendarTest(SingleCourseTestMixin, HackRepoMixin, TestCase):
             kind=self.default_event_kind, course=self.course,
             time=lecture3_start_time, ordinal=3)
 
-        resp = self.get_course_calender_view()
+        resp = self.get_fetch_events()
 
-        events_json = json.loads(resp.context["events_json"])
+        resp_dict = json.loads(resp.content.decode())
+        events_json = resp_dict["events_json"]
+
         self.assertEqual(len(events_json), 2)
 
         self.assertDictEqual(
@@ -907,9 +997,11 @@ class ViewCalendarTest(SingleCourseTestMixin, HackRepoMixin, TestCase):
         lecture2_evt.end_time = lecture2_end_time
         lecture2_evt.save()
 
-        resp = self.get_course_calender_view()
+        resp = self.get_fetch_events()
 
-        events_json = json.loads(resp.context["events_json"])
+        resp_dict = json.loads(resp.content.decode())
+        events_json = resp_dict["events_json"]
+
         self.assertEqual(len(events_json), 2)
 
         self.assertDictEqual(
@@ -932,9 +1024,11 @@ class ViewCalendarTest(SingleCourseTestMixin, HackRepoMixin, TestCase):
 
             lecture2_end_time += timedelta(hours=1)
 
-        resp = self.get_course_calender_view()
+        resp = self.get_fetch_events()
 
-        events_json = json.loads(resp.context["events_json"])
+        resp_dict = json.loads(resp.content.decode())
+        events_json = resp_dict["events_json"]
+
         self.assertEqual(len(events_json), 2)
 
         self.assertDictEqual(

--- a/yarn.lock
+++ b/yarn.lock
@@ -79,12 +79,12 @@ for-each@^0.3.2:
   dependencies:
     is-function "~1.0.0"
 
-fullcalendar@^2.9.1:
-  version "2.9.1"
-  resolved "https://registry.yarnpkg.com/fullcalendar/-/fullcalendar-2.9.1.tgz#dd2a84469b627749e47c5dd9fd71f56146e0651b"
+fullcalendar@^3.9.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/fullcalendar/-/fullcalendar-3.9.0.tgz#b608a9989f3416f0b1d526c6bdfeeaf2ac79eda5"
   dependencies:
-    jquery ">=1.7.1"
-    moment ">=2.5.0"
+    jquery "2 - 3"
+    moment "^2.20.1"
 
 global@4.3.0:
   version "4.3.0"
@@ -116,7 +116,7 @@ jquery-ui-dist@^1.12.1:
   version "1.12.1"
   resolved "https://registry.yarnpkg.com/jquery-ui-dist/-/jquery-ui-dist-1.12.1.tgz#5c0815d3cc6f90ff5faaf5b268a6e23b4ca904fa"
 
-jquery@>=1.7, jquery@>=1.7.1, jquery@>=1.9.1, jquery@^3.3.1:
+"jquery@2 - 3", jquery@>=1.7, jquery@>=1.9.1, jquery@^3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.3.1.tgz#958ce29e81c9790f31be7792df5d4d95fc57fbca"
 
@@ -136,9 +136,9 @@ min-document@^2.19.0, min-document@^2.6.1:
   dependencies:
     dom-walk "^0.1.0"
 
-moment@>=2.5.0:
-  version "2.21.0"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.21.0.tgz#2a114b51d2a6ec9e6d83cf803f838a878d8a023a"
+moment@^2.20.1:
+  version "2.22.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.1.tgz#529a2e9bf973f259c9643d237fda84de3a26e8ad"
 
 parse-headers@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
Used AJAX to fetch the events and event_info, this made it possible to create/update/delete events in FullCalendar UI without refresh the page. 

1. Added listview (month) in FullCalendar UI.
2. FullCalendar.js need to be updated to 3.9.0.
