### PR TITLE
CAS support.

### DIFF
--- a/cas-config/.gitignore
+++ b/cas-config/.gitignore
@@ -1,0 +1,1 @@
+callback.py

--- a/cas-config/apps.py
+++ b/cas-config/apps.py
@@ -1,0 +1,7 @@
+from django.apps import AppConfig
+from django.utils.translation import ugettext_lazy as _
+
+
+class CasConfig(AppConfig):
+    name = 'cas-config'
+    verbose_name = _("CAS attribute callback shim")

--- a/cas-config/models.py
+++ b/cas-config/models.py
@@ -1,0 +1,22 @@
+from django.conf import settings
+from django.dispatch import receiver
+from django_cas_ng.signals import cas_user_authenticated
+
+
+@receiver(cas_user_authenticated)
+def cas_attribute_callback_manager(sender, user, created, attributes, ticket, service, request, **kwargs):
+    """
+    Upon receiving a signal from django-cas-ng that a user was successfully logged in over CAS,
+    if a CAS_ATTRIBUTE_CALLBACK is defined in settings,
+    call it with the data we got from this signal.
+
+    This is a bit of a roundabout way to do it, but allows to flexibly configure it without
+    touching the main RELATE code at all.
+    """
+    callback = getattr(settings, 'CAS_ATTRIBUTE_CALLBACK', None)
+    if callback:
+        import importlib
+        getattr(
+            importlib.import_module(callback['module']),
+            callback['function']
+        )(user, created, attributes, ticket, service, request)

--- a/course/auth.py
+++ b/course/auth.py
@@ -1087,6 +1087,10 @@ def sign_out(request, redirect_field_name=REDIRECT_FIELD_NAME):
         if _get_subject_id(request.session) is not None:
             response = saml2_logout(request)
 
+    if settings.RELATE_SIGN_IN_BY_CAS_ENABLED:
+        from django_cas_ng.views import LogoutView as cas_logout
+        response = cas_logout.as_view()(request)
+
     auth_logout(request)
 
     if response is not None:

--- a/local_settings_example.py
+++ b/local_settings_example.py
@@ -210,6 +210,9 @@ RELATE_SIGN_IN_BY_EXAM_TICKETS_ENABLED = True
 # See saml_config.py.example for help.
 RELATE_SIGN_IN_BY_SAML2_ENABLED = False
 
+# If you enable this, you will also need to set up the CAS settings further down.
+RELATE_SIGN_IN_BY_CAS_ENABLED = False
+
 # }}}
 
 # {{{ editable institutional id before verification?
@@ -579,6 +582,23 @@ if RELATE_SIGN_IN_BY_SAML2_ENABLED:
             },
         'valid_for': 24,  # how long is our metadata valid
         }
+
+# }}}
+
+# {{{ cas (optional)
+
+if RELATE_SIGN_IN_BY_CAS_ENABLED:
+    # For these settings, as well as the full list of django-cas-ng settings refer to documentation
+    # at https://github.com/mingchen/django-cas-ng
+    CAS_SERVER_URL = "https://your-cas-login-domain/cas/"
+    CAS_CREATE_USER = True
+    CAS_USERNAME_ATTRIBUTE = 'username'
+
+    # This is an extra addition. To allow one to easily use a more complex attribute mapper
+    # than a simple map in CAS_RENAME_ATTRIBUTES,
+    # we have the cas-config app, which will call the function you define here
+    # with the same parameters as django-cas-ng signal cas_user_authenticated.
+    CAS_ATTRIBUTE_CALLBACK = {'module': 'cas-config.callback', 'function': 'cas_callback'}
 
 # }}}
 

--- a/relate/settings.py
+++ b/relate/settings.py
@@ -66,6 +66,9 @@ INSTALLED_APPS = (
 if local_settings.get("RELATE_SIGN_IN_BY_SAML2_ENABLED"):
     INSTALLED_APPS = INSTALLED_APPS + ("djangosaml2",)  # type: ignore
 
+if local_settings.get("RELATE_SIGN_IN_BY_CAS_ENABLED"):
+    INSTALLED_APPS = INSTALLED_APPS + ("django_cas_ng", 'cas-config', )  # type: ignore
+
 # }}}
 
 # {{{ django: middleware
@@ -85,6 +88,9 @@ MIDDLEWARE = (
     "relate.utils.MaintenanceMiddleware",
 )
 
+if local_settings.get("RELATE_SIGN_IN_BY_CAS_ENABLED"):
+    MIDDLEWARE = MIDDLEWARE + ('django_cas_ng.middleware.CASMiddleware',)  # type: ignore
+
 # }}}
 
 # {{{ django: auth
@@ -100,6 +106,11 @@ if local_settings.get("RELATE_SIGN_IN_BY_SAML2_ENABLED"):
     AUTHENTICATION_BACKENDS = AUTHENTICATION_BACKENDS + (  # type: ignore
             'course.auth.Saml2Backend',
             )
+
+if local_settings.get("RELATE_SIGN_IN_BY_CAS_ENABLED"):
+    AUTHENTICATION_BACKENDS = AUTHENTICATION_BACKENDS + (  # type: ignore
+         'django_cas_ng.backends.CASBackend',
+    )
 
 AUTH_USER_MODEL = 'accounts.User'
 

--- a/relate/templates/sign-in-choice.html
+++ b/relate/templates/sign-in-choice.html
@@ -5,6 +5,15 @@
   <h1>{% blocktrans %}Sign in to {{ relate_site_name }}{% endblocktrans %}</h1>
 
   <ul class="list-sign-in-methods">
+    {% if relate_sign_in_by_cas_enabled %}
+      <li>
+        <a
+          class="btn btn-primary"
+          href="{% url 'cas_ng_login' %}{{next_uri}}"
+          role="button"><i class="fa fa-institution"></i>
+          {% trans "Sign in using your institution's login" %} &raquo;</a>
+      </li>
+    {% endif %}
     {% if relate_sign_in_by_saml2_enabled %}
       <li>
         <a

--- a/relate/urls.py
+++ b/relate/urls.py
@@ -566,4 +566,14 @@ if settings.RELATE_SIGN_IN_BY_SAML2_ENABLED:
             url(r'^saml2-test/', djangosaml2.views.echo_attributes),
             ])
 
+if settings.RELATE_SIGN_IN_BY_CAS_ENABLED:
+    from django_cas_ng.views import LoginView as CasLoginView
+    from django_cas_ng.views import LogoutView as CasLogoutView
+    from django_cas_ng.views import CallbackView as CasCallbackView
+    urlpatterns.extend([
+        url(r'^cas/login', CasLoginView.as_view(), name='cas_ng_login'),
+        url(r'^cas/logout', CasLogoutView.as_view(), name='cas_ng_logout'),
+        url(r'^cas/callback$', CasCallbackView.as_view(), name='cas_ng_proxy_callback'),
+    ])
+
 # vim: fdm=marker

--- a/relate/utils.py
+++ b/relate/utils.py
@@ -192,6 +192,8 @@ def settings_context_processor(request):
         settings.RELATE_SIGN_IN_BY_EXAM_TICKETS_ENABLED,
         "relate_sign_in_by_saml2_enabled":
         settings.RELATE_SIGN_IN_BY_SAML2_ENABLED,
+        "relate_sign_in_by_cas_enabled":
+        settings.RELATE_SIGN_IN_BY_CAS_ENABLED,
         "maintenance_mode": is_maintenance_mode(request),
         "site_announcement": getattr(settings, "RELATE_SITE_ANNOUNCEMENT", None),
         "relate_site_name": _(get_site_name())

--- a/requirements.txt
+++ b/requirements.txt
@@ -72,6 +72,9 @@ djangosaml2==0.17.2
 pyOpenSSL
 future
 
+# To support CAS login
+django-cas-ng==3.6.0
+
 # Try to avoid https://github.com/Julian/jsonschema/issues/449
 attrs>=19
 


### PR DESCRIPTION
Greetings. We *(the [Center for Pedagogical Mastery](https://cpm.dogm.mos.ru/))* are currently evaluating RELATE as an alternative to [Open edX](https://open.edx.org/), *(that is, we are hoping to get rid of it as soon as possible, because it's really not a good fit for how we teach, and RELATE appears to be much closer to ideal for us)*. To do that, the first thing we needed to do is to add support for authorization over [CAS protocol](https://en.wikipedia.org/wiki/Central_Authentication_Service), keeping it extensible for the unorthodox uses we've put it for. *(We have a separate in-house system managing course subscriptions, which communicates which courses people should be subscribed to as CAS attributes, so the basic attribute mapper that django-cas-ng provides is insufficient.)* This, of course, should be generally useful.

To that end, I present this PR, hoping you could accept it. It works, and passes all the tests that were there already, but I couldn't think of what kind of tests would be appropriate to test the new functionality. Should you deem it unsuitable, I'm ready to hack it until it is.