### PR TITLE
Fix empty dropdown in ModelSelect2Widget widget.

### DIFF
--- a/course/auth.py
+++ b/course/auth.py
@@ -197,7 +197,10 @@ class ImpersonateForm(StyledForm):
                 queryset=qset,
                 required=True,
                 help_text=_("Select user to impersonate."),
-                widget=UserSearchWidget(queryset=qset),
+                widget=UserSearchWidget(
+                    queryset=qset,
+                    attrs={"data-minimum-input-length": 0},
+                ),
                 label=_("User"))
 
         self.fields["add_impersonation_header"] = forms.BooleanField(


### PR DESCRIPTION
After upgraded to 7.04 +, the dropdown ModelSelect2Widget needs input >=2 characters for search by default, otherwise there won't be any result. The fix was suggested by [this issue](https://github.com/applegrew/django-select2/issues/568).