### PR TITLE
`check_exam_ticket`: filter out revoked tickets

### DIFF
--- a/course/exam.py
+++ b/course/exam.py
@@ -515,7 +515,9 @@ def check_exam_ticket(
         if restrict_to_course is not None:
             ticket_kwargs["participation__course"] = restrict_to_course
 
-        ticket = ExamTicket.objects.get(
+        ticket = ExamTicket.objects.exclude(
+                state=exam_ticket_states.revoked
+                ).get(
                 participation__user=user,
                 code=code,
                 **ticket_kwargs


### PR DESCRIPTION
As of right now, this is the ad-hoc fix applied before a CS450 exam. But the code that's being touched here is still brittle in the face of multiple valid exam tickets existing.