### PR TITLE
feat: whitelist iframe/object tags

### DIFF
--- a/course/content.py
+++ b/course/content.py
@@ -1383,6 +1383,10 @@ def filter_html_attributes(tag, name, value):
                 or (name == "class" and value.startswith("btn btn-")))
     elif tag == "img":
         result = result or name == "src"
+    elif tag == "iframe":
+        result = (result or (name in ["src", "width", "height"]))
+    elif tag == "object":
+        result = (result or (name in ["data", "width", "height"]))
     elif tag == "div":
         result = result or (name == "class" and value == "well")
     elif tag == "i":
@@ -1479,6 +1483,7 @@ def markup_to_html(
                     "div", "span", "p", "img",
                     "h1", "h2", "h3", "h4", "h5", "h6",
                     "table", "td", "tr", "th", "pre",
+                    "iframe", "object",
                     ],
                 attributes=filter_html_attributes)
 


### PR DESCRIPTION
Relates to #973. Gets iframe/objects rendering again. I realize there's security concerns around iframes. Maybe this should be conditional based on an ENV var, so the user needs to opt in?

<img width="486" alt="Screenshot 2023-10-20 at 8 27 57 AM" src="https://github.com/inducer/relate/assets/1447940/2769b785-e40a-49cf-b33a-e0106e5f5dc1">
