### PR TITLE
Fix readonly logic for text/code questions

### DIFF
--- a/course/page/code.py
+++ b/course/page/code.py
@@ -164,12 +164,13 @@ class CodeForm(StyledForm):
                 autofocus=(
                     not read_only
                     and (data is not None and "answer" in data)))
+        if read_only:
+            cm_widget.attrs["readonly"] = None
 
         self.fields["answer"] = forms.CharField(required=True,
             initial=initial_code,
             help_text=cm_help_text,
             widget=cm_widget,
-            disabled=read_only,
             label=_("Answer"))
 
     def clean(self):

--- a/course/page/text.py
+++ b/course/page/text.py
@@ -52,39 +52,39 @@ class TextAnswerForm(StyledForm):
     use_required_attribute = False
 
     @staticmethod
-    def get_text_widget(widget_type, check_only=False,
+    def get_text_widget(widget_type, read_only=False, check_only=False,
             interaction_mode=None, initial_text=None):
         """Returns None if no widget found."""
 
+        help_text = None
         if widget_type in [None, "text_input"]:
             if check_only:
                 return True
 
             widget = forms.TextInput()
-            widget.attrs["autofocus"] = None
-            return widget, None
 
         elif widget_type == "textarea":
             if check_only:
                 return True
 
             widget = forms.Textarea()
-            widget.attrs["autofocus"] = None
-            return widget, None
 
         elif widget_type.startswith("editor:"):
             if check_only:
                 return True
 
             from course.utils import get_codemirror_widget
-            cm_widget, cm_help_text = get_codemirror_widget(
+            widget, help_text = get_codemirror_widget(
                     language_mode=widget_type[widget_type.find(":")+1:],
                     interaction_mode=interaction_mode)
 
-            return cm_widget, cm_help_text
-
         else:
             return None, None
+
+        widget.attrs["autofocus"] = None
+        if read_only:
+            widget.attrs["readonly"] = None
+        return widget, help_text
 
     def __init__(self, read_only, interaction_mode, validators, *args, **kwargs):
         widget_type = kwargs.pop("widget_type", "text_input")
@@ -92,13 +92,12 @@ class TextAnswerForm(StyledForm):
 
         super().__init__(*args, **kwargs)
         widget, help_text = self.get_text_widget(
-                    widget_type,
+                    widget_type, read_only,
                     interaction_mode=interaction_mode)
         self.validators = validators
         self.fields["answer"] = forms.CharField(
                 required=True,
                 initial=initial_text,
-                disabled=read_only,
                 widget=widget,
                 help_text=help_text,
                 label=_("Answer"))

--- a/course/utils.py
+++ b/course/utils.py
@@ -979,7 +979,7 @@ class CodeMirrorTextarea(forms.Textarea):
 def get_codemirror_widget(
         language_mode: str,
         interaction_mode: str | None,
-        config: dict | None = None,
+        *,
         autofocus: bool = False,
         additional_keys: dict[str, JsLiteral] | None = None,
         ) -> tuple[CodeMirrorTextarea, str]:

--- a/relate/static/js/codemirror.js
+++ b/relate/static/js/codemirror.js
@@ -100,7 +100,7 @@ export function editorFromTextArea(textarea, extensions, autofocus, additionalKe
     )),
   );
 
-  if (textarea.disabled) {
+  if (textarea.disabled || textarea.readOnly) {
     extensions.push(
       EditorState.readOnly.of(true),
       EditorView.editable.of(false),


### PR DESCRIPTION
Broken in https://github.com/inducer/relate/commit/ea36dc0dab3e2ed568f403c6af4e97fde7b0f363, part of gh-864.

The gist is that that change reinterpreted read-only as disabled, which is not true. In django, disabled fields only provide their initial value, not the bound value. And the DOM will not include them in form submissions.