### PR TITLE
Remove non exist static references.

### DIFF
--- a/course/templates/course/generic-course-form.html
+++ b/course/templates/course/generic-course-form.html
@@ -10,11 +10,6 @@
 
 {# keep this in sync with relate/templates/generic-form.html #}
 {% block head_assets_form_media %}
-  <link href="{% static 'eonasdan-bootstrap-datetimepicker/build/css/bootstrap-datetimepicker.min.css' %}" rel="stylesheet">
-
-  <script src="{% static 'moment/min/moment-with-locales.min.js' %}"></script>
-  <script src="{% static 'moment-timezone/builds/moment-timezone.min.js' %}"></script>
-  <script src="{% static 'eonasdan-bootstrap-datetimepicker/build/js/bootstrap-datetimepicker.min.js' %}"></script>
   {{ form.media }}
 {% endblock %}
 

--- a/course/templates/course/manage-auth-tokens.html
+++ b/course/templates/course/manage-auth-tokens.html
@@ -10,11 +10,6 @@
 
 {# keep this in sync with relate/templates/generic-form.html #}
 {% block head_assets_form_media %}
-  <link href="{% static 'eonasdan-bootstrap-datetimepicker/build/css/bootstrap-datetimepicker.min.css' %}" rel="stylesheet">
-
-  <script src="{% static 'moment/min/moment-with-locales.min.js' %}"></script>
-  <script src="{% static 'moment-timezone/builds/moment-timezone.min.js' %}"></script>
-  <script src="{% static 'eonasdan-bootstrap-datetimepicker/build/js/bootstrap-datetimepicker.min.js' %}"></script>
   {{ form.media }}
 {% endblock %}
 


### PR DESCRIPTION
Since the introduction of `django-bootstrap-datepicker-plus`, those links were no longer valid.