### PR TITLE
(chore): fix relate home page "TEaching"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 RELATE
 ======
 
-Relate is an Environment for Learning And TEaching
+Relate is an Environment for Learning And Teaching
 
 .. image:: https://gitlab.tiker.net/inducer/relate/badges/main/pipeline.svg
     :alt: Gitlab Build Status

--- a/course/templates/course/home.html
+++ b/course/templates/course/home.html
@@ -7,7 +7,7 @@
     <div class="card mb-4">
       <div class="card-body">
         <h1>{% blocktrans with RELATE=relate_site_name %} Welcome to {{ RELATE }} {% endblocktrans %}</h1>
-        <p>{% trans "RELATE is an Environment for Learning And TEaching" %}</p>
+        <p>{% trans "RELATE is an Environment for Learning And Teaching" %}</p>
         <p>
         <a class="btn btn-lg btn-outline-primary" href="https://github.com/inducer/relate" role="button">{% trans "Learn more" %} &raquo;</a>
         </p>


### PR DESCRIPTION
We use Relate for our training program, and I'd like to thank you for keeping it open source and continuously improving it.

Every time I opened Relate, it was a little painful to see that misspelling, so I decided to submit this PR to fix it. 😄