### PR TITLE
Render edit_course view with course.force_lang.

### DIFF
--- a/course/views.py
+++ b/course/views.py
@@ -1429,12 +1429,13 @@ def edit_course(pctx):
         raise PermissionDenied()
 
     request = pctx.request
+    instance = pctx.course
 
     if request.method == 'POST':
         form = EditCourseForm(request.POST, instance=pctx.course)
         if form.is_valid():
             if form.has_changed():
-                form.save()
+                instance = form.save()
                 messages.add_message(
                     request, messages.SUCCESS,
                     _("Successfully updated course settings."))
@@ -1447,13 +1448,15 @@ def edit_course(pctx):
             messages.add_message(request, messages.ERROR,
                                  _("Failed to update course settings."))
 
-    else:
-        form = EditCourseForm(instance=pctx.course)
+    form = EditCourseForm(instance=instance)
 
-    return render_course_page(pctx, "course/generic-course-form.html", {
-        "form_description": _("Edit Course"),
-        "form": form
-        })
+    # Render the page with course.force_lang, in case force_lang was updated
+    from course.utils import LanguageOverride
+    with LanguageOverride(instance):
+        return render_course_page(pctx, "course/generic-course-form.html", {
+            "form_description": _("Edit Course"),
+            "form": form
+            })
 
 # }}}
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -337,10 +337,11 @@ class TestEditCourse(SingleCourseTestMixin, MockAddMessageMixing, TestCase):
         # the message shows "success"
         with mock.patch('course.views.EditCourseForm.is_valid') as mock_is_valid, \
             mock.patch('course.views.EditCourseForm.has_changed') as mock_changed, \
-            mock.patch('course.views.EditCourseForm.save'), \
+            mock.patch('course.views.EditCourseForm.save')as mock_save, \
             mock.patch("course.views.render_course_page"),\
                 mock.patch("course.views._") as mock_gettext:
 
+            mock_save.return_value = self.course
             mock_is_valid.return_value = True
             mock_changed.return_value = True
             mock_gettext.side_effect = lambda x: x
@@ -365,6 +366,7 @@ class TestEditCourse(SingleCourseTestMixin, MockAddMessageMixing, TestCase):
                 mock.patch("course.views._") as mock_gettext:
 
             mock_gettext.side_effect = lambda x: x
+            mock_save.return_value = self.course
             request = self.rf.post(self.get_edit_course_url(),
                                    data=data)
             request.user = self.instructor_participation.user


### PR DESCRIPTION
Previously, updating force_lang need an extra fresh to display the edit_course view with the latest course language.