### PR TITLE
Add NaN/Inf checks into check_numpy_array_features

### DIFF
--- a/course/page/code_feedback.py
+++ b/course/page/code_feedback.py
@@ -64,7 +64,7 @@ class Feedback:
                     0, f"'{name}' does not consist of floating point numbers--"
                     f"got: '{data.dtype}'")
 
-    def check_numpy_array_features(self, name, ref, data, report_failure=True):
+    def check_numpy_array_features(self, name, ref, data, report_failure=True, check_finite=True):
         import numpy as np
         assert isinstance(ref, np.ndarray)
 
@@ -90,6 +90,12 @@ class Feedback:
             return bad(
                     f"'{name}' does not have correct data type--"
                     f"got: '{data.dtype}', expected: '{ref.dtype}'")
+
+        if check_finite:
+            if np.any(np.isnan(data)):
+                return bad(f"'{name}' contains NaN")
+            if np.any(np.isinf(data)):
+                return bad(f"'{name}' contains Inf")
 
         return True
 


### PR DESCRIPTION
For normal scenario (and provide a killer switch to turn off the check), all numpy arrays should not have NaN or Inf.

