### PR TITLE
Fix locale loading and late events rendering in calendar.

### DIFF
--- a/course/templates/course/calendar.html
+++ b/course/templates/course/calendar.html
@@ -1,6 +1,7 @@
 {% extends "course/course-base-with-markup.html" %}
 {% load i18n %}
 {% load static %}
+{% get_current_language as LANGUAGE_CODE %}
 
 {% block title %}
   {{ course.number}}
@@ -22,7 +23,8 @@
             rlFullCalendar.setupCalendar(
                   document.getElementById("coursecal"),
                   {{ events_json|safe }},
-                  '{{ default_date }}'
+                  '{{ default_date }}',
+                  '{{ LANGUAGE_CODE }}',
                 )
           });
   </script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
       "devDependencies": {
         "@rollup/plugin-commonjs": "^17.1.0",
         "@rollup/plugin-node-resolve": "^11.1.0",
+        "@rollup/plugin-replace": "^4.0.0",
         "autoprefixer": "^10.4.0",
         "eslint": "^8.3.0",
         "eslint-config-airbnb-base": "^15.0.0",
@@ -295,6 +296,19 @@
       },
       "peerDependencies": {
         "rollup": "^1.20.0||^2.0.0"
+      }
+    },
+    "node_modules/@rollup/plugin-replace": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-4.0.0.tgz",
+      "integrity": "sha512-+rumQFiaNac9y64OHtkHGmdjm7us9bo1PlbgQfdihQtuNxzjpaB064HbRnewUOggLQxVCCyINfStkgmBeQpv1g==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/pluginutils": "^3.1.0",
+        "magic-string": "^0.25.7"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0 || ^2.0.0"
       }
     },
     "node_modules/@rollup/pluginutils": {
@@ -8679,6 +8693,16 @@
         "deepmerge": "^4.2.2",
         "is-module": "^1.0.0",
         "resolve": "^1.19.0"
+      }
+    },
+    "@rollup/plugin-replace": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-4.0.0.tgz",
+      "integrity": "sha512-+rumQFiaNac9y64OHtkHGmdjm7us9bo1PlbgQfdihQtuNxzjpaB064HbRnewUOggLQxVCCyINfStkgmBeQpv1g==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^3.1.0",
+        "magic-string": "^0.25.7"
       }
     },
     "@rollup/pluginutils": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "devDependencies": {
     "@rollup/plugin-commonjs": "^17.1.0",
     "@rollup/plugin-node-resolve": "^11.1.0",
+    "@rollup/plugin-replace": "^4.0.0",
     "autoprefixer": "^10.4.0",
     "eslint": "^8.3.0",
     "eslint-config-airbnb-base": "^15.0.0",

--- a/relate/static/js/fullcalendar.js
+++ b/relate/static/js/fullcalendar.js
@@ -5,7 +5,7 @@ import listPlugin from '@fullcalendar/list';
 import allLocales from '@fullcalendar/core/locales-all';
 
 /* eslint-disable-next-line import/prefer-default-export */
-export function setupCalendar(domEl, events, initialDate) {
+export function setupCalendar(domEl, events, initialDate, locale) {
   const calendar = new Calendar(domEl, {
     plugins: [
       dayGridPlugin,
@@ -13,6 +13,7 @@ export function setupCalendar(domEl, events, initialDate) {
       listPlugin,
     ],
     locales: allLocales,
+    locale,
     initialView: 'dayGridMonth',
     headerToolbar: {
       left: 'prev,next today',
@@ -21,6 +22,7 @@ export function setupCalendar(domEl, events, initialDate) {
     },
     initialDate,
     events,
+    defaultTimedEventDuration: '00:00:00.001',
   });
   calendar.render();
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,6 +5,7 @@ import commonjs from '@rollup/plugin-commonjs';
 import { terser } from 'rollup-plugin-terser';
 import styles from 'rollup-plugin-styles';
 import gzipPlugin from 'rollup-plugin-gzip';
+import replace from '@rollup/plugin-replace';
 
 // `npm run build` -> `production` is true
 // `npm run dev` -> `production` is false
@@ -22,6 +23,10 @@ const defaultPlugins = [
     customCompression: (content) => brotliPromise(Buffer.from(content)),
     fileName: '.br',
   }),
+  replace({
+      'zh-cn': 'zh-hans',
+      'zh-tw': 'zh-hant',
+  })
 ];
 
 export default [

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -26,6 +26,7 @@ const defaultPlugins = [
   replace({
       'zh-cn': 'zh-hans',
       'zh-tw': 'zh-hant',
+      preventAssignment: true,
   })
 ];
 


### PR DESCRIPTION
Fix #907 
1. Added locale param in `setupCalendar`
2. Set [`defaultTimedEventDuration`](https://fullcalendar.io/docs/defaultTimedEventDuration) to 1 ms
3. Replace Chinese specific locale name when build.