### PR TITLE
Make impersonate_user local to a course

### DIFF
--- a/relate/templates/base.html
+++ b/relate/templates/base.html
@@ -108,7 +108,7 @@
                             {% if currently_impersonating %}
                               <li><a onclick=stop_impersonate()>{% trans "Stop impersonating" %}</a></li>
                             {% else %}
-                              <li><a href="{% url 'relate-impersonate' %}" target="_blank">{% trans "Impersonate user" %}</a></li>
+                              <li><a href="{% url 'relate-impersonate' course.identifier %}" target="_blank">{% trans "Impersonate user" %}</a></li>
                             {% endif %}
                             {% if pperm.set_fake_time or request.relate_impersonate_original_user|may_set_fake_time %}
                               <li><a href="{% url 'relate-set_fake_time' %}" target="_blank">{% trans "Set fake time" %}</a></li>

--- a/relate/urls.py
+++ b/relate/urls.py
@@ -99,11 +99,12 @@ urlpatterns = [
         name="relate-monitor_task"),
 
     # {{{ troubleshooting
-
-    url(r'^user/impersonate/$',
+    url(r"^course"
+        "/" + COURSE_ID_REGEX
+        + "/impersonate/$",
         course.auth.impersonate,
         name="relate-impersonate"),
-    url(r'^user/stop_impersonating/$',
+    url(r"^user/stop_impersonating/$",
         course.auth.stop_impersonating,
         name="relate-stop_impersonating"),
 


### PR DESCRIPTION
If a user is a super-user, they'll be able to impersonate anyone.
If not, a user (ta) be able to impersonate a user who they have access
to (student) in that particular course.

Note that when impersonating, a ta will only be able to access the
courses of that student that he/she has permission for. Access to
other courses will be denied. (Any urls starting with /course/<id>)

One possible issue with this approach is that a ta will be able to
see the home page of the student, which means they'll be able to see
the titles of some private courses that the student has access to.