### PR TITLE
Handle etree in mdown stash

### DIFF
--- a/course/content.py
+++ b/course/content.py
@@ -29,6 +29,7 @@ import os
 import re
 import sys
 from typing import cast
+from xml.etree.ElementTree import Element, tostring
 
 import dulwich.objects
 import dulwich.repo
@@ -1318,6 +1319,12 @@ class LinkFixerTreeprocessor(Treeprocessor):
         for i, html in enumerate(self.md.htmlStash.rawHtmlBlocks):
             outf = StringIO()
             parser = TagProcessingHTMLParser(outf, self.process_tag)
+
+            # According to
+            # https://github.com/python/typeshed/blob/61ba4de28f1469d6a642c983d5a7674479c12444/stubs/Markdown/markdown/util.pyi#L44
+            # this should not happen, but... *shrug*
+            if isinstance(html, Element):
+                html = tostring(html).decode("utf-8")
             parser.feed(html)
 
             self.md.htmlStash.rawHtmlBlocks[i] = outf.getvalue()


### PR DESCRIPTION
Fixes the following server error:
```
Traceback (most recent call last):
  File "/home/andreas/relate/.venv/lib/python3.12/site-packages/django/core/handlers/exception.py", line 55, in
inner
    response = get_response(request)
               ^^^^^^^^^^^^^^^^^^^^^
  File "/home/andreas/relate/.venv/lib/python3.12/site-packages/django/core/handlers/base.py", line 197, in
_get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/andreas/relate/course/utils.py", line 821, in wrapper
    response = f(pctx, *args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/andreas/relate/course/views.py", line 167, in course_page
    chunks = get_processed_page_chunks(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/andreas/relate/course/content.py", line 1807, in get_processed_page_chunks
    chunk.html_content = markup_to_html(course, repo, commit_sha, chunk.content)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/andreas/relate/course/content.py", line 1472, in markup_to_html
    result = markdown.markdown(text,
             ^^^^^^^^^^^^^^^^
  File "/home/andreas/relate/.venv/lib/python3.12/site-packages/markdown/core.py", line 482, in markdown
    return md.convert(text)
           ^^^^^^^^^^^^^^^^
  File "/home/andreas/relate/.venv/lib/python3.12/site-packages/markdown/core.py", line 361, in convert
    newRoot = treeprocessor.run(root)
              ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/andreas/relate/course/content.py", line 1321, in run
    parser.feed(html)
    ^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/html/parser.py", line 110, in feed
    self.rawdata = self.rawdata + data
                   ^^^^^^^^^^^^^^^^^^^

Exception Type: TypeError at /course/cs555-s20/
Exception Value: can only concatenate str (not "xml.etree.ElementTree.Element") to str
Raised during: course.views.course_page
```