### PR TITLE
Fix rendering of analytics using Django safe strings

### DIFF
--- a/course/analytics.py
+++ b/course/analytics.py
@@ -543,9 +543,6 @@ def page_analytics(pctx, flow_id, group_id, page_id):
                     grading_page_context, visit.page_data.data, visit.answer)
         if normalized_answer is None:
             normalized_answer = _("(No answer)")
-        else:
-            import bleach
-            normalized_answer = bleach.clean(normalized_answer)
 
         answer_feedback = visit.get_most_recent_feedback()
 

--- a/course/flow.py
+++ b/course/flow.py
@@ -1711,11 +1711,9 @@ def add_buttons_to_form(
         flow_session: FlowSession,
         permissions: frozenset[str]) -> StyledForm:
     from crispy_forms.layout import Submit
-    show_save_button = getattr(form, "show_save_button", True)
-    if show_save_button:
-        form.helper.add_input(
-                Submit("save", _("Save answer"),
-                    css_class="relate-save-button"))
+    form.helper.add_input(
+            Submit("save", _("Save answer"),
+                css_class="relate-save-button"))
 
     if will_receive_feedback(permissions):
         if flow_permission.change_answer in permissions:

--- a/course/page/base.py
+++ b/course/page/base.py
@@ -736,8 +736,10 @@ class PageBase(ABC):
             answer_data: Any
             ) -> str | None:
         """An HTML-formatted answer to be used for summarization and
-        display in analytics. Since this may include user input, it is
-        expected to be sanitized.
+        display in analytics. By default, this is escaped when included
+        in the output page, however it may use utilities such as
+        :func:`~django.utils.safestring.mark_safe` to mark the output
+        as safe and avoid escaping.
         """
         return None
 

--- a/course/page/choice.py
+++ b/course/page/choice.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from django.utils.html import format_html_join
+
 
 __copyright__ = "Copyright (C) 2014 Andreas Kloeckner"
 
@@ -647,19 +649,15 @@ class MultipleChoiceQuestion(ChoiceQuestionBase, PageBaseWithoutHumanGrading):
         return AnswerFeedback(correctness=correctness)
 
     def get_answer_html(self, page_context, idx_list, unpermute=False):
-        answer_html_list = []
         if unpermute:
             idx_list = list(set(idx_list))
-        for idx in idx_list:
-            answer_html_list.append(
-                    "<li>"
-                    + (self.process_choice_string(
+
+        return format_html_join(
+            "\n", "{}",
+            [(self.process_choice_string(
                         page_context,
-                        self.choices[idx].text))
-                    + "</li>"
-                    )
-        answer_html = "<ul>"+"".join(answer_html_list)+"</ul>"
-        return answer_html
+                        self.choices[idx].text),)
+            for idx in idx_list])
 
     def correct_answer(self, page_context, page_data, answer_data, grade_data):
         corr_idx_list = self.unpermuted_correct_indices()

--- a/course/page/code.py
+++ b/course/page/code.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from django.utils.safestring import mark_safe
+
 
 __copyright__ = "Copyright (C) 2014 Andreas Kloeckner"
 
@@ -1067,7 +1069,7 @@ class CodeQuestion(PageBaseWithTitle, PageBaseWithValue):
         normalized_answer = self.get_code_from_answer_data(answer_data)
 
         from django.utils.html import escape
-        return f"<pre>{escape(normalized_answer)}</pre>"
+        return mark_safe(f"<pre>{escape(normalized_answer)}</pre>")
 
     def normalized_bytes_answer(self, page_context, page_data, answer_data):
         if answer_data is None:

--- a/course/page/inline.py
+++ b/course/page/inline.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from django.utils.html import format_html_join
+
 
 __copyright__ = "Copyright (C) 2015 Andreas Kloeckner, Dong Zhuang"
 
@@ -347,8 +349,7 @@ class ShortAnswer(AnswerBase):
         return "width: " + str(max(self.width, opt_width)) + "em"
 
     def get_answer_text(self, page_context, answer):
-        from django.utils.html import escape
-        return escape(answer)
+        return answer
 
     def get_correct_answer_text(self, page_context):
 
@@ -472,8 +473,9 @@ class ChoicesAnswer(AnswerBase):
     def get_answer_text(self, page_context, answer):
         if answer == "":
             return answer
-        return self.process_choice_string(
-            page_context, self.answers_desc.choices[int(answer)])
+        return mark_safe(
+            self.process_choice_string(
+                page_context, self.answers_desc.choices[int(answer)]))
 
     def get_width_str(self, opt_width=0):
         return None
@@ -979,9 +981,9 @@ class InlineMultiQuestion(
 
         answer_dict = answer_data["answer"]
 
-        return ", ".join(
-            [self.answer_instance_list[idx].get_answer_text(
-                page_context, answer_dict[self.embedded_name_list[idx]])
+        return format_html_join(", ", "{}",
+            [(self.answer_instance_list[idx].get_answer_text(
+                page_context, answer_dict[self.embedded_name_list[idx]]),)
                 for idx, name in enumerate(self.embedded_name_list)]
         )
 

--- a/course/page/text.py
+++ b/course/page/text.py
@@ -766,8 +766,7 @@ class TextQuestionBase(PageBaseWithTitle):
         if not self._is_case_sensitive():
             normalized_answer = normalized_answer.lower()
 
-        from django.utils.html import escape
-        return escape(normalized_answer)
+        return normalized_answer
 
     def normalized_bytes_answer(self, page_context, page_data, answer_data):
         if answer_data is None:

--- a/course/page/text.py
+++ b/course/page/text.py
@@ -1150,9 +1150,6 @@ class HumanGradedTextQuestion(TextQuestionBase, PageBaseWithValue,
 # {{{ rich text
 
 class RichTextAnswerForm(StyledForm):
-    # FIXME: ugh, this should be a PageBase thing
-    show_save_button = False
-
     def __init__(self, read_only: bool, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 

--- a/course/page/upload.py
+++ b/course/page/upload.py
@@ -44,7 +44,6 @@ from relate.utils import StyledForm, string_concat
 # {{{ upload question
 
 class FileUploadForm(StyledForm):
-    show_save_button = False
     uploaded_file = forms.FileField(required=True,
             label=gettext_lazy("Uploaded file"))
 

--- a/course/templates/course/analytics-page.html
+++ b/course/templates/course/analytics-page.html
@@ -38,7 +38,7 @@
   <div class="answer-analytics">
   {% for astats in answer_stats_list %}
     <div class="answer-entry">
-      {{ astats.normalized_answer|safe }}
+      {{ astats.normalized_answer }}
       {% blocktrans trimmed with astats_count=astats.count count counter=astats.count %}
         ({{ astats_count }} response)
       {% plural %}

--- a/frontend/css/style.scss
+++ b/frontend/css/style.scss
@@ -118,6 +118,11 @@ label div.relate-markup p:only-child {
   margin-bottom: 0;
 }
 
+/* remove extra spacing from ChoiceQuestion options in analytics */
+div.answer-analytics div.relate-markup p:only-child {
+  margin-bottom: 0;
+}
+
 /* }}} */
 
 /* {{{ histograms */

--- a/relate/bin/relate.py
+++ b/relate/bin/relate.py
@@ -130,8 +130,6 @@ def lint_yaml(args):
         else:
             check_file(item)
 
-    print(f"{had_problems=}")
-
     return int(had_problems)
 
 # }}}

--- a/tests/test_flow/test_flow.py
+++ b/tests/test_flow/test_flow.py
@@ -3992,20 +3992,6 @@ class AddButtonsToFormTest(unittest.TestCase):
         values = list(dict(inputs).values())
         return names, values
 
-    def test_not_add_save_button(self):
-        class MyForm(StyledForm):
-            show_save_button = False
-
-        form = MyForm()
-
-        self.mock_will_receive_feedback.return_value = True
-        flow.add_buttons_to_form(form, self.fpctx, self.flow_session, frozenset())
-
-        names, values = self.get_form_submit_inputs(form)
-        self.assertNotIn("save", names)
-        self.assertIn("submit", names)
-        self.assertIn("Submit final answer", values)
-
     def test_add_save_button_by_default(self):
         class MyForm(StyledForm):
             pass

--- a/tests/test_pages/test_choice.py
+++ b/tests/test_pages/test_choice.py
@@ -439,12 +439,11 @@ class MultiChoicesQuestionTest(SingleCoursePageSandboxTestBaseMixin, TestCase):
         self.assertResponseContextEqual(
             resp, "correct_answer",
             "The correct answer is: "
-            "<ul><li><div class='relate-markup'><p>Sprinkles</p></div></li>"
-            "<li><div class='relate-markup'><p>Chocolate chunks</p></div></li>"
-            "<li><div class='relate-markup'><p>Almond bits</p></div></li>"
-            "</ul>"
+            "<div class='relate-markup'><p>Sprinkles</p></div>\n"
+            "<div class='relate-markup'><p>Chocolate chunks</p></div>\n"
+            "<div class='relate-markup'><p>Almond bits</p></div>"
             "Additional acceptable options are: "
-            "<ul><li><div class='relate-markup'><p>A flawed option</p></div></li></ul>")
+            "<div class='relate-markup'><p>A flawed option</p></div>")
 
     # }}}
 


### PR DESCRIPTION
The previous solution, introduced when fixing
GHSA-3jmp-r88c-34j9/CVE-2024-32405 used bulk
escaping using bleach, which led to many unsightly rendered-as-text HTML elements.