### PR TITLE
Fix AssertionError when creating a course via the web UI

### DIFF
--- a/course/versioning.py
+++ b/course/versioning.py
@@ -205,7 +205,7 @@ def git_clone_and_create_course(
             new_course: Course,
             owner: User,
             *, skip_validate: bool = False,
-        ):
+        ) -> Repo:
     repo = Repo.init(repo_fs_path)
 
     client, remote_path = \
@@ -231,6 +231,11 @@ def git_clone_and_create_course(
 
     create_course(vrepo, ObjectID(new_sha),
         new_course, owner, skip_validate=skip_validate)
+
+    # Hand the initialized repo back to the caller so it can be closed. Without
+    # this, set_up_new_course's local `repo` stays None and its post-success
+    # `assert repo is not None` fails (and the clone's file handles leak).
+    return repo
 
 
 class CourseCreationForm(StyledModelForm):
@@ -289,7 +294,7 @@ def set_up_new_course(request: http.HttpRequest) -> http.HttpResponse:
                 try:
                     assert request.user.is_authenticated
 
-                    git_clone_and_create_course(
+                    repo = git_clone_and_create_course(
                                 repo_path,
                                 new_course,
                                 request.user,  # pyright: ignore[reportArgumentType]


### PR DESCRIPTION
### Problem

Creating a course through **Set up new course** fails with an `AssertionError`, even though the content validates and the course is actually created. The user sees:

> Course content validated, creation succeeded.
> Course creation failed: AssertionError:

…and then a 500 when opening the new course.

Traceback:

```
File "course/versioning.py", line 324, in set_up_new_course
    assert repo is not None
AssertionError
```

### Cause

`set_up_new_course` initializes a local `repo = None` and closes it on both the success (`else`) and failure (`except`) paths. But `git_clone_and_create_course` opens its own `repo` via `Repo.init(...)` and **never returns it**, so the caller's `repo` stays `None`. On the success path, `else: assert repo is not None` therefore always fires — *after* `create_course` has already validated content and written the `Course` row. The clone's file handles also leak, since the intended `repo.close()` never receives a real repo.

### Fix

Return the initialized repo from `git_clone_and_create_course` and assign it in the caller, so the existing `close()` logic on both branches works as intended. Two-line change plus a return annotation; no behavior change beyond closing the repo as was already intended.

### Testing

- `python -m py_compile course/versioning.py` passes.
- Verified by reasoning through both paths: on success `repo` is now the real repo and is closed; on failure before the assignment, `repo` is `None` and the `if repo is not None` guard still holds.