### PR TITLE
Import dark theme from https://github.com/dennis84/codemirror-themes/…

### DIFF
--- a/relate/static/css/codemirror.scss
+++ b/relate/static/css/codemirror.scss
@@ -37,14 +37,15 @@
   .cmt-string    {color: #FF5500;}
 
   @media (prefers-color-scheme: dark) {
-
-    .cmt-atom      {color: #F78C6C;}
-    .cmt-comment   {color: #545454;}
-    .cmt-keyword   {color: #C792EA;}
-    .cmt-literal   {color: #FFCB6B;}
-    .cmt-number    {color: #FF5370;}
-    .cmt-operator  {color: #89DDFF;}
-    .cmt-separator {color: #FF7DE9;}
-    .cmt-string    {color: #F07178;}
+/*Converted from https://github.com/dennis84/codemirror-themes/blob/main/theme/github-dark.ts*/
+    
+    .cmt-atom      {color: #ffab70;}
+    .cmt-comment   {color: #6a737d;}
+    .cmt-keyword   {color: #f97583;}
+    .cmt-literal   {color: #ffab70;}
+    .cmt-number    {color: #79b8ff;}
+    .cmt-operator  {color: #f97583;}
+    .cmt-separator {color: #ffab70;}
+    .cmt-string    {color: #9ecbff;}
   }
 }


### PR DESCRIPTION
…blob/main/theme/github-dark.ts

Import dark theme from https://github.com/dennis84/codemirror-themes/blob/main/theme/github-dark.ts

The correct solution here is to go back to https://discuss.codemirror.net/t/dynamic-light-mode-dark-mode-how/4709/5 and look at the solution: https://discuss.codemirror.net/t/dynamic-light-mode-dark-mode-how/4709/2

The idea is to use the default theme implementation and not use the compatibility bodge. This would probably involve including some theme files in the source, and I would prefer a theme picker as shown https://codemirror.net/5/demo/theme.html ( this is codemirror5 but you get the idea)

