### PR TITLE
Configurable Forms for flows

### DIFF
--- a/course/constants.py
+++ b/course/constants.py
@@ -38,6 +38,8 @@ NAME_VALID_REGEX = r"^\w+$"
 COURSE_ID_REGEX = "(?P<course_identifier>[-a-zA-Z0-9]+)"
 EVENT_KIND_REGEX = "(?P<event_kind>[_a-z0-9]+)"
 FLOW_ID_REGEX = "(?P<flow_id>[-_a-zA-Z0-9]+)"
+FORM_ID_REGEX = "(?P<form_id>[-_a-zA-Z0-9]+)"
+FORM_FIELD_ID_REGEX = "(?P<form_id>[-_a-zA-Z0-9]+)"
 GRADING_OPP_ID_REGEX = "(?P<grading_opp_id>[-_a-zA-Z0-9]+)"
 # FIXME : Support page hierarchy. Add '/' here, fix validation code.
 STATICPAGE_PATH_REGEX = r"(?P<page_path>[-\w]+)"

--- a/course/forms.py
+++ b/course/forms.py
@@ -77,7 +77,7 @@ class CreateForm(forms.Form):
         self.id = str(uuid.uuid1()).replace("-", "")
 
         from django.utils.timezone import now
-        self.created_time = now().strftime("%Y-%m-%d %H:%M")
+        self.created_time = now().strftime("%Y-%m-%d @ %H:%M")
 
         for field in form_fields:
             field_data = dict(required=True,
@@ -251,10 +251,8 @@ def view_form(pctx, form_id):
     page_warnings = None
     page_errors = None
     try:
-        print(new_page_source)
         new_page_source = expand_yaml_macros(
                 pctx.repo, pctx.course_commit_sha, new_page_source)
-        print(new_page_source)
 
         yaml_data = yaml.safe_load(new_page_source)  # type: ignore
         page_desc = dict_to_struct(yaml_data)

--- a/course/forms.py
+++ b/course/forms.py
@@ -2,7 +2,7 @@
 
 from __future__ import division
 
-__copyright__ = "Copyright (C) 2014 Andreas Kloeckner"
+__copyright__ = "Copyright (C) 2019 Isuru Fernando"
 
 __license__ = """
 Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -26,6 +26,9 @@ THE SOFTWARE.
 
 from typing import cast, Tuple
 import os
+import uuid
+import textwrap
+import yaml
 
 import django.forms as forms
 from django.utils.safestring import mark_safe
@@ -41,7 +44,8 @@ from course.utils import course_view, render_course_page
 from course.constants import participation_permission as pperm
 from course.utils import (  # noqa
         CoursePageContext)
-from course.content import FlowPageDesc, get_course_repo, get_repo_blob, get_raw_yaml_from_repo
+from course.content import FlowPageDesc, get_course_repo, get_repo_blob, get_yaml_from_repo, expand_yaml_macros
+from relate.utils import dict_to_struct, Struct
 
 # {{{ for mypy
 
@@ -59,45 +63,109 @@ PAGE_DATA_SESSION_KEY_PREFIX = "cf_page_sandbox_page_data"
 # }}}
 
 
-class CreateFlowForm(forms.Form):
+class CreateForm(forms.Form):
     # prevents form submission with codemirror's empty textarea
     use_required_attribute = False
 
-    def __init__(self, initial_text,
-            language_mode, interaction_mode, help_text, *args, **kwargs):
-        # type: (Text, Text, Text, Text, *Any, **Any) -> None
-        super(SandboxForm, self).__init__(*args, **kwargs)
+    def __init__(self, form_fields):
+        super(CreateForm, self).__init__()
 
         from crispy_forms.helper import FormHelper
         self.helper = FormHelper()
 
-        from course.utils import get_codemirror_widget
-        cm_widget, cm_help_text = get_codemirror_widget(
-                language_mode=language_mode,
-                interaction_mode=interaction_mode)
+        self.form_fields = form_fields
+        self.id = str(uuid.uuid1()).replace("-", "")
 
-        self.fields["content"] = forms.CharField(
-                required=False,
-                initial=initial_text,
-                widget=cm_widget,
-                help_text=mark_safe(
-                    help_text
-                    + " "
-                    + ugettext("Press Alt/Cmd+(Shift+)P to preview.")
-                    + " "
-                    + cm_help_text),
-                label=_("Content"))
+        from django.utils.timezone import now
+        self.created_time = now().strftime("%Y-%m-%d %H:%M")
 
-        # 'strip' attribute was added to CharField in Django 1.9
-        # with 'True' as default value.
-        self.fields["content"].strip = False
+        for field in form_fields:
+            field_data = dict(required=True,
+                              initial=field.value,
+                              label=field.label)
+            if field.type == "Choice":
+                self.fields[field.id] = forms.ChoiceField(
+                        choices=[(c, c) for c in field.choices],
+                        **field_data)
+            elif field.type == "Text":
+                self.fields[field.id] = forms.CharField(
+                        **field_data)
+            elif field.type == "Integer":
+                self.fields[field.id] = forms.IntegerField(
+                        **field_data)
+
+            if field.id == "template_in":
+                self.template_in = field.value
+            if field.id == "template_out":
+                file_out = field.value.rsplit(".", 1)
+                self.template_out = file_out[0] + "_" + self.id
+                if len(file_out) > 1:
+                    self.template_out += "." + file_out[-1]
+            if field.id == "announce":
+                self.announce = str(field.value).lower() == "true"
 
         self.helper.add_input(
-                Submit("preview", _("Preview"), accesskey="p"),
+                Submit("submit", _("Submit"), accesskey="p"),
                 )
         self.helper.add_input(
-                Submit("clear", _("Clear"), css_class="btn-default"),
+                Submit("reset", _("Reset"), css_class="btn-default"),
                 )
+        self.helper.add_input(
+                Submit("validate", _("Validate"), css_class="btn-default"),
+                )
+
+
+    def get_jinja_text(self):
+        text = textwrap.dedent("""
+                {{% with id="{id}",
+                """).format(id=self.id)
+        for field in self.form_fields:
+            text += "        {field_name}=\"{field_value}\",\n".format(field_name=field.id, field_value=field.value)
+        text += "        created_time=\"{created_time}\" %}}".format(created_time=self.created_time)
+        text += textwrap.dedent("""
+                {{% include "{template_in}" %}}
+                {{% endwith %}}
+                """).format(template_in=self.template_in)
+        return text, self.template_out
+
+
+def process_value(field):
+    if field.type == "Integer":
+        try:
+            field.value = int(field.value)
+        except ValueError:
+            pass
+    elif field.type == "Float":
+        try:
+            field.value = float(field.value)
+        except ValueError:
+            pass
+
+
+def process_form_fields(form_fields, data):
+    if "reset" in data:
+        data = {}
+    for field in form_fields:
+        if not hasattr(field, "label"):
+            field.label = field.id
+        if not hasattr(field, "help"):
+            field.help = field.label
+
+        if field.id in data:
+            field.value = data[field.id]
+
+        if field.type == "Choice":
+            choices = []
+            for value in field.choices:
+                if value.startswith("~DEFAULT~"):
+                    v = value[9:].strip()
+                    choices.append(v)
+                    if not hasattr(field, "value"):
+                        field.value = v
+                else:
+                    choices.append(value)
+            field.choices = choices
+        process_value(field)
 
 
 def list_form_names(repo, commit_sha):
@@ -116,24 +184,24 @@ def list_form_names(repo, commit_sha):
     return sorted(form_names)
 
 
+def get_form(repo, form_name, commit_sha):
+    contents = get_yaml_from_repo(repo, "forms/%s.yml" % form_name, commit_sha)
+    contents.name = form_name
+    return contents
+
+
 def get_all_forms(repo, commit_sha):
     form_names = list_form_names(repo, commit_sha)
     forms = []
     for name in form_names:
-        contents = get_raw_yaml_from_repo(repo, "forms/%s.yml" % name, commit_sha)
-        contents["name"] = name
+        contents = get_form(repo, name, commit_sha)
         forms.append(contents)
-
     return forms
-
-
-def validate_form(form):
-    pass
 
 
 @course_view
 def view_all_forms(pctx):
-    if not pctx.has_permission(pperm.use_markup_sandbox):
+    if not pctx.has_permission(pperm.update_content):
         raise PermissionDenied()
 
     forms = get_all_forms(pctx.repo, pctx.course_commit_sha)
@@ -145,28 +213,87 @@ def view_all_forms(pctx):
 
 @course_view
 def view_form(pctx, form_id):
-    if not pctx.has_permission(pperm.use_markup_sandbox):
+    if not pctx.has_permission(pperm.update_content):
         raise PermissionDenied()
 
-    def make_form(data=None):
-        help_text = (ugettext("Enter <a href=\"http://documen.tician.de/"
-                "relate/content.html#relate-markup\">"
-                "RELATE markup</a>."))
-        return CreateFlowForm(
-                None, "markdown", request.user.editor_mode,
-                help_text,
-                data)
+    form_info = get_form(pctx.repo, form_id, pctx.course_commit_sha)
+
+    from course.enrollment import get_participation_role_identifiers
+    roles = get_participation_role_identifiers(
+            pctx.course, pctx.participation)
+
+    if not any(role in form_info.access_roles for role in roles):
+        raise PermissionDenied()
+
+    def back_to_form(form, form_info, page_errors=None, page_warnings=None):
+        return render_course_page(pctx, "course/form.html", {
+            "form": form,
+            "description": form_info.description,
+            "title": form_info.title,
+            "page_errors": page_errors,
+            "page_warnings": page_warnings,
+        })
 
     request = pctx.request
 
-    if request.method == "POST":
-        form = make_form(request.POST)
+    if request.method != "POST":
+        process_form_fields(form_info.fields, {})
+        form = CreateForm(form_info.fields)
+        return back_to_form(form, form_info)
+
+    process_form_fields(form_info.fields, request.POST)
+    form = CreateForm(form_info.fields)
+
+    if "clear" in request.POST:
+        return back_to_form(form, form_info)
+
+    new_page_source, file_out = form.get_jinja_text()
+    page_warnings = None
+    page_errors = None
+    try:
+        print(new_page_source)
+        new_page_source = expand_yaml_macros(
+                pctx.repo, pctx.course_commit_sha, new_page_source)
+        print(new_page_source)
+
+        yaml_data = yaml.safe_load(new_page_source)  # type: ignore
+        page_desc = dict_to_struct(yaml_data)
+
+        if not isinstance(page_desc, Struct):
+            raise ValidationError("Provided page source code is not "
+                    "a dictionary. Do you need to remove a leading "
+                    "list marker ('-') or some stray indentation?")
+
+        from course.validation import validate_flow_desc, ValidationContext
+        vctx = ValidationContext(
+                repo=pctx.repo,
+                commit_sha=pctx.course_commit_sha)
+
+        validate_flow_desc(vctx, "form", page_desc)
+
+        page_warnings = vctx.warnings
+
+    except Exception:
+        import sys
+        tp, e, _ = sys.exc_info()
+
+        page_errors = (
+                ugettext("Page failed to load/validate")
+                + ": "
+                + "%(err_type)s: %(err_str)s" % {
+                    "err_type": tp.__name__, "err_str": e})  # type: ignore
+
+        return back_to_form(form, form_info, page_errors, page_warnings)
     else:
-        form = make_form()
+        # Yay, it did validate.
+        pass
 
-    return render_course_page(pctx, "course/sandbox-markup.html", {
+    if "validate" in request.POST:
+        return back_to_form(form, form_info, page_errors, page_warnings)
+
+    return render_course_page(pctx, "course/form.html", {
         "form": form,
-        "preview_text": preview_text,
+        "description": form_info.description,
+        "title": form_info.title,
     })
-
 

--- a/course/forms.py
+++ b/course/forms.py
@@ -46,7 +46,7 @@ from course.constants import participation_permission as pperm
 from course.utils import (  # noqa
         CoursePageContext)
 from course.content import FlowPageDesc, get_course_repo, get_repo_blob, get_yaml_from_repo, expand_yaml_macros
-from relate.utils import dict_to_struct, Struct, string_concat
+from relate.utils import dict_to_struct, Struct, string_concat, as_local_time
 from course.versioning import run_course_update_command
 
 # {{{ for mypy
@@ -67,9 +67,8 @@ class CreateForm(forms.Form):
         self.helper = FormHelper()
 
         self.form_fields = form_fields
-        self.id = str(uuid.uuid1()).replace("-", "")
-
         self.created_time = now()
+        self.id = as_local_time(self.created_time).strftime("%Y%m%d_%H%M%S_%f")
 
         for field in form_fields:
             field_data = dict(required=True,
@@ -108,7 +107,6 @@ class CreateForm(forms.Form):
 
 
     def get_jinja_text(self):
-        from relate.utils import as_local_time
         created_time = as_local_time(self.created_time).strftime("%Y-%m-%d @ %H:%M")
 
         text = "{{% with id=\"{id}\",\n".format(id=self.id)

--- a/course/forms.py
+++ b/course/forms.py
@@ -108,10 +108,13 @@ class CreateForm(forms.Form):
 
 
     def get_jinja_text(self):
+        from relate.utils import as_local_time
+        created_time = as_local_time(self.created_time).strftime("%Y-%m-%d @ %H:%M")
+
         text = "{{% with id=\"{id}\",\n".format(id=self.id)
         for field in self.form_fields:
             text += "        {field_name}=\"{field_value}\",\n".format(field_name=field.id, field_value=field.value)
-        text += "        created_time=\"{created_time}\" %}}".format(created_time=self.created_time.strftime("%Y-%m-%d @ %H:%M"))
+        text += "        created_time=\"{created_time}\" %}}".format(created_time=created_time)
         text += textwrap.dedent("""
                 {{% include "{template_in}" %}}
                 {{% endwith %}}

--- a/course/forms.py
+++ b/course/forms.py
@@ -1,0 +1,172 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import division
+
+__copyright__ = "Copyright (C) 2014 Andreas Kloeckner"
+
+__license__ = """
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"""
+
+from typing import cast, Tuple
+import os
+
+import django.forms as forms
+from django.utils.safestring import mark_safe
+from django.contrib import messages  # noqa
+from django.core.exceptions import PermissionDenied, ObjectDoesNotExist
+from django.utils.translation import ugettext, ugettext_lazy as _
+from django import http  # noqa
+
+from crispy_forms.layout import Submit
+
+from course.utils import course_view, render_course_page
+
+from course.constants import participation_permission as pperm
+from course.utils import (  # noqa
+        CoursePageContext)
+from course.content import FlowPageDesc, get_course_repo, get_repo_blob, get_raw_yaml_from_repo
+
+# {{{ for mypy
+
+if False:
+    from typing import Text, Optional, Any, Iterable, Dict  # noqa
+
+# }}}
+
+# {{{ sandbox session key prefix
+
+PAGE_SESSION_KEY_PREFIX = "cf_validated_sandbox_page"
+ANSWER_DATA_SESSION_KEY_PREFIX = "cf_page_sandbox_answer_data"
+PAGE_DATA_SESSION_KEY_PREFIX = "cf_page_sandbox_page_data"
+
+# }}}
+
+
+class CreateFlowForm(forms.Form):
+    # prevents form submission with codemirror's empty textarea
+    use_required_attribute = False
+
+    def __init__(self, initial_text,
+            language_mode, interaction_mode, help_text, *args, **kwargs):
+        # type: (Text, Text, Text, Text, *Any, **Any) -> None
+        super(SandboxForm, self).__init__(*args, **kwargs)
+
+        from crispy_forms.helper import FormHelper
+        self.helper = FormHelper()
+
+        from course.utils import get_codemirror_widget
+        cm_widget, cm_help_text = get_codemirror_widget(
+                language_mode=language_mode,
+                interaction_mode=interaction_mode)
+
+        self.fields["content"] = forms.CharField(
+                required=False,
+                initial=initial_text,
+                widget=cm_widget,
+                help_text=mark_safe(
+                    help_text
+                    + " "
+                    + ugettext("Press Alt/Cmd+(Shift+)P to preview.")
+                    + " "
+                    + cm_help_text),
+                label=_("Content"))
+
+        # 'strip' attribute was added to CharField in Django 1.9
+        # with 'True' as default value.
+        self.fields["content"].strip = False
+
+        self.helper.add_input(
+                Submit("preview", _("Preview"), accesskey="p"),
+                )
+        self.helper.add_input(
+                Submit("clear", _("Clear"), css_class="btn-default"),
+                )
+
+
+def list_form_names(repo, commit_sha):
+    # type: (Repo_ish, bytes) -> List[Text]
+    form_names = []
+    try:
+        form_tree = get_repo_blob(repo, "forms", commit_sha)
+    except ObjectDoesNotExist:
+        # That's OK--no forms yet.
+        pass
+    else:
+        for entry in form_tree.items():
+            if entry.path.endswith(b".yml"):
+                form_names.append(entry.path[:-4].decode("utf-8"))
+
+    return sorted(form_names)
+
+
+def get_all_forms(repo, commit_sha):
+    form_names = list_form_names(repo, commit_sha)
+    forms = []
+    for name in form_names:
+        contents = get_raw_yaml_from_repo(repo, "forms/%s.yml" % name, commit_sha)
+        contents["name"] = name
+        forms.append(contents)
+
+    return forms
+
+
+def validate_form(form):
+    pass
+
+
+@course_view
+def view_all_forms(pctx):
+    if not pctx.has_permission(pperm.use_markup_sandbox):
+        raise PermissionDenied()
+
+    forms = get_all_forms(pctx.repo, pctx.course_commit_sha)
+
+    return render_course_page(pctx, "course/forms.html", {
+        "forms": forms,
+    })
+
+
+@course_view
+def view_form(pctx, form_id):
+    if not pctx.has_permission(pperm.use_markup_sandbox):
+        raise PermissionDenied()
+
+    def make_form(data=None):
+        help_text = (ugettext("Enter <a href=\"http://documen.tician.de/"
+                "relate/content.html#relate-markup\">"
+                "RELATE markup</a>."))
+        return CreateFlowForm(
+                None, "markdown", request.user.editor_mode,
+                help_text,
+                data)
+
+    request = pctx.request
+
+    if request.method == "POST":
+        form = make_form(request.POST)
+    else:
+        form = make_form()
+
+    return render_course_page(pctx, "course/sandbox-markup.html", {
+        "form": form,
+        "preview_text": preview_text,
+    })
+
+

--- a/course/templates/course/course-base.html
+++ b/course/templates/course/course-base.html
@@ -119,6 +119,7 @@
       {% if pperm.use_markup_sandbox %}
         <li><a href="{% url "relate-view_markup_sandbox" course.identifier %}">{% trans "Markup sandbox" %}</a></li>
       {% endif %}
+      <li><a href="{% url "relate-view_all_forms" course.identifier %}">{% trans "Forms" %}</a></li>
 
       {% if pperm.test_flow %}
         <li role="presentation" class="divider"></li>

--- a/course/templates/course/form.html
+++ b/course/templates/course/form.html
@@ -1,0 +1,34 @@
+{% extends "course/course-base.html" %}
+{% load i18n %}
+
+{% load crispy_forms_tags %}
+{% load static %}
+
+{% block content %}
+  <h1>{{ title }}</h1>
+  {{ description }}
+
+  {% if page_errors %}
+    <div class="alert alert-danger">
+      <i class="fa fa-ban"></i>
+      {{ page_errors | safe }}
+    </div>
+  {% endif %}
+
+  {% if page_warnings %}
+    <div class="alert alert-warning">
+      <i class="fa fa-warning"></i>
+      {% blocktrans  trimmed %} Warnings were encountered when validating the page: {% endblocktrans %}
+
+      <ul>
+      {% for w in page_warnings %}
+        <li>{{ w.location }}: {{ w.text }}</li>
+      {% endfor %}
+      </ul>
+    </div>
+  {% endif %}
+  <div class="well">
+    {% crispy form %}
+  </div>
+{% endblock %}
+

--- a/course/templates/course/forms.html
+++ b/course/templates/course/forms.html
@@ -1,0 +1,19 @@
+{% extends "course/course-base.html" %}
+{% load i18n %}
+
+{% load crispy_forms_tags %}
+{% load static %}
+
+{%block header_extra %}
+  <script src="{% static "codemirror/keymap/vim.js" %}"></script>
+{% endblock %}
+
+{% block content %}
+  <h1>{% trans "Templates" %}</h1>
+  <ul>
+      {% for form in forms %}
+      <li><a href="{% url "relate-view_form" course.identifier form.name %}">{{ form.title }}</a></li>
+      {% endfor %}
+  </ul>
+{% endblock %}
+

--- a/course/templates/course/forms.html
+++ b/course/templates/course/forms.html
@@ -9,7 +9,7 @@
 {% endblock %}
 
 {% block content %}
-  <h1>{% trans "Templates" %}</h1>
+  <h1>{% trans "Forms" %}</h1>
   <ul>
       {% for form in forms %}
       <li><a href="{% url "relate-view_form" course.identifier form.name %}">{{ form.title }}</a></li>

--- a/course/validation.py
+++ b/course/validation.py
@@ -1203,7 +1203,7 @@ def validate_form_desc(vctx, location, form_desc):
 
     # Check required fields
 
-    for req_field in ["template_in", "template_out", "announce"]:
+    for req_field in ["template_in", "template_out"]:
         if req_field not in field_ids:
             raise ValidationError(
                     string_concat("%(location)s: ",

--- a/course/validation.py
+++ b/course/validation.py
@@ -1170,7 +1170,6 @@ def validate_form_desc(vctx, location, form_desc):
                 ("type", str),
                 ("fields", list),
                 ("access_roles", list),
-                ("template", str),
                 ],
             allowed_attrs=[],
             )
@@ -1202,6 +1201,15 @@ def validate_form_desc(vctx, location, form_desc):
 
     # }}}
 
+    # Check required fields
+
+    for req_field in ["template_in", "template_out", "announce"]:
+        if req_field not in field_ids:
+            raise ValidationError(
+                    string_concat("%(location)s: ",
+                        _("required form field id '%(field_id)s' not found"))
+                    % {'location': location, 'field_id': req_field})
+
 
 def validate_form_field(vctx, location, field_desc):
     validate_struct(
@@ -1213,14 +1221,15 @@ def validate_form_field(vctx, location, field_desc):
                 ("type", str),
                 ],
             allowed_attrs=[
-                ("values", list),
-                ("default", (str, int, float, bool)),
+                ("choices", list),
+                ("value", (str, int, float, bool)),
+                ("label", str),
                 ],
             )
 
     from course.constants import FORM_FIELD_ID_REGEX
 
-    if field_desc.type not in ["Text", "Integer", "Float", "Choice"]:
+    if field_desc.type not in ["Text", "Integer", "Float", "Choice", "Hidden"]:
         raise ValidationError(
                 string_concat("%(location)s: ",
                     _("form field type '%(field_type)s' not recognized"))

--- a/relate/urls.py
+++ b/relate/urls.py
@@ -27,7 +27,8 @@ THE SOFTWARE.
 from django.conf.urls import include, url
 from django.contrib import admin
 from django.conf import settings
-from course.constants import COURSE_ID_REGEX, FLOW_ID_REGEX, STATICPAGE_PATH_REGEX
+from course.constants import (COURSE_ID_REGEX, FLOW_ID_REGEX, STATICPAGE_PATH_REGEX,
+    FORM_ID_REGEX)
 
 import course.auth
 import course.views
@@ -41,6 +42,7 @@ import course.flow
 import course.analytics
 import course.exam
 import course.api
+import course.forms
 
 urlpatterns = [
     url(r"^login/$",
@@ -155,6 +157,18 @@ urlpatterns = [
         + "/sandbox/page/$",
         course.sandbox.view_page_sandbox,
         name="relate-view_page_sandbox"),
+
+    url(r"^course"
+        "/" + COURSE_ID_REGEX
+        + "/forms/list",
+        course.forms.view_all_forms,
+        name="relate-view_all_forms"),
+
+    url(r"^course"
+        "/" + COURSE_ID_REGEX
+        + "/forms/view/" + FORM_ID_REGEX,
+        course.forms.view_form,
+        name="relate-view_form"),
 
     url("^purge-pageview-data/$",
         course.flow.purge_page_view_data,

--- a/relate/urls.py
+++ b/relate/urls.py
@@ -160,13 +160,14 @@ urlpatterns = [
 
     url(r"^course"
         "/" + COURSE_ID_REGEX
-        + "/forms/list",
+        + "/forms/$",
         course.forms.view_all_forms,
         name="relate-view_all_forms"),
 
     url(r"^course"
         "/" + COURSE_ID_REGEX
-        + "/forms/view/" + FORM_ID_REGEX,
+        + "/forms/" + FORM_ID_REGEX
+        + "/$",
         course.forms.view_form,
         name="relate-view_form"),
 


### PR DESCRIPTION
cc @lukeolson

A form description looks like https://github.com/isuruf/relate-sample/blob/master/forms/instant.yml

There are 5 types of fields. `Text, Integer, Float, Choice, Hidden`.
`template_in` and `template_out` are mandatory fields and they can be either `Hidden` or `Text`. If `Hidden` the values are fixed, but if `Text`, the user who fills the form can fill them.
If `template_out=flows/asd.yml` then the actual output would be `flows/asd_20190930_022148_311577.yml` where the time is appended.

There's a type for a form which is only `flow` for now. If there's a `announce` field and set to true and the type is a `flow`, then an `InstantFlowRequest` is created.

Flow created looks like
```
{% with id="20190930_022148_311577",
        field1="1",
        field2="A",
        template_in="flows/instant_flow.jinja",
        template_out="flows/instant_flow.yml",
        announce="True",
        created_time="2019-09-30 @ 02:21" %}
{% include "flows/instant_flow.jinja" %}
{% endwith %}
```
The templated flow `template_in` can use the form variables by their id and also have access to `created_time` and `id`. `created_time` is useful for instant flows that @lukeolson mentioned.

Let me know what you think.