### PR TITLE
Support tabbed view to display external resources

### DIFF
--- a/course/content.py
+++ b/course/content.py
@@ -527,6 +527,25 @@ class FlowRulesDesc(Struct):
 
 # {{{ mypy: flow
 
+class TabDesc(Struct):
+    """
+    .. attribute:: title
+
+        (Required) Title to be displayed on the tab.
+
+    .. attribute:: url
+
+        (Required) The URL of the external web page.
+    """
+
+    def __init__(self, title: str, url: str) -> None:
+        self.title = title
+        self.url = url
+
+    title: str
+    url: str
+
+
 class FlowPageDesc(Struct):
     id: str
     type: str
@@ -594,6 +613,11 @@ class FlowDesc(Struct):
         A list of :ref:`pages <flow-page>`. If you specify this, a single
         :class:`FlowPageGroupDesc` will be implicitly created. Exactly one of
         :attr:`groups` or :class:`pages` must be given.
+
+    .. attribute:: external_resources
+
+        A list of :class:`TabDesc`. These are links to external
+        resources that are displayed as tabs on the flow tabbed page.
     """
 
     title: str
@@ -601,6 +625,7 @@ class FlowDesc(Struct):
     rules: FlowRulesDesc
     pages: list[FlowPageDesc]
     groups: list[FlowPageGroupDesc]
+    external_resources: list[TabDesc]
     notify_on_submit: list[str] | None
 
 # }}}

--- a/course/exam.py
+++ b/course/exam.py
@@ -837,6 +837,7 @@ class ExamLockdownMiddleware:
                 update_expiration_mode,
                 update_page_bookmark_state,
                 view_flow_page,
+                view_flow_page_with_ext_resource_tabs,
                 view_resume_flow,
                 view_start_flow,
             )
@@ -868,6 +869,7 @@ class ExamLockdownMiddleware:
                     resolver_match.func in [
                         view_resume_flow,
                         view_flow_page,
+                        view_flow_page_with_ext_resource_tabs,
                         update_expiration_mode,
                         update_page_bookmark_state,
                         finish_flow_session_view]

--- a/course/templates/course/tabbed-page.html
+++ b/course/templates/course/tabbed-page.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+{% load i18n %}
+{% load static %}
+
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  {% block favicon %}{% endblock %}
+
+  <title>{% block title %}{{ relate_site_name }}{% endblock %}</title>
+
+  {% block bundle_loads %}
+  <script src="{% static 'bundle-base.js' %}"></script>
+  <script src="{% static 'bundle-base-with-markup.js' %}"></script>
+  {% endblock %}
+
+<style>
+  html,
+  body {
+    height: 100%;
+    margin: 0;
+  }
+
+  .tab-content {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .tab-pane {
+    height: 100%;
+  }
+
+  iframe {
+    width: 100%;
+    height: 100%;
+  }
+</style>
+
+</head>
+
+<ul class="nav nav-tabs" id="tab-bar" role="tablist">
+  {% for tab in tabs %}
+  <li class="nav-item" role="presentation">
+    <button class="nav-link {% if forloop.first %}active{% endif %}" id="{{ tab.title }}-tab" data-bs-toggle="tab"
+      data-bs-target="#{{ tab.title }}-tab-pane" type="button" role="tab" aria-controls="{{ tab.title }}-tab-pane"
+      aria-selected="true">
+      {{ tab.title }}
+    </button>
+  </li>
+  {% endfor %}
+</ul>
+
+<div class="tab-content" id="tab-content">
+  {% for tab in tabs %}
+  <div class="tab-pane {% if forloop.first %}show active{% endif %}" id="{{ tab.title }}-tab-pane" role="tabpanel"
+    aria-labelledby="{{ tab.title }}-tab" tabindex="0">
+    <iframe src="{{ tab.url }}" frameborder="0" allowfullscreen></iframe>
+  </div>
+  {% endfor %}
+</div>
+
+</html>

--- a/course/validation.py
+++ b/course/validation.py
@@ -1009,26 +1009,26 @@ def validate_flow_permission(
 
 def validate_flow_desc(vctx, location, flow_desc):
     validate_struct(
-            vctx,
-            location,
-            flow_desc,
-            required_attrs=[
-                ("title", str),
-                ("description", "markup"),
-                ],
-            allowed_attrs=[
-                ("completion_text", "markup"),
-                ("rules", Struct),
-                ("groups", list),
-                ("pages", list),
-                ("notify_on_submit", list),
-
-                # deprecated (moved to grading rule)
-                ("max_points", (int, float)),
-                ("max_points_enforced_cap", (int, float)),
-                ("bonus_points", (int, float)),
-                ]
-            )
+        vctx,
+        location,
+        flow_desc,
+        required_attrs=[
+            ("title", str),
+            ("description", "markup"),
+        ],
+        allowed_attrs=[
+            ("completion_text", "markup"),
+            ("rules", Struct),
+            ("groups", list),
+            ("pages", list),
+            ("notify_on_submit", list),
+            ("external_resources", list),
+            # deprecated (moved to grading rule)
+            ("max_points", (int, float)),
+            ("max_points_enforced_cap", (int, float)),
+            ("bonus_points", (int, float)),
+        ],
+    )
 
     if hasattr(flow_desc, "rules"):
         validate_flow_rules(vctx, location, flow_desc.rules)

--- a/doc/flow.rst
+++ b/doc/flow.rst
@@ -110,6 +110,12 @@ An Example
         - Green
         - ~CORRECT~ Yellow
 
+    external_resources:
+
+    -
+        title: Numpy
+        url: https://numpy.org/doc/
+
     completion_text: |
 
         # See you in class!
@@ -294,6 +300,33 @@ For example, to grant permission to revise an answer on a
         add_permissions:
             - change_answer
     value: 1
+
+.. _tabbed-page-view:
+
+Tabbed page view
+^^^^^^^^^^^^^^^^^^^^
+
+A flow page can be displayed in a tabbed view, where the first tab is the
+flow page itself, and the subsequent tabs are additional external websites. 
+
+An example use case is when the participant does not have access to
+browser-native tab functionality. This is the case when using the
+"Guardian" browser with the "ProctorU" proctoring service.
+
+To access the tabbed page for a flow, append `/ext-resource-tabs` to the URL.
+Alternatively, you can create a link to allow users to navigate to the tabbed 
+page directly. For example, `[Open tabs](ext-resource-tabs)`.
+
+You might need to set `X_FRAME_OPTIONS` in your Django settings to allow embedding
+the flow page and external websites in iframes, depending on your site's configuration.
+For example, you can add the following to your `local_settings.py`:
+
+.. code-block:: python
+
+    X_FRAME_OPTIONS = 'ALLOWALL'  # or specify a domain like 'ALLOW-FROM https://www.yourwebsite.com'
+
+
+.. autoclass:: TabDesc
 
 .. _flow-life-cycle:
 

--- a/relate/urls.py
+++ b/relate/urls.py
@@ -397,6 +397,15 @@ urlpatterns = [
         name="relate-view_flow_page"),
     re_path(r"^course"
         "/" + COURSE_ID_REGEX
+        + "/flow-session"
+        "/(?P<flow_session_id>[0-9]+)"
+        "/(?P<page_ordinal>[0-9]+)"
+        "/ext-resource-tabs"
+        "/$",
+        course.flow.view_flow_page_with_ext_resource_tabs,
+        name="relate-view_flow_page_with_ext_resource_tabs"),
+    re_path(r"^course"
+        "/" + COURSE_ID_REGEX
         + "/prev_answers"
         "/flow-page"
         "/(?P<flow_session_id>[0-9]+)"


### PR DESCRIPTION
Improvement of #1190 

To enter the tabbed page for a view, simply replace "flow-session" to "flow-session-tabbed" in the url.
For example,
"https://relate.cs.illinois.edu/course/cs450-f24/flow-session/907037/0/" to "https://relate.cs.illinois.edu/course/cs450-f24/flow-session-tabbed/907037/0/"

![image](https://github.com/user-attachments/assets/78a91614-47ce-4abb-960a-62256c719fcf)

Demo video: https://github.com/user-attachments/assets/042296c4-8eef-43e3-9caf-c262c2948437


